### PR TITLE
Support windows tensorrt backend.

### DIFF
--- a/mmdeploy/backend/tensorrt/init_plugins.py
+++ b/mmdeploy/backend/tensorrt/init_plugins.py
@@ -2,6 +2,7 @@
 import ctypes
 import glob
 import os
+import platform
 
 from mmdeploy.utils import get_root_logger
 
@@ -12,10 +13,16 @@ def get_ops_path() -> str:
     Returns:
         str: A path of the TensorRT plugin library.
     """
-    wildcard = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            '../../../build/lib/libmmdeploy_tensorrt_ops.so'))
+    if platform.system() == 'Windows':
+        wildcard = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                '../../../build/lib/Release/mmdeploy_tensorrt_ops.dll'))
+    else:
+        wildcard = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                '../../../build/lib/libmmdeploy_tensorrt_ops.so'))
 
     paths = glob.glob(wildcard)
     lib_path = paths[0] if len(paths) > 0 else ''


### PR DESCRIPTION
# Environment

```
2022-01-26 17:46:08,338 - mmdeploy - INFO - **********Environmental information**********
'gcc' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
2022-01-26 17:46:09,600 - mmdeploy - INFO - sys.platform: win32
2022-01-26 17:46:09,600 - mmdeploy - INFO - Python: 3.8.5 (default, Sep  3 2020, 21:29:08) [MSC v.1916 64 bit (AMD64)]
2022-01-26 17:46:09,600 - mmdeploy - INFO - CUDA available: True
2022-01-26 17:46:09,600 - mmdeploy - INFO - GPU 0: NVIDIA GeForce RTX 3080 Laptop GPU
2022-01-26 17:46:09,600 - mmdeploy - INFO - CUDA_HOME: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.3
2022-01-26 17:46:09,600 - mmdeploy - INFO - NVCC: Build cuda_11.3.r11.3/compiler.29745058_0
2022-01-26 17:46:09,600 - mmdeploy - INFO - GCC: n/a
2022-01-26 17:46:09,600 - mmdeploy - INFO - PyTorch: 1.10.0+cu113
2022-01-26 17:46:09,600 - mmdeploy - INFO - PyTorch compiling details: PyTorch built with:
  - C++ Version: 199711
  - MSVC 192829337
  - Intel(R) Math Kernel Library Version 2020.0.2 Product Build 20200624 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v2.2.3 (Git Hash 7336ca9f055cf1bfa13efb658fe15dc9b41f0740)
  - OpenMP 2019
  - LAPACK is enabled (usually provided by MKL)
  - CPU capability usage: AVX512
  - CUDA Runtime 11.3
  - NVCC architecture flags: -gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_61,code=sm_61;-gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_37,code=compute_37
  - CuDNN 8.2
  - Magma 2.5.4
  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, CUDA_VERSION=11.3, CUDNN_VERSION=8.2.0, CXX_COMPILER=C:/w/b/windows/tmp_bin/sccache-cl.exe, CXX_FLAGS=/DWIN32 /D_WINDOWS /GR /EHsc /w /bigobj -DUSE_PTHREADPOOL -openmp:experimental -IC:/w/b/windows/mkl/include -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOCUPTI -DUSE_FBGEMM -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -DEDGE_PROFILER_USE_KINETO, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, PERF_WITH_AVX512=1, TORCH_VERSION=1.10.0, USE_CUDA=ON, USE_CUDNN=ON, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=OFF, USE_NNPACK=OFF, USE_OPENMP=ON,

2022-01-26 17:46:09,600 - mmdeploy - INFO - TorchVision: 0.11.1+cu113
2022-01-26 17:46:09,600 - mmdeploy - INFO - OpenCV: 4.5.2
2022-01-26 17:46:09,600 - mmdeploy - INFO - MMCV: 1.4.2
2022-01-26 17:46:09,600 - mmdeploy - INFO - MMCV Compiler: MSVC 192930136
2022-01-26 17:46:09,600 - mmdeploy - INFO - MMCV CUDA Compiler: 11.3
2022-01-26 17:46:09,600 - mmdeploy - INFO - MMDeployment: 0.1.0+d522874
2022-01-26 17:46:09,600 - mmdeploy - INFO -

2022-01-26 17:46:09,601 - mmdeploy - INFO - **********Backend information**********
2022-01-26 17:46:09,882 - mmdeploy - INFO - onnxruntime: None ops_is_avaliable : False
2022-01-26 17:46:09,882 - mmdeploy - INFO - tensorrt: 8.2.1.8 ops_is_avaliable : True
2022-01-26 17:46:09,884 - mmdeploy - INFO - ncnn: None ops_is_avaliable : False
2022-01-26 17:46:09,884 - mmdeploy - INFO - pplnn_is_avaliable: False
2022-01-26 17:46:09,885 - mmdeploy - INFO - openvino_is_avaliable: False
2022-01-26 17:46:09,885 - mmdeploy - INFO -

2022-01-26 17:46:09,885 - mmdeploy - INFO - **********Codebase information**********
2022-01-26 17:46:09,885 - mmdeploy - INFO - mmcls: None
2022-01-26 17:46:09,886 - mmdeploy - INFO - mmdet: 2.20.0
2022-01-26 17:46:09,886 - mmdeploy - INFO - mmedit: None
2022-01-26 17:46:09,887 - mmdeploy - INFO - mmocr: None
2022-01-26 17:46:09,887 - mmdeploy - INFO - mmseg: None

```

# Reason

Windows build .dll file:

![image](https://user-images.githubusercontent.com/10473170/151139078-5a358b5a-b2a7-46f4-9094-0964498e2946.png)

So load_plugin need to check platform for windows.

# Result

Test result:

![企业微信截图_1643190031842](https://user-images.githubusercontent.com/10473170/151139594-32cd4be2-8cde-46e8-88f5-eb09da4fd900.png)

Successfully loaded mmdeploy_tensorrt_ops.dll.