### PR TITLE
[Fix]: dynamic shape not valid in mmseg

### DIFF
--- a/mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py
+++ b/mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py
@@ -35,7 +35,7 @@ def encoder_decoder__simple_test(ctx, self, img, img_meta, **kwargs):
     seg_pred = seg_logit.argmax(dim=1)
     # our inference backend only support 4D output
     shape = seg_pred.shape
-    if is_dynamic_shape(ctx.cfg):
+    if not is_dynamic_shape(ctx.cfg):
         shape = [int(_) for _ in shape]
     seg_pred = seg_pred.view(shape[0], 1, shape[1], shape[2])
     return seg_pred


### PR DESCRIPTION
## Motivation
Related to issue #44 

Dynamic shape is mistaken as static shape in `mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py:39`
https://github.com/open-mmlab/mmdeploy/blob/03e1213848edbfc1d242f64b13372bc512871f6e/mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py#L38

## Modification

change to right logic

## BC-breaking (Optional)

None
