### PR TITLE
fix unnecessary change of config for dynamic exporting

### DIFF
--- a/mmdeploy/codebase/mmseg/deploy/segmentation.py
+++ b/mmdeploy/codebase/mmseg/deploy/segmentation.py
@@ -36,7 +36,7 @@ def process_model_config(model_cfg: mmcv.Config,
     # for static exporting
     if input_shape is not None:
         cfg.data.test.pipeline[1]['img_scale'] = tuple(input_shape)
-    cfg.data.test.pipeline[1]['transforms'][0]['keep_ratio'] = False
+        cfg.data.test.pipeline[1]['transforms'][0]['keep_ratio'] = False
     cfg.data.test.pipeline = [LoadImage()] + cfg.data.test.pipeline[1:]
 
     return cfg


### PR DESCRIPTION
## Motivation

fix unnecessary change of config for dynamic exporting #195

## Modification

Only change preprocess pipeline if input_shape set for static exporting and inference.

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
