### PR TITLE
[Doc] Update Nvidia Jetson TX2 benchmark

### DIFF
--- a/docs/en/benchmark.md
+++ b/docs/en/benchmark.md
@@ -28,7 +28,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
 <summary style="margin-left: 25px;">MMCls</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="3">MMCls</th>
@@ -188,7 +188,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
 <summary style="margin-left: 25px;">MMDet</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="3">MMDet</th>
@@ -340,7 +340,65 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
   </tr>
 </tbody>
 </table>
-
+<table class="docutils">
+<thead>
+  <tr>
+    <th align="center" colspan="3">MMDet</th>
+    <th align="center" colspan="4">NCNN</th>
+    <th align="center"></th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td align="center" rowspan="3">Model</td>
+    <td align="center" rowspan="3">Dataset</td>
+    <td align="center" rowspan="3">Input</td>
+    <td align="center" colspan="2">SnapDragon888</td>
+    <td align="center" colspan="2">Adreno660</td>
+    <td align="center" rowspan="3">model config file</td>
+  </tr>
+  <tr>
+    <td align="center" colspan="2">fp32</td>
+    <td align="center" colspan="2">fp32</td>
+  </tr>
+  <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
+  </tr>
+  <tr>
+    <td align="center">MobileNetv2-YOLOv3</td>
+    <td align="center">COCO</td>
+    <td align="center">1x3x320x320</td>
+    <td align="center">48.57</td>
+    <td align="center">20.59</td>
+    <td align="center">66.55</td>
+    <td align="center">15.03</td>
+    <td>$MMDET_DIR/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py</td>
+  </tr>
+  <tr>
+    <td align="center">SSD-Lite</td>
+    <td align="center">COCO</td>
+    <td align="center">1x3x320x320</td>
+    <td align="center">44.91</td>
+    <td align="center">22.27</td>
+    <td align="center">66.19</td>
+    <td align="center">15.11</td>
+    <td>$MMDET_DIR/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py</td>
+  </tr>
+  <tr>
+    <td align="center">YOLOX</td>
+    <td align="center">COCO</td>
+    <td align="center">1x3x416x416</td>
+    <td align="center">111.60</td>
+    <td align="center">8.96</td>
+    <td align="center">134.50</td>
+    <td align="center">7.43</td>
+    <td>$MMDET_DIR/configs/yolox/yolox_tiny_8x8_300e_coco.py</td>
+  </tr>
+</tbody>
+</table>
 </div>
 </details>
 
@@ -348,7 +406,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
 <summary style="margin-left: 25px;">MMEdit</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="2">MMEdit</th>
@@ -511,7 +569,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
 <summary style="margin-left: 25px;">MMSeg</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="3">MMSeg</th>

--- a/docs/en/benchmark.md
+++ b/docs/en/benchmark.md
@@ -49,7 +49,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -205,7 +205,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -355,7 +355,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -422,7 +422,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -501,7 +501,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -586,7 +586,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -707,7 +707,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">ResNet-18</td>
@@ -868,7 +868,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center">YOLOV3</td>
@@ -1052,7 +1052,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">SRCNN</td>
@@ -1241,7 +1241,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="3">DBNet*</td>
@@ -1335,7 +1335,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center">FCN</td>

--- a/docs/en/benchmark.md
+++ b/docs/en/benchmark.md
@@ -28,11 +28,11 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
 <summary style="margin-left: 25px;">MMCls</summary>
 <div style="margin-left: 25px;">
 
-<table class="docutils">
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="3">MMCls</th>
-    <th align="center" colspan="10">TensorRT</th>
+    <th align="center" colspan="12">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
     <th align="center" colspan="4">NCNN</th>
     <th></th>
@@ -45,10 +45,11 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="4">JetsonNano2GB</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -56,11 +57,14 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" colspan="2">int8</td>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp32</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -92,6 +96,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">16.86</td>
     <td align="center">30.54</td>
     <td align="center">32.75</td>
