### PR TITLE
[Enhacement] Allow test.py to save evaluation results

### DIFF
--- a/docs/en/tutorials/how_to_evaluate_a_model.md
+++ b/docs/en/tutorials/how_to_evaluate_a_model.md
@@ -22,6 +22,7 @@ ${MODEL_CFG} \
 --device ${DEVICE} \
 [--cfg-options ${CFG_OPTIONS}] \
 [--metric-options ${METRIC_OPTIONS}]
+[--log2file work_dirs/output.txt]
 ```
 
 ## Description of all arguments
@@ -39,6 +40,7 @@ ${MODEL_CFG} \
 * `--cfg-options`: Extra or overridden settings that will be merged into the current deploy config.
 * `--metric-options`: Custom options for evaluation. The key-value pair in xxx=yyy
 format will be kwargs for dataset.evaluate() function.
+* `--log2file`: log evaluation results (and speed) to file.
 
 \* Other arguments in `tools/test.py` are used for speed test. They have no concern with evaluation.
 

--- a/docs/en/tutorials/how_to_measure_performance_of_models.md
+++ b/docs/en/tutorials/how_to_measure_performance_of_models.md
@@ -24,10 +24,10 @@ ${MODEL_CFG} \
 * `deploy_cfg`: The config for deployment.
 * `model_cfg`: The config of the model in OpenMMLab codebases.
 * `--model`: The backend model files. For example, if we convert a model to ncnn, we need to pass a ".param" file and a ".bin" file. If we convert a model to TensorRT, we need to pass the model file with ".engine" suffix.
+* `--log2file`: log evaluation results and speed to file.
 * `--speed-test`:  Whether to activate speed test.
 * `--warmup`: warmup before counting inference elapse, require setting speed-test first.
 * `--log-interval`: The interval between each log, require setting speed-test first.
-* `--log2file`: Log speed test result in file format, need speed-test first.
 
 \* Other arguments in `tools/test.py` are used for performance test. They have no concern with speed test.
 

--- a/mmdeploy/codebase/base/task.py
+++ b/mmdeploy/codebase/base/task.py
@@ -230,6 +230,7 @@ class BaseTask(metaclass=ABCMeta):
                          out: Optional[str] = None,
                          metric_options: Optional[dict] = None,
                          format_only: bool = False,
+                         log_file: Optional[str] = None,
                          **kwargs):
         """Perform post-processing to predictions of model.
 
@@ -244,13 +245,16 @@ class BaseTask(metaclass=ABCMeta):
                 for single label dataset, and "mAP", "CP", "CR", "CF1",
                 "OP", "OR", "OF1" for multi-label dataset in mmcls.
                 Defaults is `None`.
-            out (str): Output result file in pickle format, defaults to `None`.
+            out (str): Output inference results in pickle format, defaults to
+                `None`.
             metric_options (dict): Custom options for evaluation, will be
                 kwargs for dataset.evaluate() function. Defaults to `None`.
             format_only (bool): Format the output results without perform
                 evaluation. It is useful when you want to format the result
                 to a specific format and submit it to the test server. Defaults
                 to `False`.
+            log_file (str | None): The file to write the evaluation results.
+                Defaults to `None` and the results will only print on stdout.
         """
         pass
 

--- a/mmdeploy/codebase/mmcls/deploy/classification.py
+++ b/mmdeploy/codebase/mmcls/deploy/classification.py
@@ -232,8 +232,6 @@ class Classification(BaseTask):
         import warnings
         from mmcv.utils import get_logger
         logger = get_logger('test', log_file=log_file, log_level=logging.INFO)
-        print(log_file)
-        print(logger)
 
         if metrics:
             results = dataset.evaluate(outputs, metrics, metric_options)

--- a/mmdeploy/codebase/mmcls/deploy/classification.py
+++ b/mmdeploy/codebase/mmcls/deploy/classification.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import logging
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import mmcv
@@ -208,7 +209,8 @@ class Classification(BaseTask):
                          metrics: Optional[str] = None,
                          out: Optional[str] = None,
                          metric_options: Optional[dict] = None,
-                         format_only: bool = False) -> None:
+                         format_only: bool = False,
+                         log_file: Optional[str] = None) -> None:
         """Perform post-processing to predictions of model.
 
         Args:
@@ -224,13 +226,19 @@ class Classification(BaseTask):
                 evaluation. It is useful when you want to format the result
                 to a specific format and submit it to the test server.
                 Default: False.
+            log_file (str | None): The file to write the evaluation results.
+                Defaults to `None` and the results will only print on stdout.
         """
         import warnings
+        from mmcv.utils import get_logger
+        logger = get_logger('test', log_file=log_file, log_level=logging.INFO)
+        print(log_file)
+        print(logger)
 
         if metrics:
             results = dataset.evaluate(outputs, metrics, metric_options)
             for k, v in results.items():
-                print(f'\n{k} : {v:.2f}')
+                logger.info(f'{k} : {v:.2f}')
         else:
             warnings.warn('Evaluation metrics are not specified.')
             scores = np.vstack(outputs)
@@ -243,13 +251,13 @@ class Classification(BaseTask):
                 'pred_class': pred_class
             }
             if not out:
-                print('\nthe predicted result for the first element is '
-                      f'pred_score = {pred_score[0]:.2f}, '
-                      f'pred_label = {pred_label[0]} '
-                      f'and pred_class = {pred_class[0]}. '
-                      'Specify --out to save all results to files.')
+                logger.info('the predicted result for the first element is '
+                            f'pred_score = {pred_score[0]:.2f}, '
+                            f'pred_label = {pred_label[0]} '
+                            f'and pred_class = {pred_class[0]}. '
+                            'Specify --out to save all results to files.')
         if out:
-            print(f'\nwriting results to {out}')
+            logger.debug(f'writing results to {out}')
             mmcv.dump(results, out)
 
     def get_preprocess(self) -> Dict:

--- a/mmdeploy/codebase/mmedit/deploy/super_resolution.py
+++ b/mmdeploy/codebase/mmedit/deploy/super_resolution.py
@@ -10,7 +10,7 @@ from torch.utils.data import Dataset
 
 from mmdeploy.codebase.base import BaseTask
 from mmdeploy.codebase.mmedit.deploy.mmediting import MMEDIT_TASK
-from mmdeploy.utils import Task, get_input_shape, get_root_logger, load_config
+from mmdeploy.utils import Task, get_input_shape, load_config
 
 
 def process_model_config(model_cfg: mmcv.Config,
@@ -249,6 +249,7 @@ class SuperResolution(BaseTask):
                          out: Optional[str] = None,
                          metric_options: Optional[dict] = None,
                          format_only: bool = False,
+                         log_file: Optional[str] = None,
                          **kwargs) -> None:
         """Evaluation function implemented in mmedit.
 
@@ -265,17 +266,20 @@ class SuperResolution(BaseTask):
                 evaluation. It is useful when you want to format the result
                 to a specific format and submit it to the test server. Defaults
                 to `False`.
+            log_file (str | None): The file to write the evaluation results.
+                Defaults to `None` and the results will only print on stdout.
         """
+        from mmcv.utils import get_logger
+        logger = get_logger('test', log_file=log_file)
+
         if out:
-            logger = get_root_logger()
-            logger.info(f'\nwriting results to {out}')
+            logger.debug(f'writing results to {out}')
             mmcv.dump(outputs, out)
         # The Dataset doesn't need metrics
-        print('\n')
         # print metrics
         stats = dataset.evaluate(outputs)
         for stat in stats:
-            print('Eval-{}: {}'.format(stat, stats[stat]))
+            logger.info('Eval-{}: {}'.format(stat, stats[stat]))
 
     def get_preprocess(self) -> Dict:
         """Get the preprocess information for SDK.

--- a/mmdeploy/codebase/mmocr/deploy/text_detection.py
+++ b/mmdeploy/codebase/mmocr/deploy/text_detection.py
@@ -10,7 +10,7 @@ from torch import nn
 from torch.utils.data import Dataset
 
 from mmdeploy.codebase.base import BaseTask
-from mmdeploy.utils import Task, get_input_shape, get_root_logger
+from mmdeploy.utils import Task, get_input_shape
 from .mmocr import MMOCR_TASK
 
 
@@ -246,7 +246,8 @@ class TextDetection(BaseTask):
                          metrics: Optional[str] = None,
                          out: Optional[str] = None,
                          metric_options: Optional[dict] = None,
-                         format_only: bool = False):
+                         format_only: bool = False,
+                         log_file: Optional[str] = None):
         """Perform post-processing to predictions of model.
 
         Args:
@@ -254,7 +255,7 @@ class TextDetection(BaseTask):
             dataset (Dataset): Input dataset to run test.
             model_cfg (mmcv.Config): The model config.
             metrics (str): Evaluation metrics, which depends on
-                the codebase and the dataset, e.g., e.g., "acc" for text
+                the codebase and the dataset, e.g., "acc" for text
                 recognition, and "hmean-iou" for text detection.
             out (str): Output result file in pickle format, defaults to `None`.
             metric_options (dict): Custom options for evaluation, will be
@@ -263,10 +264,14 @@ class TextDetection(BaseTask):
                 evaluation. It is useful when you want to format the result
                 to a specific format and submit it to the test server. Defaults
                 to `False`.
+            log_file (str | None): The file to write the evaluation results.
+                Defaults to `None` and the results will only print on stdout.
         """
+        from mmcv.utils import get_logger
+        logger = get_logger('test', log_file=log_file)
+
         if out:
-            logger = get_root_logger()
-            logger.info(f'\nwriting results to {out}')
+            logger.debug(f'writing results to {out}')
             mmcv.dump(outputs, out)
         kwargs = {} if metric_options is None else metric_options
         if format_only:
@@ -280,7 +285,7 @@ class TextDetection(BaseTask):
             ]:
                 eval_kwargs.pop(key, None)
             eval_kwargs.update(dict(metric=metrics, **kwargs))
-            print(dataset.evaluate(outputs, **eval_kwargs))
+            logger.info(dataset.evaluate(outputs, **eval_kwargs))
 
     def get_preprocess(self) -> Dict:
         """Get the preprocess information for SDK.

--- a/mmdeploy/codebase/mmocr/deploy/text_recognition.py
+++ b/mmdeploy/codebase/mmocr/deploy/text_recognition.py
@@ -10,7 +10,7 @@ from torch import nn
 from torch.utils.data import Dataset
 
 from mmdeploy.codebase.base import BaseTask
-from mmdeploy.utils import Task, get_input_shape, get_root_logger
+from mmdeploy.utils import Task, get_input_shape
 from .mmocr import MMOCR_TASK
 
 
@@ -259,7 +259,8 @@ class TextRecognition(BaseTask):
                          metrics: Optional[str] = None,
                          out: Optional[str] = None,
                          metric_options: Optional[dict] = None,
-                         format_only: bool = False):
+                         format_only: bool = False,
+                         log_file: Optional[str] = None):
         """Perform post-processing to predictions of model.
 
         Args:
@@ -267,7 +268,7 @@ class TextRecognition(BaseTask):
             outputs (list): A list of predictions of model inference.
             dataset (Dataset): Input dataset to run test.
             metrics (str): Evaluation metrics, which depends on
-                the codebase and the dataset, e.g., e.g., "acc" for text
+                the codebase and the dataset, e.g., "acc" for text
                 recognition, and "hmean-iou" for text detection.
             out (str): Output result file in pickle format, defaults to `None`.
             metric_options (dict): Custom options for evaluation, will be
@@ -276,10 +277,14 @@ class TextRecognition(BaseTask):
                 evaluation. It is useful when you want to format the result
                 to a specific format and submit it to the test server. Defaults
                 to `False`.
+            log_file (str | None): The file to write the evaluation results.
+                Defaults to `None` and the results will only print on stdout.
         """
+        from mmcv.utils import get_logger
+        logger = get_logger('test', log_file=log_file)
+
         if out:
-            logger = get_root_logger()
-            logger.info(f'\nwriting results to {out}')
+            logger.debug(f'writing results to {out}')
             mmcv.dump(outputs, out)
         kwargs = {} if metric_options is None else metric_options
         if format_only:
@@ -293,7 +298,7 @@ class TextRecognition(BaseTask):
             ]:
                 eval_kwargs.pop(key, None)
             eval_kwargs.update(dict(metric=metrics, **kwargs))
-            print(dataset.evaluate(outputs, **eval_kwargs))
+            logger.info(dataset.evaluate(outputs, **eval_kwargs))
 
     def get_preprocess(self) -> Dict:
         """Get the preprocess information for SDK.

--- a/mmdeploy/codebase/mmseg/deploy/segmentation.py
+++ b/mmdeploy/codebase/mmseg/deploy/segmentation.py
@@ -7,7 +7,7 @@ import torch
 from torch.utils.data import Dataset
 
 from mmdeploy.codebase.base import BaseTask
-from mmdeploy.utils import Task, get_input_shape, get_root_logger
+from mmdeploy.utils import Task, get_input_shape
 from .mmsegmentation import MMSEG_TASK
 
 
@@ -206,7 +206,8 @@ class Segmentation(BaseTask):
                          metrics: Optional[str] = None,
                          out: Optional[str] = None,
                          metric_options: Optional[dict] = None,
-                         format_only: bool = False):
+                         format_only: bool = False,
+                         log_file: Optional[str] = None):
         """Perform post-processing to predictions of model.
 
         Args:
@@ -223,16 +224,20 @@ class Segmentation(BaseTask):
                 evaluation. It is useful when you want to format the result
                 to a specific format and submit it to the test server. Defaults
                 to `False`.
+            log_file (str | None): The file to write the evaluation results.
+                Defaults to `None` and the results will only print on stdout.
         """
+        from mmcv.utils import get_logger
+        logger = get_logger('test', log_file=log_file)
+
         if out:
-            logger = get_root_logger()
-            logger.info(f'\nwriting results to {out}')
+            logger.debug(f'writing results to {out}')
             mmcv.dump(outputs, out)
         kwargs = {} if metric_options is None else metric_options
         if format_only:
             dataset.format_results(outputs, **kwargs)
         if metrics:
-            dataset.evaluate(outputs, metrics, **kwargs)
+            dataset.evaluate(outputs, metrics, logger=logger, **kwargs)
 
     def get_preprocess(self) -> Dict:
         """Get the preprocess information for SDK.

--- a/mmdeploy/utils/timer.py
+++ b/mmdeploy/utils/timer.py
@@ -103,7 +103,7 @@ class TimeCounter:
                 is `None`.
         """
         assert warmup >= 1
-        logger = get_logger('mmdeploy', log_file=file)
+        logger = get_logger('test', log_file=file)
         cls.logger = logger
         if func_name is not None:
             warnings.warn('func_name must be globally unique if you call '

--- a/mmdeploy/utils/timer.py
+++ b/mmdeploy/utils/timer.py
@@ -1,18 +1,16 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import io
-import sys
 import time
 import warnings
 from contextlib import contextmanager
-from typing import Union
+from typing import Optional
 
 import torch
+from mmcv.utils import get_logger
 
 
 class TimeCounter:
     """A tool for counting inference time of backends."""
     names = dict()
-    file = sys.stdout
 
     # Avoid instantiating every time
     @classmethod
@@ -76,10 +74,7 @@ class TimeCounter:
                         msg = f'[{func.__name__}]-{count} times per count: '\
                               f'{times_per_count:.2f} ms, '\
                               f'{1000/times_per_count:.2f} FPS'
-                        if cls.file != sys.stdout:
-                            msg += '\n'
-                        cls.file.write(msg)
-                        cls.file.flush()
+                        cls.logger.info(msg)
 
                 return result
 
@@ -94,7 +89,7 @@ class TimeCounter:
                  warmup: int = 1,
                  log_interval: int = 1,
                  with_sync: bool = False,
-                 file: Union[str, io.TextIOWrapper] = sys.stdout):
+                 file: Optional[str] = None):
         """Activate the time counter.
 
         Args:
@@ -104,13 +99,12 @@ class TimeCounter:
             log_interval (int): Interval between each log, default 1.
             with_sync (bool): Whether use cuda synchronize for time counting,
                 default False.
-            file (str | io.TextIOWrapper): A file or file-like object to save
-                output messages. The default is `sys.stdout`.
+            file (str | None): The file to save output messages. The default
+                is `None`.
         """
         assert warmup >= 1
-        if file != sys.stdout:
-            file = open(file, 'w+')
-        cls.file = file
+        logger = get_logger('mmdeploy', log_file=file)
+        cls.logger = logger
         if func_name is not None:
             warnings.warn('func_name must be globally unique if you call '
                           'activate multiple times')
@@ -127,8 +121,6 @@ class TimeCounter:
                 cls.names[name]['with_sync'] = with_sync
                 cls.names[name]['enable'] = True
         yield
-        if file != sys.stdout:
-            cls.file.close()
         if func_name is not None:
             cls.names[func_name]['enable'] = False
         else:

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
-import sys
 
 from mmcv import DictAction
 from mmcv.parallel import MMDataParallel
@@ -72,7 +71,8 @@ def parse_args():
     parser.add_argument(
         '--log2file',
         type=str,
-        help='log speed in file format, require speed-test first')
+        help='log evaluation results and speed to file',
+        default=None)
 
     args = parser.parse_args()
     return args
@@ -117,15 +117,12 @@ def main():
         model.CLASSES = model.module.CLASSES
     if args.speed_test:
         with_sync = not is_device_cpu
-        output_file = sys.stdout
-        if args.log2file:
-            output_file = args.log2file
 
         with TimeCounter.activate(
                 warmup=args.warmup,
                 log_interval=args.log_interval,
                 with_sync=with_sync,
-                file=output_file):
+                file=args.log2file):
             outputs = task_processor.single_gpu_test(model, data_loader,
                                                      args.show, args.show_dir)
     else:
@@ -133,7 +130,7 @@ def main():
                                                  args.show_dir)
     task_processor.evaluate_outputs(model_cfg, outputs, dataset, args.metrics,
                                     args.out, args.metric_options,
-                                    args.format_only)
+                                    args.format_only, args.log2file)
 
 
 if __name__ == '__main__':

--- a/tools/test.py
+++ b/tools/test.py
@@ -55,6 +55,11 @@ def parse_args():
         help='custom options for evaluation, the key-value pair in xxx=yyy '
         'format will be kwargs for dataset.evaluate() function')
     parser.add_argument(
+        '--log2file',
+        type=str,
+        help='log evaluation results and speed to file',
+        default=None)
+    parser.add_argument(
         '--speed-test', action='store_true', help='activate speed test')
     parser.add_argument(
         '--warmup',
@@ -68,11 +73,6 @@ def parse_args():
         help='the interval between each log, require setting '
         'speed-test first',
         default=100)
-    parser.add_argument(
-        '--log2file',
-        type=str,
-        help='log evaluation results and speed to file',
-        default=None)
 
     args = parser.parse_args()
     return args


### PR DESCRIPTION
## Motivation

The evaluation results of `test.py` are hard to redirect to a file.

## Modification

Use logger to manage all the logs of `test.py`. Now all the outputs of `test.py` will be saved to `--log2file`.

