### PR TITLE
Lock pplcv to v0.6.1

### DIFF
--- a/docker/GPU/Dockerfile
+++ b/docker/GPU/Dockerfile
@@ -7,6 +7,7 @@ ARG TORCHVISION_VERSION=0.9.0
 ARG ONNXRUNTIME_VERSION=1.8.1
 ARG MMCV_VERSION=1.4.0
 ARG CMAKE_VERSION=3.20.0
+ARG PPLCV_VERSION=0.6.1
 ENV FORCE_CUDA="1"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -66,8 +67,8 @@ RUN git clone https://github.com/open-mmlab/mmdeploy &&\
     pip install -e .
 
 ### build sdk
-RUN wget https://github.com/openppl-public/ppl.cv/archive/refs/tags/v0.6.1.zip &&\
-    unzip v0.6.1.zip && mv ppl.cv-0.6.1 ppl.cv &&\
+RUN wget https://github.com/openppl-public/ppl.cv/archive/refs/tags/v${PPLCV_VERSION}.zip &&\
+    unzip v${PPLCV_VERSION}.zip && mv ppl.cv-${PPLCV_VERSION} ppl.cv &&\
     cd ppl.cv &&\
     ./build.sh cuda
 

--- a/docker/GPU/Dockerfile
+++ b/docker/GPU/Dockerfile
@@ -66,9 +66,11 @@ RUN git clone https://github.com/open-mmlab/mmdeploy &&\
     pip install -e .
 
 ### build sdk
-RUN git clone https://github.com/openppl-public/ppl.cv.git &&\
+RUN wget https://github.com/openppl-public/ppl.cv/archive/refs/tags/v0.6.1.zip &&\
+    unzip v0.6.1.zip && mv ppl.cv-0.6.1 ppl.cv &&\
     cd ppl.cv &&\
     ./build.sh cuda
+
 RUN cd /root/workspace/mmdeploy &&\
     rm -rf build/CM* &&\
     mkdir -p build && cd build &&\

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -137,7 +137,7 @@ Each package's installation command is given based on Ubuntu 18.04.
 
   A high-performance image processing library of openPPL supporting x86 and cuda platforms.</br>
   It is **OPTIONAL** which only be needed if `cuda` platform is required.
-  
+
   Using v0.6.1, since latest updates have broughtup breaking changes
   ```Bash
   wget https://github.com/openppl-public/ppl.cv/archive/refs/tags/v0.6.1.zip

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -137,8 +137,11 @@ Each package's installation command is given based on Ubuntu 18.04.
 
   A high-performance image processing library of openPPL supporting x86 and cuda platforms.</br>
   It is **OPTIONAL** which only be needed if `cuda` platform is required.
-  ```bash
-  git clone git@github.com:openppl-public/ppl.cv.git
+  
+  Using v0.6.1, since latest updates have broughtup breaking changes
+  ```Bash
+  wget https://github.com/openppl-public/ppl.cv/archive/refs/tags/v0.6.1.zip
+  unzip v0.6.1.zip && mv ppl.cv-0.6.1 ppl.cv
   cd ppl.cv
   ./build.sh cuda
   ```

--- a/docs/zh_cn/build.md
+++ b/docs/zh_cn/build.md
@@ -135,7 +135,8 @@ pip install -e .
   此依赖项为可选项，只有在cuda平台下，才需安装。安装命令如下所示:
 
   ```bash
-  git clone git@github.com:openppl-public/ppl.cv.git
+  wget https://github.com/openppl-public/ppl.cv/archive/refs/tags/v0.6.1.zip
+  unzip v0.6.1.zip && mv ppl.cv-0.6.1 ppl.cv
   cd ppl.cv
   ./build.sh cuda
   ```


### PR DESCRIPTION
To avoid breaking changes which arose from recent updates in pplcv , fix pplcv to v0.6.1

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