+    <td align="center">24.13</td>
+    <td align="center">41.44</td>
     <td align="center">1.30</td>
     <td align="center">768.28</td>
     <td align="center">33.91</td>
@@ -114,6 +120,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">11.35</td>
     <td align="center">49.18</td>
     <td align="center">20.13</td>
+    <td align="center">37.45</td>
+    <td align="center">26.70</td>
     <td align="center">1.36</td>
     <td align="center">737.67</td>
     <td align="center">133.44</td>
@@ -136,6 +144,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">13.41</td>
     <td align="center">48.78</td>
     <td align="center">20.50</td>
+    <td align="center">29.62</td>
+    <td align="center">33.76</td>
     <td align="center">1.91</td>
     <td align="center">524.07</td>
     <td align="center">107.84</td>
@@ -158,6 +168,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">65.54</td>
     <td align="center">10.23</td>
     <td align="center">97.77</td>
+    <td align="center">7.37</td>
+    <td align="center">135.73</td>
     <td align="center">4.69</td>
     <td align="center">213.33</td>
     <td align="center">9.55</td>
@@ -175,13 +187,14 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
 <details>
 <summary style="margin-left: 25px;">MMDet</summary>
 <div style="margin-left: 25px;">
-<table class="docutils">
+
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="3">MMDet</th>
-    <th align="center" colspan="6">TensorRT</th>
+    <th align="center" colspan="8">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
-    <th align="center"></th>
+    <th></th>
   </tr>
 </thead>
 <tbody>
@@ -190,16 +203,20 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" rowspan="3">Dataset</td>
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">int8</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -219,6 +236,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">40.13</td>
     <td align="center">24.92</td>
     <td align="center">40.13</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">18.07</td>
     <td align="center">55.35</td>
     <td>$MMDET_DIR/configs/yolo/yolov3_d53_320_273e_coco.py</td>
@@ -233,6 +252,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">108.56</td>
     <td align="center">8.04</td>
     <td align="center">124.38</td>
+    <td align="center">1.28</td>
+    <td align="center">1.28</td>
     <td align="center">19.72</td>
     <td align="center">50.71</td>
     <td>$MMDET_DIR/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py</td>
@@ -247,6 +268,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">38.78</td>
     <td align="center">16.88</td>
     <td align="center">59.23</td>
+    <td align="center">780.48</td>
+    <td align="center">1.28</td>
     <td align="center">38.34</td>
     <td align="center">26.08</td>
     <td>$MMDET_DIR/configs/retinanet/retinanet_r50_fpn_1x_coco.py</td>
@@ -261,6 +284,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">43.20</td>
     <td align="center">17.68</td>
     <td align="center">56.57</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">-</td>
     <td align="center">-</td>
     <td>$MMDET_DIR/configs/fcos/fcos_r50_caffe_fpn_gn-head_1x_coco.py</td>
@@ -275,6 +300,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">47.58</td>
     <td align="center">13.50</td>
     <td align="center">74.08</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">30.41</td>
     <td align="center">32.89</td>
     <td>$MMDET_DIR/configs/fsaf/fsaf_r50_fpn_1x_coco.py</td>
@@ -289,6 +316,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">37.70</td>
     <td align="center">19.14</td>
     <td align="center">52.23</td>
+    <td align="center">733.81</td>
+    <td align="center">1.36</td>
     <td align="center">65.40</td>
     <td align="center">15.29</td>
     <td>$MMDET_DIR/configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py</td>
@@ -303,84 +332,29 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">4.14</td>
     <td align="center">-</td>
     <td align="center">-</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">86.80</td>
     <td align="center">11.52</td>
     <td>$MMDET_DIR/configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py</td>
   </tr>
 </tbody>
 </table>
