### PR TITLE
fix onnxruntime wrapper for gpu inference

### DIFF
--- a/mmdeploy/backend/onnxruntime/wrapper.py
+++ b/mmdeploy/backend/onnxruntime/wrapper.py
@@ -79,7 +79,7 @@ class ORTWrapper(BaseWrapper):
             input_tensor = input_tensor.contiguous()
             if not self.is_cuda_available:
                 input_tensor = input_tensor.cpu()
-            element_type = input_tensor.numpy().dtype
+            element_type = input_tensor.cpu().numpy().dtype
             self.io_binding.bind_input(
                 name=name,
                 device_type=self.device_type,

--- a/mmdeploy/backend/onnxruntime/wrapper.py
+++ b/mmdeploy/backend/onnxruntime/wrapper.py
@@ -79,8 +79,9 @@ class ORTWrapper(BaseWrapper):
             input_tensor = input_tensor.contiguous()
             if not self.is_cuda_available:
                 input_tensor = input_tensor.cpu()
-            # Avoid unnecessary data move between host and device
-            element_type = input_tensor.new_zeros(1, device='cpu').numpy().dtype
+            # Avoid unnecessary data transfer between host and device
+            element_type = input_tensor.new_zeros(
+                1, device='cpu').numpy().dtype
             self.io_binding.bind_input(
                 name=name,
                 device_type=self.device_type,

--- a/mmdeploy/backend/onnxruntime/wrapper.py
+++ b/mmdeploy/backend/onnxruntime/wrapper.py
@@ -27,7 +27,7 @@ class ORTWrapper(BaseWrapper):
          >>> import torch
          >>>
          >>> onnx_file = 'model.onnx'
-         >>> model = ORTWrapper(onnx_file, -1)
+         >>> model = ORTWrapper(onnx_file, 'cpu')
          >>> inputs = dict(input=torch.randn(1, 3, 224, 224, device='cpu'))
          >>> outputs = model(inputs)
          >>> print(outputs)
@@ -79,7 +79,8 @@ class ORTWrapper(BaseWrapper):
             input_tensor = input_tensor.contiguous()
             if not self.is_cuda_available:
                 input_tensor = input_tensor.cpu()
-            element_type = input_tensor.cpu().numpy().dtype
+            # Avoid unnecessary data move between host and device
+            element_type = input_tensor.new_zeros(1, device='cpu').numpy().dtype
             self.io_binding.bind_input(
                 name=name,
                 device_type=self.device_type,


### PR DESCRIPTION

### Error message
```
[                                                  ] 0/104125, elapsed: 0s, ETA:Traceback (most recent call last):
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmdeploy/scripts/mmpose/../../tools/test.py", line 140, in <module>
    main()
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmdeploy/scripts/mmpose/../../tools/test.py", line 133, in main
    args.show_dir)
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmdeploy/mmdeploy/codebase/base/task.py", line 138, in single_gpu_test
    out_dir, **kwargs)
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmdeploy/mmdeploy/codebase/mmpose/deploy/mmpose.py", line 132, in single_gpu_test
    return single_gpu_test(model, data_loader)
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmpose/mmpose/apis/test.py", line 37, in single_gpu_test
    result = model(return_loss=False, **data)
  File "/home/PJLAB/maningsheng/anaconda3/envs/pt1.8/lib/python3.7/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/PJLAB/maningsheng/anaconda3/envs/pt1.8/lib/python3.7/site-packages/mmcv/parallel/data_parallel.py", line 50, in forward
    return super().forward(*inputs, **kwargs)
  File "/home/PJLAB/maningsheng/anaconda3/envs/pt1.8/lib/python3.7/site-packages/torch/nn/parallel/data_parallel.py", line 165, in forward
    return self.module(*inputs[0], **kwargs[0])
  File "/home/PJLAB/maningsheng/anaconda3/envs/pt1.8/lib/python3.7/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmdeploy/mmdeploy/codebase/mmpose/deploy/pose_detection_model.py", line 72, in forward
    outputs = self.forward_test(input_img, img_metas, *args, **kwargs)
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmdeploy/mmdeploy/codebase/mmpose/deploy/pose_detection_model.py", line 89, in forward_test
    outputs = self.wrapper({self.input_name: imgs})
  File "/home/PJLAB/maningsheng/anaconda3/envs/pt1.8/lib/python3.7/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/PJLAB/maningsheng/projects/openmmlab/mmdeploy/mmdeploy/backend/onnxruntime/wrapper.py", line 82, in forward
    element_type = input_tensor.numpy().dtype
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.

```
## Motivation

Fix error when run `tools/test.py` with `onnxruntime-gpu` installed for onnxruntime backend models.

## Modification

Fix error when run `tools/test.py` with `onnxruntime-gpu` installed.

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
