### PR TITLE
lock mmcls version

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,4 @@
-mmcls>=0.15.0
+mmcls>=0.15.0,<=0.19.0
 mmdet>=2.19.0
 mmedit
 mmocr==0.3.0


### PR DESCRIPTION
## Motivation

Lock mmcls version to v0.19.0 since v0.20.0 has dependency of mmcv>=v1.4.2. Also see issue https://github.com/open-mmlab/mmdeploy/issues/130

## Modification

Lock mmcls version

## BC-breaking (Optional)
None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