-<table class="docutils">
-<thead>
-  <tr>
-    <th align="center" colspan="3">MMDet</th>
-    <th align="center" colspan="4">NCNN</th>
-    <th align="center"></th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td align="center" rowspan="3">Model</td>
-    <td align="center" rowspan="3">Dataset</td>
-    <td align="center" rowspan="3">Input</td>
-    <td align="center" colspan="2">SnapDragon888</td>
-    <td align="center" colspan="2">Adreno660</td>
-    <td rowspan="3">model config file</td>
-  </tr>
-  <tr>
-    <td align="center" colspan="2">fp32</td>
-    <td align="center" colspan="2">fp32</td>
-  </tr>
-  <tr>
-    <td align="center">latency (ms)</td>
-    <td align="center">FPS</td>
-    <td align="center">latency (ms)</td>
-    <td align="center">FPS</td>
-  </tr>
-  <tr>
-    <td align="center">MobileNetv2-YOLOv3</td>
-    <td align="center">COCO</td>
-    <td align="center">1x3x320x320</td>
-    <td align="center">48.57</td>
-    <td align="center">20.59</td>
-    <td align="center">66.55</td>
-    <td align="center">15.03</td>
-    <td>$MMDET_DIR/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py</td>
-  </tr>
-  <tr>
-    <td align="center">SSD-Lite</td>
-    <td align="center">COCO</td>
-    <td align="center">1x3x320x320</td>
-    <td align="center">44.91</td>
-    <td align="center">22.27</td>
-    <td align="center">66.19</td>
-    <td align="center">15.11</td>
-    <td>$MMDET_DIR/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py</td>
-  </tr>
-  <tr>
-    <td align="center">YOLOX</td>
-    <td align="center">COCO</td>
-    <td align="center">1x3x416x416</td>
-    <td align="center">111.60</td>
-    <td align="center">8.96</td>
-    <td align="center">134.50</td>
-    <td align="center">7.43</td>
-    <td>$MMDET_DIR/configs/yolox/yolox_tiny_8x8_300e_coco.py</td>
-  </tr>
-</tbody>
-</table>
+
 </div>
 </details>
 
 <details>
 <summary style="margin-left: 25px;">MMEdit</summary>
 <div style="margin-left: 25px;">
-<table class="docutils">
+
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="2">MMEdit</th>
-    <th align="center" colspan="6">TensorRT</th>
+    <th align="center" colspan="8">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
-    <th align="center"></th>
+    <th></th>
   </tr>
 </thead>
 <tbody>
@@ -388,16 +362,20 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" rowspan="3">Model</td>
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">int8</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -416,6 +394,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">80.50</td>
     <td align="center">12.45</td>
     <td align="center">80.35</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">7.67</td>
     <td align="center">130.39</td>
     <td>$MMEDIT_DIR/configs/restorers/esrgan/esrgan_psnr_x4c64b23g32_g1_1000k_div2k.py</td>
@@ -429,12 +409,15 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">2836.62</td>
     <td align="center">0.26</td>
     <td align="center">3850.45</td>
+    <td align="center">58.86</td>
+    <td align="center">16.99</td>
     <td align="center">0.56</td>
     <td align="center">1775.11</td>
     <td>$MMEDIT_DIR/configs/restorers/srcnn/srcnn_x4k915_g1_1000k_div2k.py</td>
   </tr>
 </tbody>
 </table>
+
 </div>
 </details>
 
@@ -527,13 +510,14 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
 <details>
 <summary style="margin-left: 25px;">MMSeg</summary>
 <div style="margin-left: 25px;">
-<table class="docutils">
+
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="3">MMSeg</th>
-    <th align="center" colspan="6">TensorRT</th>
+    <th align="center" colspan="8">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
-    <th align="center"></th>
+    <th></th>
   </tr>
 </thead>
 <tbody>
@@ -542,16 +526,20 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" rowspan="3">Dataset</td>
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">int8</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -571,6 +559,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">41.72</td>
     <td align="center">18.13</td>
     <td align="center">55.15</td>
+    <td align="center">1682.54</td>
+    <td align="center">0.59</td>
     <td align="center">27.00</td>
     <td align="center">37.04</td>
     <td>$MMSEG_DIR/configs/fcn/fcn_r50-d8_512x1024_40k_cityscapes.py</td>
