### PR TITLE
modified for correctly using ort on GPU

### DIFF
--- a/mmdeploy/backend/onnxruntime/wrapper.py
+++ b/mmdeploy/backend/onnxruntime/wrapper.py
@@ -50,18 +50,12 @@ class ORTWrapper(BaseWrapper):
         else:
             logging.warning(f'The library of onnxruntime custom ops does \
             not exist: {ort_custom_op_path}')
-
-        sess = ort.InferenceSession(onnx_file, session_options)
-
+            
         device_id = parse_device_id(device)
-
-        providers = ['CPUExecutionProvider']
-        options = [{}]
         is_cuda_available = ort.get_device() == 'GPU'
-        if is_cuda_available:
-            providers.insert(0, 'CUDAExecutionProvider')
-            options.insert(0, {'device_id': device_id})
-        sess.set_providers(providers, options)
+        providers = [('CUDAExecutionProvider', {'device_id': device_id})] if is_cuda_available else ['CPUExecutionProvider']
+        sess = ort.InferenceSession(onnx_file, session_options, providers=providers)
+
         if output_names is None:
             output_names = [_.name for _ in sess.get_outputs()]
         self.sess = sess


### PR DESCRIPTION
The previous code works wrong, no matter you select which device, for example you select device 3
when call `ort.InferenceSession` functions, it just load model to device:0, after that you give a provider and `device_Id:3`, then load same model to device 3 (load twice)
so I simplified the process which works fine