### PR TITLE
[Fix] Support MMDet custom dataset

### DIFF
--- a/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
@@ -605,17 +605,27 @@ def get_classes_from_config(model_cfg: Union[str, mmcv.Config], **kwargs) -> \
 
     module_dict = DATASETS.module_dict
     data_cfg = model_cfg.data
+    classes = None
+    module = None
 
-    if 'test' in data_cfg:
-        module = module_dict[data_cfg.test.type]
-    elif 'val' in data_cfg:
-        module = module_dict[data_cfg.val.type]
-    elif 'train' in data_cfg:
-        module = module_dict[data_cfg.train.type]
-    else:
+    keys = ['test', 'val', 'train']
+
+    for key in keys:
+        if key in data_cfg:
+            if 'classes' in data_cfg[key]:
+                classes = list(data_cfg[key]['classes'])
+                break
+            elif 'type' in data_cfg[key]:
+                module = module_dict[data_cfg[key]['type']]
+                break
+
+    if classes is None and module is None:
         raise RuntimeError(f'No dataset config found in: {model_cfg}')
 
-    return module.CLASSES
+    if classes is not None:
+        return classes
+    else:
+        return module.CLASSES
 
 
 def build_object_detection_model(model_files: Sequence[str],

--- a/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
@@ -583,18 +583,26 @@ class NCNNEnd2EndModel(End2EndModel):
         return [dets, labels]
 
 
-def get_classes_from_config(model_cfg: Union[str, mmcv.Config], **kwargs):
-    """Get class name from config.
+def get_classes_from_config(model_cfg: Union[str, mmcv.Config], **kwargs) -> \
+        List[str]:
+    """Get class name from config. The class name is the `classes` field if it
+    is set in the config, or the classes in `module_dict` of MMDet whose type
+    is set in the config.
 
     Args:
         model_cfg (str | mmcv.Config): Input model config file or
             Config object.
 
     Returns:
-        list[str]: A list of string specifying names of different class.
+        List[str]: A list of string specifying names of different class.
     """
     # load cfg if necessary
     model_cfg = load_config(model_cfg)[0]
+
+    # For custom dataset
+    if 'classes' in model_cfg:
+        return list(model_cfg['classes'])
+
     module_dict = DATASETS.module_dict
     data_cfg = model_cfg.data
 

--- a/tests/test_codebase/test_mmdet/test_object_detection_model.py
+++ b/tests/test_codebase/test_mmdet/test_object_detection_model.py
@@ -401,6 +401,19 @@ class TestGetClassesFromCfg:
     data_cfg3 = mmcv.Config(dict(data=dict(train=dict(type='CocoDataset'))))
     data_cfg4 = mmcv.Config(dict(data=dict(error=dict(type='CocoDataset'))))
 
+    data_cfg_classes_1 = mmcv.Config(
+        dict(
+            data=dict(
+                test=dict(classes=('a')),
+                val=dict(classes=('b')),
+                train=dict(classes=('b')))))
+
+    data_cfg_classes_2 = mmcv.Config(
+        dict(data=dict(val=dict(classes=('a')), train=dict(classes=('b')))))
+    data_cfg_classes_3 = mmcv.Config(
+        dict(data=dict(train=dict(classes=('a')))))
+    data_cfg_classes_4 = mmcv.Config(dict(classes=('a')))
+
     @pytest.mark.parametrize('cfg',
                              [data_cfg1, data_cfg2, data_cfg3, data_cfg4])
     def test_get_classes_from_cfg(self, cfg):
@@ -415,13 +428,15 @@ class TestGetClassesFromCfg:
             assert get_classes_from_config(
                 cfg) == DATASETS.module_dict['CocoDataset'].CLASSES
 
-    def test_get_classes_from_custom_cfg(self):
-        data_cfg = mmcv.Config(dict(classes=('a', 'b', 'c')))
-
+    @pytest.mark.parametrize('cfg', [
+        data_cfg_classes_1, data_cfg_classes_2, data_cfg_classes_3,
+        data_cfg_classes_4
+    ])
+    def test_get_classes_from_custom_cfg(self, cfg):
         from mmdeploy.codebase.mmdet.deploy.object_detection_model import \
             get_classes_from_config
 
-        assert get_classes_from_config(data_cfg) == ['a', 'b', 'c']
+        assert get_classes_from_config(cfg) == ['a']
 
 
 @backend_checker(Backend.ONNXRUNTIME)


### PR DESCRIPTION
## Motivation

#22 : We cannot get the `CLASSES` of custom dataset in MMDet.

## Modification

Modify `object_detection_model.py::get_classes_from_cfg`.
