### PR TITLE
Fix memleak

### DIFF
--- a/csrc/apis/c/detector.cpp
+++ b/csrc/apis/c/detector.cpp
@@ -155,7 +155,7 @@ MM_SDK_API void mmdeploy_detector_release_result(mm_detect_t* results, const int
   for (int i = 0; i < count; ++i) {
     for (int j = 0; j < result_count[i]; ++j, ++result_ptr) {
       if (result_ptr->mask) {
-        delete result_ptr->mask->data;
+        delete [] result_ptr->mask->data;
         delete result_ptr->mask;
       }
     }

--- a/csrc/apis/c/detector.cpp
+++ b/csrc/apis/c/detector.cpp
@@ -155,7 +155,7 @@ MM_SDK_API void mmdeploy_detector_release_result(mm_detect_t* results, const int
   for (int i = 0; i < count; ++i) {
     for (int j = 0; j < result_count[i]; ++j, ++result_ptr) {
       if (result_ptr->mask) {
-        delete [] result_ptr->mask->data;
+        delete[] result_ptr->mask->data;
         delete result_ptr->mask;
       }
     }

--- a/csrc/codebase/common.h
+++ b/csrc/codebase/common.h
@@ -14,7 +14,7 @@ namespace mmdeploy {
 class Context {
  public:
   explicit Context(const Value& config) {
-    DEBUG("config: {}", cfg);
+    DEBUG("config: {}", config);
     device_ = config["context"]["device"].get<Device>();
     stream_ = config["context"]["stream"].get<Stream>();
   }

--- a/csrc/codebase/mmdet/object_detection.cpp
+++ b/csrc/codebase/mmdet/object_detection.cpp
@@ -107,8 +107,7 @@ Result<DetectorOutput> ResizeBBox::GetBBoxes(const Value& prep_res, const Tensor
             rect[3] - rect[1]);
       continue;
     }
-    DEBUG("remap left {}, top {}, right {}, bottom {}", rect[0], rect[1], rect[2],
-          rect[3]);
+    DEBUG("remap left {}, top {}, right {}, bottom {}", rect[0], rect[1], rect[2], rect[3]);
     DetectorOutput::Detection det{};
     det.index = i;
     det.label_id = static_cast<int>(*labels_ptr);

--- a/csrc/codebase/mmdet/object_detection.cpp
+++ b/csrc/codebase/mmdet/object_detection.cpp
@@ -107,8 +107,8 @@ Result<DetectorOutput> ResizeBBox::GetBBoxes(const Value& prep_res, const Tensor
             rect[3] - rect[1]);
       continue;
     }
-    DEBUG("remap left {}, top {}, right {}, bottom {}", rect.left, rect.top, rect.right,
-          rect.bottom);
+    DEBUG("remap left {}, top {}, right {}, bottom {}", rect[0], rect[1], rect[2],
+          rect[3]);
     DetectorOutput::Detection det{};
     det.index = i;
     det.label_id = static_cast<int>(*labels_ptr);


### PR DESCRIPTION
## Motivation

Find memory leak when testing SDK by enabling ASAN

## Modification

1. `delete [] result_ptr->mask->data;` in `detector.cpp`

## BC-breaking (Optional)


## Use cases (Optional)



## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