@@ -585,6 +575,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">41.49</td>
     <td align="center">16.33</td>
     <td align="center">61.23</td>
+    <td align="center">1586.19</td>
+    <td align="center">0.63</td>
     <td align="center">27.26</td>
     <td align="center">36.69</td>
     <td>$MMSEG_DIR/configs/pspnet/pspnet_r50-d8_512x1024_80k_cityscapes.py</td>
@@ -599,6 +591,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">31.45</td>
     <td align="center">19.85</td>
     <td align="center">50.38</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">36.01</td>
     <td align="center">27.77</td>
     <td>$MMSEG_DIR/configs/deeplabv3/deeplabv3_r50-d8_512x1024_80k_cityscapes.py</td>
@@ -613,12 +607,15 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">21.26</td>
     <td align="center">50.38</td>
     <td align="center">26.67</td>
+    <td align="center">2534.96</td>
+    <td align="center">0.39</td>
     <td align="center">34.80</td>
     <td align="center">28.74</td>
     <td>$MMSEG_DIR/configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_80k_cityscapes.py</td>
   </tr>
 </tbody>
 </table>
+
 </div>
 </details>
 

--- a/docs/en/benchmark.md
+++ b/docs/en/benchmark.md
@@ -236,8 +236,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">40.13</td>
     <td align="center">24.92</td>
     <td align="center">40.13</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">18.07</td>
     <td align="center">55.35</td>
     <td>$MMDET_DIR/configs/yolo/yolov3_d53_320_273e_coco.py</td>
@@ -284,8 +284,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">43.20</td>
     <td align="center">17.68</td>
     <td align="center">56.57</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">-</td>
     <td align="center">-</td>
     <td>$MMDET_DIR/configs/fcos/fcos_r50_caffe_fpn_gn-head_1x_coco.py</td>
@@ -300,8 +300,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">47.58</td>
     <td align="center">13.50</td>
     <td align="center">74.08</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">30.41</td>
     <td align="center">32.89</td>
     <td>$MMDET_DIR/configs/fsaf/fsaf_r50_fpn_1x_coco.py</td>
@@ -332,8 +332,8 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center">4.14</td>
     <td align="center">-</td>
     <td align="center">-</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">86.80</td>
     <td align="center">11.52</td>
     <td>$MMDET_DIR/configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py</td>

