### PR TITLE
support export hardsigmoid in torch<=1.8

### DIFF
--- a/mmdeploy/pytorch/ops/__init__.py
+++ b/mmdeploy/pytorch/ops/__init__.py
@@ -3,6 +3,7 @@ from .adaptive_avg_pool import (adaptive_avg_pool1d__default,
                                 adaptive_avg_pool2d__default,
                                 adaptive_avg_pool3d__default)
 from .grid_sampler import grid_sampler__default
+from .hardsigmoid import hardsigmoid__default
 from .instance_norm import instance_norm__tensorrt
 from .lstm import generic_rnn__ncnn
 from .squeeze import squeeze__default
@@ -10,5 +11,6 @@ from .squeeze import squeeze__default
 __all__ = [
     'adaptive_avg_pool1d__default', 'adaptive_avg_pool2d__default',
     'adaptive_avg_pool3d__default', 'grid_sampler__default',
-    'instance_norm__tensorrt', 'generic_rnn__ncnn', 'squeeze__default'
+    'hardsigmoid__default', 'instance_norm__tensorrt', 'generic_rnn__ncnn',
+    'squeeze__default'
 ]

--- a/mmdeploy/pytorch/ops/hardsigmoid.py
+++ b/mmdeploy/pytorch/ops/hardsigmoid.py
@@ -7,7 +7,6 @@ from mmdeploy.core import SYMBOLIC_REWRITER
 @SYMBOLIC_REWRITER.register_symbolic(
     'hardsigmoid', is_pytorch=True, arg_descriptors=['v'])
 def hardsigmoid__default(ctx, g, self):
-    """Support export hardsigmoid
-    This rewrite enable export hardsigmoid in torch<=1.8.2
-    """
-    return g.op("HardSigmoid", self, alpha_f=1 / 6)
+    """Support export hardsigmoid This rewrite enable export hardsigmoid in
+    torch<=1.8.2."""
+    return g.op('HardSigmoid', self, alpha_f=1 / 6)

--- a/mmdeploy/pytorch/ops/hardsigmoid.py
+++ b/mmdeploy/pytorch/ops/hardsigmoid.py
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# Modified from:
+# https://github.com/pytorch/pytorch/blob/9ade03959392e5a90b74261012de1d806cab2253/torch/onnx/symbolic_opset9.py
+from mmdeploy.core import SYMBOLIC_REWRITER
+
+
+@SYMBOLIC_REWRITER.register_symbolic(
+    'hardsigmoid', is_pytorch=True, arg_descriptors=['v'])
+def hardsigmoid__default(ctx, g, self):
+    """Support export hardsigmoid
+    This rewrite enable export hardsigmoid in torch<=1.8.2
+    """
+    return g.op("HardSigmoid", self, alpha_f=1 / 6)

--- a/tests/test_pytorch/test_pytorch_ops.py
+++ b/tests/test_pytorch/test_pytorch_ops.py
@@ -116,3 +116,10 @@ class TestSqueeze:
         nodes = get_model_onnx_nodes(model, x)
         assert nodes[0].attribute[0].ints == [0]
         assert nodes[0].op_type == 'Squeeze'
+
+
+def test_hardsigmoid():
+    x = torch.rand(1, 2, 3, 4)
+    model = torch.nn.Hardsigmoid().eval()
+    nodes = get_model_onnx_nodes(model, x)
+    assert nodes[0].op_type == 'HardSigmoid'


### PR DESCRIPTION
Hardsigmoid export is not supported before torch1.9. This PR adds such support for torch<=1.8.