### PR TITLE
[Docs] Update get_started.md

### DIFF
--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -49,7 +49,7 @@ Now you can do model inference with the APIs provided by the backend. But what i
 ```python
 from mmdeploy.apis import inference_model
 
-result = inference_model(model_cfg, deploy_cfg, backend_models, img=img, device=device)
+result = inference_model(model_cfg, deploy_cfg, backend_files, img=img, device=device)
 ```
 
 The `inference_model` will create a wrapper module and do the inference for you. The result has the same format as the original OpenMMLab repo.

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -49,7 +49,7 @@ python ${MMDEPLOY_DIR}/tools/deploy.py \
 ```python
 from mmdeploy.apis import inference_model
 
-result = inference_model(model_cfg, deploy_cfg, backend_models, img=img, device=device)
+result = inference_model(model_cfg, deploy_cfg, backend_files, img=img, device=device)
 ```
 
 `inference_model`会创建一个对后端模型的封装，通过该封装进行推理。推理的结果会保持与OpenMMLab中原模型同样的格式。


### PR DESCRIPTION
## Motivation

Fix a small naming inconsistency by renaming **backend_models** to **backend_files**, so that it becomes consistent with the usage of [inference_model](https://github.com/open-mmlab/mmdeploy/blob/26d40fe883c941a668bf7c309b168e4f01a6f6c2/mmdeploy/apis/inference.py#L11).

## Modification

Change from
```
from mmdeploy.apis import inference_model

result = inference_model(model_cfg, deploy_cfg, backend_models, img=img, device=device)
```

To
```
from mmdeploy.apis import inference_model

result = inference_model(model_cfg, deploy_cfg, backend_files, img=img, device=device)
```

It should be ready to merge.