--- a/docs/en/benchmark.md
+++ b/docs/en/benchmark.md
@@ -443,7 +443,7 @@ Users can directly test the speed through [how_to_measure_performance_of_models.
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -649,7 +649,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">ResNet-18</td>
@@ -810,7 +810,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center">YOLOV3</td>
@@ -994,7 +994,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">SRCNN</td>
@@ -1183,7 +1183,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="3">DBNet*</td>
@@ -1277,7 +1277,7 @@ Users can directly test the performance through [how_to_evaluate_a_model.md](tut
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center">FCN</td>

--- a/docs/zh_cn/benchmark.md
+++ b/docs/zh_cn/benchmark.md
@@ -29,11 +29,11 @@ GPU: ncnn, TensorRT, PPLNN
 <summary style="margin-left: 25px;">MMCls</summary>
 <div style="margin-left: 25px;">
 
-<table class="docutils">
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="3">MMCls</th>
-    <th align="center" colspan="10">TensorRT</th>
+    <th align="center" colspan="12">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
     <th align="center" colspan="4">NCNN</th>
     <th></th>
@@ -46,10 +46,11 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="4">JetsonNano2GB</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -57,11 +58,14 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" colspan="2">int8</td>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp32</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -93,6 +97,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">16.86</td>
     <td align="center">30.54</td>
     <td align="center">32.75</td>
+    <td align="center">24.13</td>
+    <td align="center">41.44</td>
     <td align="center">1.30</td>
     <td align="center">768.28</td>
     <td align="center">33.91</td>
@@ -115,6 +121,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">11.35</td>
     <td align="center">49.18</td>
     <td align="center">20.13</td>
+    <td align="center">37.45</td>
+    <td align="center">26.70</td>
     <td align="center">1.36</td>
     <td align="center">737.67</td>
     <td align="center">133.44</td>
@@ -137,6 +145,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">13.41</td>
     <td align="center">48.78</td>
     <td align="center">20.50</td>
+    <td align="center">29.62</td>
+    <td align="center">33.76</td>
     <td align="center">1.91</td>
     <td align="center">524.07</td>
     <td align="center">107.84</td>
@@ -159,6 +169,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">65.54</td>
     <td align="center">10.23</td>
     <td align="center">97.77</td>
+    <td align="center">7.37</td>
+    <td align="center">135.73</td>
     <td align="center">4.69</td>
     <td align="center">213.33</td>
     <td align="center">9.55</td>
@@ -176,13 +188,14 @@ GPU: ncnn, TensorRT, PPLNN
 <details>
 <summary style="margin-left: 25px;">MMDet</summary>
 <div style="margin-left: 25px;">
-<table class="docutils">
+
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="3">MMDet</th>
-    <th align="center" colspan="6">TensorRT</th>
+    <th align="center" colspan="8">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
-    <th align="center"></th>
+    <th></th>
   </tr>
 </thead>
 <tbody>
@@ -191,16 +204,20 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" rowspan="3">Dataset</td>
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">int8</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -220,6 +237,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">40.13</td>
     <td align="center">24.92</td>
     <td align="center">40.13</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">18.07</td>
     <td align="center">55.35</td>
     <td>$MMDET_DIR/configs/yolo/yolov3_d53_320_273e_coco.py</td>
@@ -234,6 +253,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">108.56</td>
     <td align="center">8.04</td>
     <td align="center">124.38</td>
+    <td align="center">1.28</td>
+    <td align="center">1.28</td>
     <td align="center">19.72</td>
     <td align="center">50.71</td>
     <td>$MMDET_DIR/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py</td>
@@ -248,6 +269,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">38.78</td>
     <td align="center">16.88</td>
     <td align="center">59.23</td>
+    <td align="center">780.48</td>
+    <td align="center">1.28</td>
     <td align="center">38.34</td>
     <td align="center">26.08</td>
     <td>$MMDET_DIR/configs/retinanet/retinanet_r50_fpn_1x_coco.py</td>
@@ -262,6 +285,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">43.20</td>
     <td align="center">17.68</td>
     <td align="center">56.57</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">-</td>
     <td align="center">-</td>
     <td>$MMDET_DIR/configs/fcos/fcos_r50_caffe_fpn_gn-head_1x_coco.py</td>
@@ -276,6 +301,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">47.58</td>
     <td align="center">13.50</td>
     <td align="center">74.08</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">30.41</td>
     <td align="center">32.89</td>
     <td>$MMDET_DIR/configs/fsaf/fsaf_r50_fpn_1x_coco.py</td>
@@ -290,6 +317,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">37.70</td>
     <td align="center">19.14</td>
     <td align="center">52.23</td>
+    <td align="center">733.81</td>
+    <td align="center">1.36</td>
     <td align="center">65.40</td>
     <td align="center">15.29</td>
     <td>$MMDET_DIR/configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py</td>
@@ -304,84 +333,29 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">4.14</td>
     <td align="center">-</td>
     <td align="center">-</td>
+    <td align="center">?</td>
+    <td align="center">?</td>
     <td align="center">86.80</td>
     <td align="center">11.52</td>
     <td>$MMDET_DIR/configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py</td>
   </tr>
 </tbody>
 </table>
-<table class="docutils">
-<thead>
-  <tr>
-    <th align="center" colspan="3">MMDet</th>
-    <th align="center" colspan="4">NCNN</th>
-    <th align="center"></th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td align="center" rowspan="3">Model</td>
-    <td align="center" rowspan="3">Dataset</td>
-    <td align="center" rowspan="3">Input</td>
-    <td align="center" colspan="2">SnapDragon888</td>
-    <td align="center" colspan="2">Adreno660</td>
-    <td rowspan="3">model config file</td>
-  </tr>
-  <tr>
-    <td align="center" colspan="2">fp32</td>
-    <td align="center" colspan="2">fp32</td>
-  </tr>
-  <tr>
-    <td align="center">latency (ms)</td>
-    <td align="center">FPS</td>
-    <td align="center">latency (ms)</td>
-    <td align="center">FPS</td>
-  </tr>
-  <tr>
-    <td align="center">MobileNetv2-YOLOv3</td>
-    <td align="center">COCO</td>
-    <td align="center">1x3x320x320</td>
-    <td align="center">48.57</td>
-    <td align="center">20.59</td>
-    <td align="center">66.55</td>
-    <td align="center">15.03</td>
-    <td>$MMDET_DIR/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py</td>
-  </tr>
-  <tr>
-    <td align="center">SSD-Lite</td>
-    <td align="center">COCO</td>
-    <td align="center">1x3x320x320</td>
-    <td align="center">44.91</td>
-    <td align="center">22.27</td>
-    <td align="center">66.19</td>
-    <td align="center">15.11</td>
-    <td>$MMDET_DIR/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py</td>
-  </tr>
-  <tr>
-    <td align="center">YOLOX</td>
-    <td align="center">COCO</td>
-    <td align="center">1x3x416x416</td>
-    <td align="center">111.60</td>
-    <td align="center">8.96</td>
-    <td align="center">134.50</td>
-    <td align="center">7.43</td>
-    <td>$MMDET_DIR/configs/yolox/yolox_tiny_8x8_300e_coco.py</td>
-  </tr>
-</tbody>
-</table>
+
 </div>
 </details>
 
 <details>
 <summary style="margin-left: 25px;">MMEdit</summary>
 <div style="margin-left: 25px;">
-<table class="docutils">
+
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="2">MMEdit</th>
-    <th align="center" colspan="6">TensorRT</th>
+    <th align="center" colspan="8">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
-    <th align="center"></th>
+    <th></th>
   </tr>
 </thead>
 <tbody>
@@ -389,16 +363,20 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" rowspan="3">Model</td>
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">int8</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -417,6 +395,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">80.50</td>
     <td align="center">12.45</td>
     <td align="center">80.35</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">7.67</td>
     <td align="center">130.39</td>
     <td>$MMEDIT_DIR/configs/restorers/esrgan/esrgan_psnr_x4c64b23g32_g1_1000k_div2k.py</td>
@@ -430,12 +410,15 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">2836.62</td>
     <td align="center">0.26</td>
     <td align="center">3850.45</td>
+    <td align="center">58.86</td>
+    <td align="center">16.99</td>
     <td align="center">0.56</td>
     <td align="center">1775.11</td>
     <td>$MMEDIT_DIR/configs/restorers/srcnn/srcnn_x4k915_g1_1000k_div2k.py</td>
   </tr>
 </tbody>
 </table>
+
 </div>
 </details>
 
@@ -528,13 +511,14 @@ GPU: ncnn, TensorRT, PPLNN
 <details>
 <summary style="margin-left: 25px;">MMSeg</summary>
 <div style="margin-left: 25px;">
-<table class="docutils">
+
+<table class='docutils'>
 <thead>
   <tr>
     <th align="center" colspan="3">MMSeg</th>
-    <th align="center" colspan="6">TensorRT</th>
+    <th align="center" colspan="8">TensorRT</th>
     <th align="center" colspan="2">PPLNN</th>
-    <th align="center"></th>
+    <th></th>
   </tr>
 </thead>
 <tbody>
@@ -543,16 +527,20 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" rowspan="3">Dataset</td>
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="6">T4</td>
+    <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
     <td align="center" colspan="2">int8</td>
+    <td align="center" colspan="2">fp32</td>
     <td align="center" colspan="2">fp16</td>
   </tr>
   <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
     <td align="center">FPS</td>
     <td align="center">latency (ms)</td>
@@ -572,6 +560,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">41.72</td>
     <td align="center">18.13</td>
     <td align="center">55.15</td>
+    <td align="center">1682.54</td>
+    <td align="center">0.59</td>
     <td align="center">27.00</td>
     <td align="center">37.04</td>
     <td>$MMSEG_DIR/configs/fcn/fcn_r50-d8_512x1024_40k_cityscapes.py</td>
@@ -586,6 +576,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">41.49</td>
     <td align="center">16.33</td>
     <td align="center">61.23</td>
+    <td align="center">1586.19</td>
+    <td align="center">0.63</td>
     <td align="center">27.26</td>
     <td align="center">36.69</td>
     <td>$MMSEG_DIR/configs/pspnet/pspnet_r50-d8_512x1024_80k_cityscapes.py</td>
@@ -600,6 +592,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">31.45</td>
     <td align="center">19.85</td>
     <td align="center">50.38</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">36.01</td>
     <td align="center">27.77</td>
     <td>$MMSEG_DIR/configs/deeplabv3/deeplabv3_r50-d8_512x1024_80k_cityscapes.py</td>
@@ -614,12 +608,15 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">21.26</td>
     <td align="center">50.38</td>
     <td align="center">26.67</td>
+    <td align="center">2534.96</td>
+    <td align="center">0.39</td>
     <td align="center">34.80</td>
     <td align="center">28.74</td>
     <td>$MMSEG_DIR/configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_80k_cityscapes.py</td>
   </tr>
 </tbody>
 </table>
+
 </div>
 </details>
 

--- a/docs/zh_cn/benchmark.md
+++ b/docs/zh_cn/benchmark.md
@@ -29,7 +29,7 @@ GPU: ncnn, TensorRT, PPLNN
 <summary style="margin-left: 25px;">MMCls</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="3">MMCls</th>
@@ -189,7 +189,7 @@ GPU: ncnn, TensorRT, PPLNN
 <summary style="margin-left: 25px;">MMDet</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="3">MMDet</th>
@@ -341,7 +341,65 @@ GPU: ncnn, TensorRT, PPLNN
   </tr>
 </tbody>
 </table>
-
+<table class="docutils">
+<thead>
+  <tr>
+    <th align="center" colspan="3">MMDet</th>
+    <th align="center" colspan="4">NCNN</th>
+    <th align="center"></th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td align="center" rowspan="3">Model</td>
+    <td align="center" rowspan="3">Dataset</td>
+    <td align="center" rowspan="3">Input</td>
+    <td align="center" colspan="2">SnapDragon888</td>
+    <td align="center" colspan="2">Adreno660</td>
+    <td align="center" rowspan="3">model config file</td>
+  </tr>
+  <tr>
+    <td align="center" colspan="2">fp32</td>
+    <td align="center" colspan="2">fp32</td>
+  </tr>
+  <tr>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
+    <td align="center">latency (ms)</td>
+    <td align="center">FPS</td>
+  </tr>
+  <tr>
+    <td align="center">MobileNetv2-YOLOv3</td>
+    <td align="center">COCO</td>
+    <td align="center">1x3x320x320</td>
+    <td align="center">48.57</td>
+    <td align="center">20.59</td>
+    <td align="center">66.55</td>
+    <td align="center">15.03</td>
+    <td>$MMDET_DIR/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py</td>
+  </tr>
+  <tr>
+    <td align="center">SSD-Lite</td>
+    <td align="center">COCO</td>
+    <td align="center">1x3x320x320</td>
+    <td align="center">44.91</td>
+    <td align="center">22.27</td>
+    <td align="center">66.19</td>
+    <td align="center">15.11</td>
+    <td>$MMDET_DIR/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py</td>
+  </tr>
+  <tr>
+    <td align="center">YOLOX</td>
+    <td align="center">COCO</td>
+    <td align="center">1x3x416x416</td>
+    <td align="center">111.60</td>
+    <td align="center">8.96</td>
+    <td align="center">134.50</td>
+    <td align="center">7.43</td>
+    <td>$MMDET_DIR/configs/yolox/yolox_tiny_8x8_300e_coco.py</td>
+  </tr>
+</tbody>
+</table>
 </div>
 </details>
 
@@ -349,7 +407,7 @@ GPU: ncnn, TensorRT, PPLNN
 <summary style="margin-left: 25px;">MMEdit</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="2">MMEdit</th>
@@ -444,7 +502,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td rowspan="3">model config file</td>
+    <td align="center" rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -512,7 +570,7 @@ GPU: ncnn, TensorRT, PPLNN
 <summary style="margin-left: 25px;">MMSeg</summary>
 <div style="margin-left: 25px;">
 
-<table class='docutils'>
+<table class="docutils">
 <thead>
   <tr>
     <th align="center" colspan="3">MMSeg</th>
@@ -650,7 +708,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">ResNet-18</td>
@@ -811,7 +869,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center">YOLOV3</td>
@@ -995,7 +1053,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">SRCNN</td>
@@ -1184,7 +1242,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="3">DBNet*</td>
@@ -1278,7 +1336,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td>model config file</td>
+    <td align="center">model config file</td>
   </tr>
   <tr>
     <td align="center">FCN</td>

--- a/docs/zh_cn/benchmark.md
+++ b/docs/zh_cn/benchmark.md
@@ -50,7 +50,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -206,7 +206,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -237,8 +237,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">40.13</td>
     <td align="center">24.92</td>
     <td align="center">40.13</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">18.07</td>
     <td align="center">55.35</td>
     <td>$MMDET_DIR/configs/yolo/yolov3_d53_320_273e_coco.py</td>
@@ -285,8 +285,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">43.20</td>
     <td align="center">17.68</td>
     <td align="center">56.57</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">-</td>
     <td align="center">-</td>
     <td>$MMDET_DIR/configs/fcos/fcos_r50_caffe_fpn_gn-head_1x_coco.py</td>
@@ -301,8 +301,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">47.58</td>
     <td align="center">13.50</td>
     <td align="center">74.08</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">30.41</td>
     <td align="center">32.89</td>
     <td>$MMDET_DIR/configs/fsaf/fsaf_r50_fpn_1x_coco.py</td>
@@ -333,8 +333,8 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">4.14</td>
     <td align="center">-</td>
     <td align="center">-</td>
-    <td align="center">?</td>
-    <td align="center">?</td>
+    <td align="center">-</td>
+    <td align="center">-</td>
     <td align="center">86.80</td>
     <td align="center">11.52</td>
     <td>$MMDET_DIR/configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py</td>
@@ -356,7 +356,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" rowspan="3">Input</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -423,7 +423,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -502,7 +502,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" colspan="2">T4</td>
     <td align="center" colspan="2">SnapDragon888</td>
     <td align="center" colspan="2">Adreno660</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -587,7 +587,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center" colspan="6">T4</td>
     <td align="center" colspan="2">Jetson TX2</td>
     <td align="center" colspan="2">T4</td>
-    <td align="center" rowspan="3">model config file</td>
+    <td rowspan="3">model config file</td>
   </tr>
   <tr>
     <td align="center" colspan="2">fp32</td>
@@ -708,7 +708,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">ResNet-18</td>
@@ -869,7 +869,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center">YOLOV3</td>
@@ -1053,7 +1053,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="2">SRCNN</td>
@@ -1242,7 +1242,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">int8</td>
     <td align="center">fp16</td>
     <td align="center">fp32</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center" rowspan="3">DBNet*</td>
@@ -1336,7 +1336,7 @@ GPU: ncnn, TensorRT, PPLNN
     <td align="center">fp16</td>
     <td align="center">int8</td>
     <td align="center">fp16</td>
-    <td align="center">model config file</td>
+    <td>model config file</td>
   </tr>
   <tr>
     <td align="center">FCN</td>


### PR DESCRIPTION
Note that some models (including mmocr models) are not supported.