### PR TITLE
[Enhancement] Optimize multilevel roi align

### DIFF
--- a/csrc/backend_ops/tensorrt/multi_level_roi_align/trt_multi_level_roi_align.hpp
+++ b/csrc/backend_ops/tensorrt/multi_level_roi_align/trt_multi_level_roi_align.hpp
@@ -13,9 +13,9 @@
 namespace mmdeploy {
 class TRTMultiLevelRoiAlign : public TRTPluginBase {
  public:
-  TRTMultiLevelRoiAlign(const std::string &name, int alignedHeight, int alignedWidth, int sampleNum,
-                        const std::vector<float> &featmapStrides, float roiScaleFactor = -1,
-                        int finestScale = 56, bool aligned = false);
+  TRTMultiLevelRoiAlign(const std::string &name, int alignedHeight, int alignedWidth, int poolMode,
+                        int sampleNum, const std::vector<float> &featmapStrides,
+                        float roiScaleFactor = -1, int finestScale = 56, bool aligned = false);
 
   TRTMultiLevelRoiAlign(const std::string name, const void *data, size_t length);
 
@@ -52,6 +52,7 @@ class TRTMultiLevelRoiAlign : public TRTPluginBase {
  private:
   int mAlignedHeight;
   int mAlignedWidth;
+  int mPoolMode;
   int mSampleNum;
   std::vector<float> mFeatmapStrides;
   float mRoiScaleFactor;

--- a/csrc/backend_ops/tensorrt/multi_level_roi_align/trt_multi_level_roi_align_kernel.cu
+++ b/csrc/backend_ops/tensorrt/multi_level_roi_align/trt_multi_level_roi_align_kernel.cu
@@ -19,21 +19,17 @@ struct FeatData {
   int num_featmap;
 };
 
-template <typename scalar_t>
-__device__ scalar_t roi_align_single(const scalar_t *bottom_data, const int roi_batch_ind,
-                                     const scalar_t roi_start_w, const scalar_t roi_start_h,
-                                     const scalar_t roi_end_w, const scalar_t roi_end_h,
-                                     const scalar_t spatial_scale, const int pw, const int ph,
-                                     const int c, const int sample_num, const int channels,
-                                     const int height, const int width, const int pooled_height,
-                                     const int pooled_width, const bool aligned) {
+template <typename scalar_t, bool aligned>
+__device__ scalar_t roi_align_single(const scalar_t *__restrict__ bottom_data,
+                                     const int roi_batch_ind, const scalar_t roi_start_w,
+                                     const scalar_t roi_start_h, const scalar_t roi_end_w,
+                                     const scalar_t roi_end_h, const scalar_t spatial_scale,
+                                     const int pw, const int ph, const int c, const int sample_num,
+                                     const int channels, const int height, const int width,
+                                     const int pooled_height, const int pooled_width) {
   // Force malformed ROIs to be 1x1
-  scalar_t roi_width = fmaxf((scalar_t)roi_end_w - (scalar_t)roi_start_w, 0.);
-  scalar_t roi_height = fmaxf((scalar_t)roi_end_h - (scalar_t)roi_start_h, 0.);
-  if (!aligned) {
-    roi_width = max(roi_width, (scalar_t)1.);
-    roi_height = max(roi_height, (scalar_t)1.);
-  }
+  scalar_t roi_width = max(roi_end_w - roi_start_w, (scalar_t)(aligned ? 0. : 1.));
+  scalar_t roi_height = max(roi_end_h - roi_start_h, (scalar_t)(aligned ? 0. : 1.));
 
   const scalar_t bin_size_h = roi_height / pooled_height;
   const scalar_t bin_size_w = roi_width / pooled_width;
@@ -41,18 +37,18 @@ __device__ scalar_t roi_align_single(const scalar_t *bottom_data, const int roi_
   const scalar_t *offset_bottom_data =
       bottom_data + (roi_batch_ind * channels + c) * height * width;
 
-  int sample_num_h = (sample_num > 0) ? sample_num : ceil(roi_height / pooled_height);  // e.g., = 2
-  int sample_num_w = (sample_num > 0) ? sample_num : ceil(roi_width / pooled_width);
+  const int sample_num_h = (sample_num > 0) ? sample_num : ceil(roi_height / pooled_height);
+  const int sample_num_w = (sample_num > 0) ? sample_num : ceil(roi_width / pooled_width);
 
   scalar_t output_val = 0;
-#pragma unroll
+  const scalar_t y_offset = roi_start_h + ph * bin_size_h;
+  const scalar_t y_scale = bin_size_h / (scalar_t)(sample_num_h);
+  const scalar_t x_offset = roi_start_w + pw * bin_size_w;
+  const scalar_t x_scale = bin_size_w / (scalar_t)(sample_num_w);
   for (int iy = 0; iy < sample_num_h; iy++) {
-    const scalar_t y = roi_start_h + ph * bin_size_h +
-                       (scalar_t)(iy + scalar_t(.5f)) * bin_size_h / (scalar_t)(sample_num_h);
-#pragma unroll
+    const scalar_t y = fma(scalar_t(iy) + scalar_t(.5f), y_scale, y_offset);
     for (int ix = 0; ix < sample_num_w; ix++) {
-      const scalar_t x = roi_start_w + pw * bin_size_w +
-                         (scalar_t)(ix + scalar_t(.5f)) * bin_size_w / (scalar_t)(sample_num_w);
+      const scalar_t x = fma(scalar_t(ix) + scalar_t(.5f), x_scale, x_offset);
       scalar_t val = bilinear_interpolate<scalar_t>(offset_bottom_data, height, width, y, x);
       output_val += val;
     }
@@ -62,18 +58,21 @@ __device__ scalar_t roi_align_single(const scalar_t *bottom_data, const int roi_
   return output_val;
 }
 
-template <typename scalar_t>
-__global__ void roi_extractor_kernel(scalar_t *output, const scalar_t *bottom_rois,
-                                     FeatData feat_data, const int sample_num,
-                                     const float roi_scale_factor, const int finest_scale,
-                                     const int pooled_height, const int pooled_width,
-                                     const bool aligned, int nThreads) {
+template <typename scalar_t, bool aligned>
+__global__ void roi_extractor_kernel(scalar_t *__restrict__ output,
+                                     const scalar_t *__restrict__ bottom_rois, FeatData feat_data,
+                                     const int sample_num, const float roi_scale_factor,
+                                     const int finest_scale, const int pooled_height,
+                                     const int pooled_width, int nThreads) {
   CUDA_1D_KERNEL_LOOP(index, nThreads) {
     const int channels = feat_data.channels;
-    const int pw = index % pooled_width;
-    const int ph = (index / pooled_width) % pooled_height;
-    const int c = (index / pooled_width / pooled_height) % channels;
-    const int n = index / pooled_width / pooled_height / channels;
+    int tmp_index = index;
+    const int pw = tmp_index % pooled_width;
+    tmp_index /= pooled_width;
+    const int ph = tmp_index % pooled_height;
+    tmp_index /= pooled_height;
+    const int c = tmp_index % channels;
+    const int n = tmp_index / channels;
 
     const scalar_t *offset_bottom_rois = bottom_rois + n * 5;
 
@@ -84,19 +83,23 @@ __global__ void roi_extractor_kernel(scalar_t *output, const scalar_t *bottom_ro
 
     const scalar_t scale = sqrtf((roi_offset_y1 - roi_offset_y0) * (roi_offset_x1 - roi_offset_x0));
 
-    const int target_lvls = fminf(feat_data.num_featmap - 1,
-                                  fmaxf(0, floorf(log2f(scale / (scalar_t)(finest_scale) + 1e-6))));
+    const int target_lvls =
+        min(feat_data.num_featmap - 1,
+            max(0, int(floorf(log2f(scale / (scalar_t)(finest_scale) + 1e-6)))));
 
     if (roi_scale_factor > 0.) {
       const scalar_t roi_off_cx = (roi_offset_x0 + roi_offset_x1) * 0.5;
       const scalar_t roi_off_cy = (roi_offset_y0 + roi_offset_y1) * 0.5;
-      const scalar_t roi_off_w = (roi_offset_x1 - roi_offset_x0 + 1) * roi_scale_factor;
-      const scalar_t roi_off_h = (roi_offset_y1 - roi_offset_y0 + 1) * roi_scale_factor;
+      const scalar_t half_scale_factor = roi_scale_factor * 0.5;
+      const scalar_t half_roi_off_w =
+          fma(roi_offset_x1 - roi_offset_x0 + 1, half_scale_factor, scalar_t(-0.5));
+      const scalar_t half_roi_off_h =
+          fma(roi_offset_y1 - roi_offset_y0 + 1, half_scale_factor, scalar_t(-0.5));
 
-      roi_offset_x0 = roi_off_cx - roi_off_w * 0.5 + 0.5;
-      roi_offset_x1 = roi_off_cx + roi_off_w * 0.5 - 0.5;
-      roi_offset_y0 = roi_off_cy - roi_off_h * 0.5 + 0.5;
-      roi_offset_y1 = roi_off_cy + roi_off_h * 0.5 - 0.5;
+      roi_offset_x0 = roi_off_cx - half_roi_off_w;
+      roi_offset_x1 = roi_off_cx + half_roi_off_w;
+      roi_offset_y0 = roi_off_cy - half_roi_off_h;
+      roi_offset_y1 = roi_off_cy + half_roi_off_h;
     }
 
     const scalar_t spatial_scale = (scalar_t)feat_data.spatial_scale[target_lvls];
@@ -105,15 +108,19 @@ __global__ void roi_extractor_kernel(scalar_t *output, const scalar_t *bottom_ro
     const scalar_t *bottom_data = (scalar_t *)feat_data.data[target_lvls];
 
     const int roi_batch_ind = offset_bottom_rois[0];
-    const scalar_t offset = aligned ? (scalar_t)0.5 : (scalar_t)0.0;
-    const scalar_t roi_start_w = roi_offset_x0 * spatial_scale - offset;
-    const scalar_t roi_start_h = roi_offset_y0 * spatial_scale - offset;
-    const scalar_t roi_end_w = (roi_offset_x1)*spatial_scale - offset;
-    const scalar_t roi_end_h = (roi_offset_y1)*spatial_scale - offset;
+    const scalar_t offset = aligned ? (scalar_t)-0.5 : (scalar_t)0.0;
+    const scalar_t roi_start_w =
+        fma(roi_offset_x0, spatial_scale, offset);  // roi_offset_x0 * spatial_scale + offset;
+    const scalar_t roi_start_h =
+        fma(roi_offset_y0, spatial_scale, offset);  // roi_offset_y0 * spatial_scale + offset;
+    const scalar_t roi_end_w =
+        fma(roi_offset_x1, spatial_scale, offset);  // (roi_offset_x1) * spatial_scale - offset;
+    const scalar_t roi_end_h =
+        fma(roi_offset_y1, spatial_scale, offset);  // (roi_offset_y1)*spatial_scale - offset;
 
-    const scalar_t output_val = roi_align_single<scalar_t>(
+    const scalar_t output_val = roi_align_single<scalar_t, aligned>(
         bottom_data, roi_batch_ind, roi_start_w, roi_start_h, roi_end_w, roi_end_h, spatial_scale,
-        pw, ph, c, sample_num, channels, height, width, pooled_height, pooled_width, aligned);
+        pw, ph, c, sample_num, channels, height, width, pooled_height, pooled_width);
 
     output[index] = output_val;
   }
@@ -136,10 +143,15 @@ void multi_level_roi_align(T *output, const T *rois, int num_rois, const void *c
     feat_data.spatial_scale[i] = 1. / float(strides[i]);
   }
   int nThreads = num_rois * c * aligned_height * aligned_width;
-  // bool aligned = true;
-  roi_extractor_kernel<T><<<GET_BLOCKS(nThreads), THREADS_PER_BLOCK, 0, stream>>>(
-      output, rois, feat_data, sample_num, roi_scale_factor, finest_scale, aligned_height,
-      aligned_width, aligned, nThreads);
+  if (aligned) {
+    roi_extractor_kernel<T, true><<<GET_BLOCKS(nThreads), THREADS_PER_BLOCK, 0, stream>>>(
+        output, rois, feat_data, sample_num, roi_scale_factor, finest_scale, aligned_height,
+        aligned_width, nThreads);
+  } else {
+    roi_extractor_kernel<T, false><<<GET_BLOCKS(nThreads), THREADS_PER_BLOCK, 0, stream>>>(
+        output, rois, feat_data, sample_num, roi_scale_factor, finest_scale, aligned_height,
+        aligned_width, nThreads);
+  }
 }
 
 template void multi_level_roi_align<float>(float *output, const float *rois, int num_rois,

--- a/csrc/backend_ops/tensorrt/multi_level_roi_align/trt_multi_level_roi_align_kernel.hpp
+++ b/csrc/backend_ops/tensorrt/multi_level_roi_align/trt_multi_level_roi_align_kernel.hpp
@@ -6,7 +6,7 @@
 template <typename T>
 void multi_level_roi_align(T *output, const T *rois, int num_rois, const void *const *feats,
                            int num_feats, int n, int c, int *h, int *w, float *strides,
-                           int aligned_height, int aligned_width, int sample_num,
+                           int aligned_height, int aligned_width, int pool_mode, int sample_num,
                            float roi_scale_factor, int finest_scale, bool aligned,
                            cudaStream_t stream);
 

--- a/tests/test_ops/test_ops.py
+++ b/tests/test_ops/test_ops.py
@@ -328,11 +328,14 @@ def test_batched_nms(backend,
 
 
 @pytest.mark.parametrize('backend', [TEST_TENSORRT])
-@pytest.mark.parametrize('out_size, sampling_ratio,roi_scale_factor,'
-                         ' finest_scale,featmap_strides, aligned',
-                         [(tuple([2, 2]), 2, 1.0, 2, list([2.0, 4.0]), 1)])
+@pytest.mark.parametrize(
+    'out_size, pool_mode, sampling_ratio,roi_scale_factor,'
+    ' finest_scale,featmap_strides, aligned',
+    [(tuple([2, 2]), 0, 2, 1.0, 2, list([2.0, 4.0]), 1),
+     (tuple([2, 2]), 1, 2, 1.0, 2, list([2.0, 4.0]), 1)])
 def test_multi_level_roi_align(backend,
                                out_size,
+                               pool_mode,
                                sampling_ratio,
                                roi_scale_factor,
                                finest_scale,
@@ -370,10 +373,21 @@ def test_multi_level_roi_align(backend,
                             [0.9178, 0.7282, 0.0291, 0.3028]]]])
         ]
         rois = torch.tensor([[0., 0., 0., 4., 4.]])
-        expected_result = torch.tensor([[[[0.1939, 0.3950], [0.3437, 0.4543]],
-                                         [[0.0778, 0.1641], [0.1305, 0.2301]],
-                                         [[0.1542, 0.2413], [0.2094,
-                                                             0.2688]]]])
+        if pool_mode == 1:
+            expected_result = torch.tensor([[[[0.1939, 0.3950],
+                                              [0.3437, 0.4543]],
+                                             [[0.0778, 0.1641],
+                                              [0.1305, 0.2301]],
+                                             [[0.1542, 0.2413],
+                                              [0.2094, 0.2688]]]])
+        else:
+            expected_result = torch.tensor([[[[0.1939, 0.4956],
+                                              [0.4185, 0.5167]],
+                                             [[0.0778, 0.2073],
+                                              [0.1569, 0.3162]],
+                                             [[0.1542, 0.2849],
+                                              [0.2370, 0.3053]]]])
+
     else:
         input = input_list[0]
         rois = input_list[1]
@@ -399,6 +413,7 @@ def test_multi_level_roi_align(backend,
         'MMCVMultiLevelRoiAlign_0',
         None,
         'mmdeploy',
+        pool_mode=pool_mode,
         aligned=aligned,
         featmap_strides=featmap_strides,
         finest_scale=finest_scale,


### PR DESCRIPTION
Use `fma` to perform interpolate.

Test input:

```
rois shape: torch.Size([1000, 5])
feat 0 shape: torch.Size([1, 256, 200, 304])
feat 1 shape: torch.Size([1, 256, 100, 152])
feat 2 shape: torch.Size([1, 256, 50, 76])
feat 3 shape: torch.Size([1, 256, 25, 38])
```

Note that there is not much speed up( less than 0.5ms). Since load feat (which is randomly accessed, can not be cached) would cost a lot of time. I have no idea how to perform the optimize.

Or should I add a fp16 implementation?