### PR TITLE
[Fix] Fixed device_id in tools/test.py for the CPU.

### DIFF
--- a/mmdeploy/backend/openvino/wrapper.py
+++ b/mmdeploy/backend/openvino/wrapper.py
@@ -107,11 +107,14 @@ class OpenVINOWrapper(BaseWrapper):
             name: torch.from_numpy(tensor)
             for name, tensor in outputs.items()
         }
-        for output_name in outputs.keys():
-            if '.' in output_name:
-                new_output_name = output_name.split('.')[0]
-                outputs[new_output_name] = outputs.pop(output_name)
-        return outputs
+        cleaned_outputs = {}
+        for name, value in outputs.items():
+            if '.' in name:
+                new_output_name = name.split('.')[0]
+                cleaned_outputs[new_output_name] = value
+            else:
+                cleaned_outputs[name] = value
+        return cleaned_outputs
 
     def forward(self, inputs: Dict[str,
                                    torch.Tensor]) -> Dict[str, torch.Tensor]:

--- a/mmdeploy/utils/device.py
+++ b/mmdeploy/utils/device.py
@@ -1,24 +1,27 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional
+
 import torch
 
 
-def parse_device_id(device: str) -> int:
-    """Parse cuda device index from a string.
+def parse_device_id(device: str) -> Optional[int]:
+    """Parse device index from a string.
 
     Args:
-        device (str): The typical style of string specifying cuda device,
-            e.g.: 'cuda:0'.
+        device (str): The typical style of string specifying device,
+            e.g.: 'cuda:0', 'cpu'.
 
     Returns:
-        int: The parsed device id, defaults to `0`.
-            If device is 'cpu' it will return `-1`.
+        Optional[int]: The return value depends on the type of device.
+            If device is 'cuda': cuda device index, defaults to `0`.
+            If device is 'cpu': `-1`.
+            Otherwise, `None` will be returned.
     """
     if device == 'cpu':
         return -1
-    device_id = 0
-    if len(device) >= 6:
-        device_id = torch.device(device).index
-    return device_id
+    if 'cuda' in device:
+        return parse_cuda_device_id(device)
+    return None
 
 
 def parse_cuda_device_id(device: str) -> int:

--- a/mmdeploy/utils/device.py
+++ b/mmdeploy/utils/device.py
@@ -11,6 +11,7 @@ def parse_device_id(device: str) -> int:
 
     Returns:
         int: The parsed device id, defaults to `0`.
+            If device is 'cpu' it will return `-1`.
     """
     if device == 'cpu':
         return -1

--- a/tests/test_utils/test_util.py
+++ b/tests/test_utils/test_util.py
@@ -379,10 +379,14 @@ class TestParseDeviceID:
         device = 'cuda:10'
         assert util.parse_device_id(device) == 10
 
-    def test_incorrect_device(self):
-        device = 'cuda_10'
+    def test_incorrect_cuda_device(self):
+        device = 'cuda_5'
         with pytest.raises(RuntimeError):
             util.parse_device_id(device)
+
+    def test_incorrect_device(self):
+        device = 'abcd:1'
+        assert util.parse_device_id(device) is None
 
 
 def test_AdvancedEnum():

--- a/tests/test_utils/test_util.py
+++ b/tests/test_utils/test_util.py
@@ -365,6 +365,26 @@ class TestGetDynamicAxes:
         assert expected_dynamic_axes == dynamic_axes
 
 
