### PR TITLE
[Enhancement] Fix tests for OpenVINO with Python 3.6

### DIFF
--- a/docs/en/tutorials/how_to_support_new_backends.md
+++ b/docs/en/tutorials/how_to_support_new_backends.md
@@ -94,7 +94,7 @@ The backends in MMDeploy must support the ONNX. The backend loads the ".onnx" fi
                   f'--input_shape="{input_shapes}" ' \
                   f'--disable_fusing '
         command = f'mo.py {mo_args}'
-        mo_output = run(command, capture_output=True, shell=True, check=True)
+        mo_output = run(command, stdout=PIPE, stderr=PIPE, shell=True, check=True)
     ```
 
     **Use executable program:**

--- a/mmdeploy/backend/openvino/onnx2openvino.py
+++ b/mmdeploy/backend/openvino/onnx2openvino.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
 import subprocess
-from subprocess import CalledProcessError, run
+from subprocess import PIPE, CalledProcessError, run
 from typing import Dict, List, Union
 
 import mmcv
@@ -86,7 +86,7 @@ def onnx2openvino(input_info: Dict[str, Union[List[int], torch.Size]],
 
     logger = get_root_logger()
     logger.info(f'Args for Model Optimizer: {command}')
-    mo_output = run(command, capture_output=True, shell=True, check=True)
+    mo_output = run(command, stdout=PIPE, stderr=PIPE, shell=True, check=True)
     logger.info(mo_output.stdout.decode())
     logger.debug(mo_output.stderr.decode())
 


### PR DESCRIPTION
## Motivation
Fixed problem #118 with `capture_output` when using Python 3.6.

## Modification
- `docs/en/tutorials/how_to_support_new_backends.md`: Updated documentation.
- `mmdeploy/backend/openvino/onnx2openvino.py`: Replaced `capture_output` with `stdout=PIPE, stderr=PIPE`.
