### PR TITLE
[Enhancement]: Remove deepcopy in patch_model

### DIFF
--- a/mmdeploy/core/rewriters/module_rewriter.py
+++ b/mmdeploy/core/rewriters/module_rewriter.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import inspect
-from copy import deepcopy
 
 import mmcv
 from torch import nn
@@ -102,7 +101,7 @@ class ModuleRewriter:
                         module, cfg, **kwargs)
             return self._replace_one_module(model, cfg, **kwargs)
 
-        return _replace_module_impl(deepcopy(model), cfg, **kwargs)
+        return _replace_module_impl(model, cfg, **kwargs)
 
     def _collect_record(self, backend: str):
         """Collect models in registry."""

--- a/mmdeploy/core/rewriters/rewriter_manager.py
+++ b/mmdeploy/core/rewriters/rewriter_manager.py
@@ -43,7 +43,8 @@ def patch_model(model: nn.Module,
                 backend: str = Backend.DEFAULT.value,
                 recursive: bool = True,
                 **kwargs) -> nn.Module:
-    """Patch the model, replace the modules that can be rewritten.
+    """Patch the model, replace the modules that can be rewritten. Note that
+    the original model will be modified permanently.
 
     Args:
         model (torch.nn.Module): The model to patch.

--- a/tests/test_core/test_module_rewriter.py
+++ b/tests/test_core/test_module_rewriter.py
@@ -32,7 +32,9 @@ def test_module_rewriter():
     torch.testing.assert_allclose(rewritten_result, result * 2)
 
     # wrong backend should not be rewritten
-
+    model = resnet50().eval()
+    bottle_neck = model.layer1[0]
+    result = bottle_neck(x)
     rewritten_model = patch_model(model, cfg=cfg)
     rewritten_bottle_nect = rewritten_model.layer1[0]
     rewritten_result = rewritten_bottle_nect(x)


### PR DESCRIPTION
## Motivation

When `patch_model`, we have to deepcopy a model, which increases the memory overhead.

## Modification

Remove `deepcopy` and add comments.