+class TestParseDeviceID:
+
+    def test_cpu(self):
+        device = 'cpu'
+        assert util.parse_device_id(device) == -1
+
+    def test_cuda(self):
+        device = 'cuda'
+        assert util.parse_device_id(device) == 0
+
+    def test_cuda10(self):
+        device = 'cuda:10'
+        assert util.parse_device_id(device) == 10
+
+    def test_incorrect_device(self):
+        device = 'cuda_10'
+        with pytest.raises(RuntimeError):
+            util.parse_device_id(device)
+
+
 def test_AdvancedEnum():
     keys = [
         Task.TEXT_DETECTION, Task.TEXT_RECOGNITION, Task.SEGMENTATION,

--- a/tools/test.py
+++ b/tools/test.py
@@ -106,7 +106,7 @@ def main():
 
     device_id = parse_device_id(args.device)
 
-    model = MMDataParallel(model, device_ids=[device_id])
+    model = MMDataParallel(model, device_ids=[0])
     # The whole dataset test wrapped a MMDataParallel class outside the module.
     # As mmcls.apis.test.py single_gpu_test defined, the MMDataParallel needs
     # a 'CLASSES' attribute. So we ensure the MMDataParallel class has the same

--- a/tools/test.py
+++ b/tools/test.py
@@ -104,9 +104,12 @@ def main():
     # load the model of the backend
     model = task_processor.init_backend_model(args.model)
 
-    device_id = parse_device_id(args.device)
+    if args.device == 'cpu':
+        device_id = 0
+    else:
+        device_id = parse_device_id(args.device)
 
-    model = MMDataParallel(model, device_ids=[0])
+    model = MMDataParallel(model, device_ids=[device_id])
     # The whole dataset test wrapped a MMDataParallel class outside the module.
     # As mmcls.apis.test.py single_gpu_test defined, the MMDataParallel needs
     # a 'CLASSES' attribute. So we ensure the MMDataParallel class has the same

--- a/tools/test.py
+++ b/tools/test.py
@@ -104,10 +104,8 @@ def main():
     # load the model of the backend
     model = task_processor.init_backend_model(args.model)
 
-    if args.device == 'cpu':
-        device_id = 0
-    else:
-        device_id = parse_device_id(args.device)
+    is_device_cpu = (args.device == 'cpu')
+    device_id = None if is_device_cpu else parse_device_id(args.device)
 
     model = MMDataParallel(model, device_ids=[device_id])
     # The whole dataset test wrapped a MMDataParallel class outside the module.
@@ -117,7 +115,7 @@ def main():
     if hasattr(model.module, 'CLASSES'):
         model.CLASSES = model.module.CLASSES
     if args.speed_test:
-        with_sync = device_id >= 0
+        with_sync = not is_device_cpu
         output_file = sys.stdout
         if args.log2file:
             output_file = args.log2file


### PR DESCRIPTION
## Motivation
It was found that `tools/test.py` with argument `--device cpu` crashes with the following error:
```bash
2022-01-11 01:45:25,318 - mmdeploy - INFO - Successfully loaded onnxruntime custom ops from             /home/sbevzyuk/mmdeployment_dir/MMDeploy/build/lib/libmmdeploy_onnxruntime_ops.so
Traceback (most recent call last):
  File "/home/sbevzyuk/mmdeployment_dir/MMDeploy/tools/test.py", line 141, in <module>
    main()
  File "/home/sbevzyuk/mmdeployment_dir/MMDeploy/tools/test.py", line 112, in main
    model = MMDataParallel(model, device_ids=[device_id])
  File "/home/sbevzyuk/anaconda3/envs/mmdeployment/lib/python3.7/site-packages/mmcv/parallel/data_parallel.py", line 35, in __init__
    super(MMDataParallel, self).__init__(*args, dim=dim, **kwargs)
  File "/home/sbevzyuk/anaconda3/envs/mmdeployment/lib/python3.7/site-packages/torch/nn/parallel/data_parallel.py", line 140, in __init__
    self.src_device_obj = torch.device(device_type, self.device_ids[0])
RuntimeError: Device index must not be negative`
```
This PR proposes a fix for this problem. 

## Modification
- `mmdeploy/backend/openvino/wrapper.py`: Fixed work with the dictionary for Python 3.8.
- `mmdeploy/utils/device.py`: The documentation of the `parse_device_id` function was updated.
- `tests/test_utils/test_util.py`: Added tests for function `parse_device_id`.
- `tools/test.py`: Added fix for `cpu`.
