### PR TITLE
Add DefaultFormatBundle

### DIFF
--- a/csrc/preprocess/cpu/CMakeLists.txt
+++ b/csrc/preprocess/cpu/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRCS
         collect_impl.cpp
         crop_impl.cpp
         image2tensor_impl.cpp
+        default_format_bundle_impl.cpp
         load_impl.cpp
         normalize_impl.cpp
         pad_impl.cpp

--- a/csrc/preprocess/cpu/default_format_bundle_impl.cpp
+++ b/csrc/preprocess/cpu/default_format_bundle_impl.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "core/utils/device_utils.h"
+#include "opencv_utils.h"
+#include "preprocess/transform/default_format_bundle.h"
+
+namespace mmdeploy {
+namespace cpu {
+
+class DefaultFormatBundleImpl : public ::mmdeploy::DefaultFormatBundleImpl {
+ public:
+  explicit DefaultFormatBundleImpl(const Value& args) : ::mmdeploy::DefaultFormatBundleImpl(args) {}
+
+ protected:
+  Result<Tensor> ToFloat32(const Tensor& tensor, const bool& img_to_float) override {
+    OUTCOME_TRY(auto src_tensor, MakeAvailableOnDevice(tensor, device_, stream_));
+    auto data_type = src_tensor.desc().data_type;
+
+    if (img_to_float && data_type == DataType::kINT8) {
+      auto cvmat = Tensor2CVMat(src_tensor);
+      cvmat.convertTo(cvmat, CV_32FC(cvmat.channels()));
+      auto dst_tensor = CVMat2Tensor(cvmat);
+      return dst_tensor;
+    }
+    return src_tensor;
+  }
+
+  Result<Tensor> HWC2CHW(const Tensor& tensor) override {
+    OUTCOME_TRY(auto src_tensor, MakeAvailableOnDevice(tensor, device_, stream_));
+    auto shape = src_tensor.shape();
+    int height = shape[1];
+    int width = shape[2];
+    int channels = shape[3];
+
+    auto dst_mat = Transpose(Tensor2CVMat(src_tensor));
+
+    auto dst_tensor = CVMat2Tensor(dst_mat);
+    dst_tensor.Reshape({1, channels, height, width});
+
+    return dst_tensor;
+  }
+};
+
+class DefaultFormatBundleImplCreator : public Creator<::mmdeploy::DefaultFormatBundleImpl> {
+ public:
+  const char* GetName() const override { return "cpu"; }
+  int GetVersion() const override { return 1; }
+  ReturnType Create(const Value& args) override {
+    return std::make_unique<DefaultFormatBundleImpl>(args);
+  }
+};
+
+}  // namespace cpu
+}  // namespace mmdeploy
+
+using mmdeploy::DefaultFormatBundleImpl;
+using mmdeploy::cpu::DefaultFormatBundleImplCreator;
+REGISTER_MODULE(DefaultFormatBundleImpl, DefaultFormatBundleImplCreator);

--- a/csrc/preprocess/cuda/CMakeLists.txt
+++ b/csrc/preprocess/cuda/CMakeLists.txt
@@ -14,6 +14,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/MMDeploy.cmake)
 set(SRCS
         crop_impl.cpp
         image2tensor_impl.cpp
+        default_format_bundle_impl.cpp
         load_impl.cpp
         normalize_impl.cpp
         pad_impl.cpp

--- a/csrc/preprocess/cuda/default_format_bundle_impl.cpp
+++ b/csrc/preprocess/cuda/default_format_bundle_impl.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include <cuda_runtime.h>
+
+#include "core/utils/device_utils.h"
+#include "preprocess/transform/default_format_bundle.h"
+
+namespace mmdeploy {
+namespace cuda {
+
+template <int channels>
+void CastToFloat(const uint8_t* src, int height, int width, float* dst, cudaStream_t stream);
+
+template <typename T>
+void Transpose(const T* src, int height, int width, int channels, T* dst, cudaStream_t stream);
+
+class DefaultFormatBundleImpl final : public ::mmdeploy::DefaultFormatBundleImpl {
+ public:
+  explicit DefaultFormatBundleImpl(const Value& args) : ::mmdeploy::DefaultFormatBundleImpl(args) {}
+
+ protected:
+  Result<Tensor> ToFloat32(const Tensor& tensor, const bool& img_to_float) override {
+    OUTCOME_TRY(auto src_tensor, MakeAvailableOnDevice(tensor, device_, stream_));
+    auto data_type = src_tensor.data_type();
+    auto h = tensor.shape(1);
+    auto w = tensor.shape(2);
+    auto c = tensor.shape(3);
+    auto stream = ::mmdeploy::GetNative<cudaStream_t>(stream_);
+
+    if (img_to_float && data_type == DataType::kINT8) {
+      TensorDesc desc{device_, DataType::kFLOAT, tensor.shape(), ""};
+      Tensor dst_tensor{desc};
+      if (c == 3) {
+        CastToFloat<3>(src_tensor.data<uint8_t>(), h, w, dst_tensor.data<float>(), stream);
+      } else if (c == 1) {
+        CastToFloat<1>(src_tensor.data<uint8_t>(), h, w, dst_tensor.data<float>(), stream);
+      } else {
+        MMDEPLOY_ERROR("channel num: unsupported channel num {}", c);
+        return Status(eNotSupported);
+      }
+      return dst_tensor;
+    }
+    return src_tensor;
+  }
+
+  Result<Tensor> HWC2CHW(const Tensor& tensor) override {
+    OUTCOME_TRY(auto src_tensor, MakeAvailableOnDevice(tensor, device_, stream_));
+    auto h = tensor.shape(1);
+    auto w = tensor.shape(2);
+    auto c = tensor.shape(3);
+    auto hw = h * w;
+
+    Tensor dst_tensor(src_tensor.desc());
+    dst_tensor.Reshape({1, c, h, w});
+
+    auto stream = ::mmdeploy::GetNative<cudaStream_t>(stream_);
+
+    if (DataType::kINT8 == tensor.data_type()) {
+      auto input = src_tensor.data<uint8_t>();
+      auto output = dst_tensor.data<uint8_t>();
+      Transpose(input, (int)h, (int)w, (int)c, output, stream);
+    } else if (DataType::kFLOAT == tensor.data_type()) {
+      auto input = src_tensor.data<float>();
+      auto output = dst_tensor.data<float>();
+      Transpose(input, (int)h, (int)w, (int)c, output, stream);
+    } else {
+      assert(0);
+    }
+    return dst_tensor;
+  }
+};
+
+class DefaultFormatBundleImplCreator : public Creator<::mmdeploy::DefaultFormatBundleImpl> {
+ public:
+  const char* GetName() const override { return "cuda"; }
+  int GetVersion() const override { return 1; }
+  ReturnType Create(const Value& cfg) override {
+    return std::make_unique<DefaultFormatBundleImpl>(cfg);
+  }
+};
+
+}  // namespace cuda
+}  // namespace mmdeploy
+
+using ::mmdeploy::DefaultFormatBundleImpl;
+using ::mmdeploy::cuda::DefaultFormatBundleImplCreator;
+REGISTER_MODULE(DefaultFormatBundleImpl, DefaultFormatBundleImplCreator);

--- a/csrc/preprocess/transform/CMakeLists.txt
+++ b/csrc/preprocess/transform/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRCS
         compose.cpp
         crop.cpp
         image2tensor.cpp
+        default_format_bundle.cpp
         load.cpp
         normalize.cpp
         pad.cpp

--- a/csrc/preprocess/transform/collect.h
+++ b/csrc/preprocess/transform/collect.h
@@ -9,7 +9,7 @@ namespace mmdeploy {
 class MMDEPLOY_API CollectImpl : public Module {
  public:
   explicit CollectImpl(const Value& args);
-  ~CollectImpl() = default;
+  ~CollectImpl() override = default;
 
   Result<Value> Process(const Value& input) override;
 
@@ -27,7 +27,7 @@ class MMDEPLOY_API CollectImpl : public Module {
 class MMDEPLOY_API Collect : public Transform {
  public:
   explicit Collect(const Value& args, int version = 0);
-  ~Collect() = default;
+  ~Collect() override = default;
 
   Result<Value> Process(const Value& input) override;
 

--- a/csrc/preprocess/transform/crop.h
+++ b/csrc/preprocess/transform/crop.h
@@ -13,7 +13,7 @@ namespace mmdeploy {
 class MMDEPLOY_API CenterCropImpl : public TransformImpl {
  public:
   explicit CenterCropImpl(const Value& args);
-  ~CenterCropImpl() = default;
+  ~CenterCropImpl() override = default;
 
   Result<Value> Process(const Value& input) override;
 
@@ -34,7 +34,7 @@ class MMDEPLOY_API CenterCropImpl : public TransformImpl {
 class MMDEPLOY_API CenterCrop : public Transform {
  public:
   explicit CenterCrop(const Value& args, int version = 0);
-  ~CenterCrop() = default;
+  ~CenterCrop() override = default;
 
   Result<Value> Process(const Value& input) override { return impl_->Process(input); }
 

--- a/csrc/preprocess/transform/default_format_bundle.cpp
+++ b/csrc/preprocess/transform/default_format_bundle.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "default_format_bundle.h"
+
+#include <cassert>
+
+#include "archive/json_archive.h"
+#include "core/tensor.h"
+
+namespace mmdeploy {
+
+DefaultFormatBundleImpl::DefaultFormatBundleImpl(const Value& args) : TransformImpl(args) {
+  if (args.contains("img_to_float") && args["img_to_float"].is_boolean()) {
+    arg_.img_to_float = args["img_to_float"].get<bool>();
+  }
+  if (args.contains("pad_val") && args["pad_val"].is_object()) {
+    for (auto& [key, _] : arg_.pad_val)
+      if (args["pad_val"].contains(key) && args["pad_val"][key].is_number_float()) {
+        arg_.pad_val[key] = args["pad_val"][key].get<float>();
+      }
+  }
+}
+
+Result<Value> DefaultFormatBundleImpl::Process(const Value& input) {
+  MMDEPLOY_DEBUG("DefaultFormatBundle input: {}", to_json(input).dump(2));
+  Value output = input;
+  if (input.contains("img")) {
+    Tensor tensor = input["img"].get<Tensor>();
+    OUTCOME_TRY(output["img"], ToFloat32(tensor, arg_.img_to_float));
+  }
+
+  Tensor tensor = output["img"].get<Tensor>();
+  // set default meta keys
+  for (auto v : tensor.shape()) {
+    output["pad_shape"].push_back(v);
+  }
+  output["scale_factor"].push_back(1.0);
+  int channel = tensor.shape()[3];
+  for (int i = 0; i < channel; i++) {
+    output["img_norm_cfg"]["mean"].push_back(0.0);
+    output["img_norm_cfg"]["std"].push_back(1.0);
+  }
+  output["img_norm_cfg"]["to_rgb"] = false;
+
+  // transpose
+  OUTCOME_TRY(output["img"], HWC2CHW(tensor));
+
+  MMDEPLOY_DEBUG("DefaultFormatBundle output: {}", to_json(output).dump(2));
+  return output;
+}
+
+DefaultFormatBundle::DefaultFormatBundle(const Value& args, int version) : Transform(args) {
+  auto impl_creator =
+      Registry<DefaultFormatBundleImpl>::Get().GetCreator(specified_platform_, version);
+  if (nullptr == impl_creator) {
+    MMDEPLOY_ERROR("'DefaultFormatBundle' is not supported on '{}' platform", specified_platform_);
+    throw std::domain_error("'DefaultFormatBundle' is not supported on specified platform");
+  }
+  impl_ = impl_creator->Create(args);
+}
+
+class DefaultFormatBundleCreator : public Creator<Transform> {
+ public:
+  const char* GetName() const override { return "DefaultFormatBundle"; }
+  int GetVersion() const override { return version_; }
+  ReturnType Create(const Value& args) override {
+    return std::make_unique<DefaultFormatBundle>(args, version_);
+  }
+
+ private:
+  int version_{1};
+};
+REGISTER_MODULE(Transform, DefaultFormatBundleCreator);
+MMDEPLOY_DEFINE_REGISTRY(DefaultFormatBundleImpl);
+}  // namespace mmdeploy

--- a/csrc/preprocess/transform/default_format_bundle.cpp
+++ b/csrc/preprocess/transform/default_format_bundle.cpp
@@ -31,16 +31,22 @@ Result<Value> DefaultFormatBundleImpl::Process(const Value& input) {
 
   Tensor tensor = output["img"].get<Tensor>();
   // set default meta keys
-  for (auto v : tensor.shape()) {
-    output["pad_shape"].push_back(v);
+  if (!output.contains("pad_shape")) {
+    for (auto v : tensor.shape()) {
+      output["pad_shape"].push_back(v);
+    }
   }
-  output["scale_factor"].push_back(1.0);
-  int channel = tensor.shape()[3];
-  for (int i = 0; i < channel; i++) {
-    output["img_norm_cfg"]["mean"].push_back(0.0);
-    output["img_norm_cfg"]["std"].push_back(1.0);
+  if (!output.contains("scale_factor")) {
+    output["scale_factor"].push_back(1.0);
   }
-  output["img_norm_cfg"]["to_rgb"] = false;
+  if (!output.contains("img_norm_cfg")) {
+    int channel = tensor.shape()[3];
+    for (int i = 0; i < channel; i++) {
+      output["img_norm_cfg"]["mean"].push_back(0.0);
+      output["img_norm_cfg"]["std"].push_back(1.0);
+    }
+    output["img_norm_cfg"]["to_rgb"] = false;
+  }
 
   // transpose
   OUTCOME_TRY(output["img"], HWC2CHW(tensor));

--- a/csrc/preprocess/transform/default_format_bundle.h
+++ b/csrc/preprocess/transform/default_format_bundle.h
@@ -1,0 +1,62 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef MMDEPLOY_DEFAULT_FORMAT_BUNDLE_H
+#define MMDEPLOY_DEFAULT_FORMAT_BUNDLE_H
+
+#include "core/tensor.h"
+#include "transform.h"
+
+namespace mmdeploy {
+/**
+ * It simplifies the pipeline of formatting common fields, including "img",
+ * "proposals", "gt_bboxes", "gt_labels", "gt_masks" and "gt_semantic_seg".
+ * These fields are formatted as follows.
+ *
+ *  - img: (1)transpose, (2)to tensor, (3)to DataContainer (stack=True)
+ *  - proposals: (1)to tensor, (2)to DataContainer
+ *  - gt_bboxes: (1)to tensor, (2)to DataContainer
+ *  - gt_bboxes_ignore: (1)to tensor, (2)to DataContainer
+ *  - gt_labels: (1)to tensor, (2)to DataContainer
+ *  - gt_masks: (1)to tensor, (2)to DataContainer (cpu_only=True)
+ *  - gt_semantic_seg: (1)unsqueeze dim-0 (2)to tensor, \
+ *                     (3)to DataContainer (stack=True)
+ *
+ */
+class MMDEPLOY_API DefaultFormatBundleImpl : public TransformImpl {
+ public:
+  DefaultFormatBundleImpl(const Value& args);
+  ~DefaultFormatBundleImpl() = default;
+
+  Result<Value> Process(const Value& input) override;
+
+ protected:
+  virtual Result<Tensor> ToFloat32(const Tensor& tensor, const bool& img_to_float) = 0;
+  virtual Result<Tensor> HWC2CHW(const Tensor& tensor) = 0;
+
+ protected:
+  struct default_format_bundle_arg_t {
+    bool img_to_float = true;
+    std::map<std::string, float> pad_val = {{"img", 0}, {"mask", 0}, {"seg", 255}};
+  };
+  using ArgType = struct default_format_bundle_arg_t;
+
+ protected:
+  ArgType arg_;
+};
+
+class MMDEPLOY_API DefaultFormatBundle : public Transform {
+ public:
+  explicit DefaultFormatBundle(const Value& args, int version = 0);
+  ~DefaultFormatBundle() = default;
+
+  Result<Value> Process(const Value& input) override { return impl_->Process(input); }
+
+ private:
+  std::unique_ptr<DefaultFormatBundleImpl> impl_;
+};
+
+MMDEPLOY_DECLARE_REGISTRY(DefaultFormatBundleImpl);
+
+}  // namespace mmdeploy
+
+#endif  // MMDEPLOY_DEFAULT_FORMAT_BUNDLE_H

--- a/csrc/preprocess/transform/default_format_bundle.h
+++ b/csrc/preprocess/transform/default_format_bundle.h
@@ -24,7 +24,6 @@ class MMDEPLOY_API DefaultFormatBundleImpl : public TransformImpl {
  protected:
   struct default_format_bundle_arg_t {
     bool img_to_float = true;
-    std::map<std::string, float> pad_val = {{"img", 0}, {"mask", 0}, {"seg", 255}};
   };
   using ArgType = struct default_format_bundle_arg_t;
 

--- a/csrc/preprocess/transform/default_format_bundle.h
+++ b/csrc/preprocess/transform/default_format_bundle.h
@@ -13,7 +13,7 @@ namespace mmdeploy {
 class MMDEPLOY_API DefaultFormatBundleImpl : public TransformImpl {
  public:
   DefaultFormatBundleImpl(const Value& args);
-  ~DefaultFormatBundleImpl() = default;
+  ~DefaultFormatBundleImpl() override = default;
 
   Result<Value> Process(const Value& input) override;
 
@@ -34,7 +34,7 @@ class MMDEPLOY_API DefaultFormatBundleImpl : public TransformImpl {
 class MMDEPLOY_API DefaultFormatBundle : public Transform {
  public:
   explicit DefaultFormatBundle(const Value& args, int version = 0);
-  ~DefaultFormatBundle() = default;
+  ~DefaultFormatBundle() override = default;
 
   Result<Value> Process(const Value& input) override { return impl_->Process(input); }
 

--- a/csrc/preprocess/transform/default_format_bundle.h
+++ b/csrc/preprocess/transform/default_format_bundle.h
@@ -8,19 +8,7 @@
 
 namespace mmdeploy {
 /**
- * It simplifies the pipeline of formatting common fields, including "img",
- * "proposals", "gt_bboxes", "gt_labels", "gt_masks" and "gt_semantic_seg".
- * These fields are formatted as follows.
- *
- *  - img: (1)transpose, (2)to tensor, (3)to DataContainer (stack=True)
- *  - proposals: (1)to tensor, (2)to DataContainer
- *  - gt_bboxes: (1)to tensor, (2)to DataContainer
- *  - gt_bboxes_ignore: (1)to tensor, (2)to DataContainer
- *  - gt_labels: (1)to tensor, (2)to DataContainer
- *  - gt_masks: (1)to tensor, (2)to DataContainer (cpu_only=True)
- *  - gt_semantic_seg: (1)unsqueeze dim-0 (2)to tensor, \
- *                     (3)to DataContainer (stack=True)
- *
+ * It simplifies the pipeline of formatting common fields
  */
 class MMDEPLOY_API DefaultFormatBundleImpl : public TransformImpl {
  public:

--- a/csrc/preprocess/transform/image2tensor.h
+++ b/csrc/preprocess/transform/image2tensor.h
@@ -17,7 +17,7 @@ namespace mmdeploy {
 class MMDEPLOY_API ImageToTensorImpl : public TransformImpl {
  public:
   ImageToTensorImpl(const Value& args);
-  ~ImageToTensorImpl() = default;
+  ~ImageToTensorImpl() override = default;
 
   Result<Value> Process(const Value& input) override;
 
@@ -37,7 +37,7 @@ class MMDEPLOY_API ImageToTensorImpl : public TransformImpl {
 class MMDEPLOY_API ImageToTensor : public Transform {
  public:
   explicit ImageToTensor(const Value& args, int version = 0);
-  ~ImageToTensor() = default;
+  ~ImageToTensor() override = default;
 
   Result<Value> Process(const Value& input) override { return impl_->Process(input); }
 

--- a/csrc/preprocess/transform/load.h
+++ b/csrc/preprocess/transform/load.h
@@ -11,7 +11,7 @@ namespace mmdeploy {
 class MMDEPLOY_API PrepareImageImpl : public TransformImpl {
  public:
   explicit PrepareImageImpl(const Value& args);
-  ~PrepareImageImpl() = default;
+  ~PrepareImageImpl() override = default;
 
   Result<Value> Process(const Value& input) override;
 
@@ -32,7 +32,7 @@ class MMDEPLOY_API PrepareImageImpl : public TransformImpl {
 class MMDEPLOY_API PrepareImage : public Transform {
  public:
   explicit PrepareImage(const Value& args, int version = 0);
-  ~PrepareImage() = default;
+  ~PrepareImage() override = default;
 
   Result<Value> Process(const Value& input) override { return impl_->Process(input); }
 

--- a/csrc/preprocess/transform/normalize.h
+++ b/csrc/preprocess/transform/normalize.h
@@ -11,7 +11,7 @@ namespace mmdeploy {
 class MMDEPLOY_API NormalizeImpl : public TransformImpl {
  public:
   explicit NormalizeImpl(const Value& args);
-  ~NormalizeImpl() = default;
+  ~NormalizeImpl() override = default;
 
   Result<Value> Process(const Value& input) override;
 
@@ -31,7 +31,7 @@ class MMDEPLOY_API NormalizeImpl : public TransformImpl {
 class MMDEPLOY_API Normalize : public Transform {
  public:
   explicit Normalize(const Value& args, int version = 0);
-  ~Normalize() = default;
+  ~Normalize() override = default;
 
   Result<Value> Process(const Value& input) override { return impl_->Process(input); }
 

--- a/mmdeploy/utils/export_info.py
+++ b/mmdeploy/utils/export_info.py
@@ -191,8 +191,6 @@ def get_preprocess(deploy_cfg: mmcv.Config, model_cfg: mmcv.Config):
         and 'RescaleToZeroOne' not in item['type']
     ]
     for i, transform in enumerate(transforms):
-        if transform['type'] == 'DefaultFormatBundle':
-            transforms[i] = dict(type='ImageToTensor', keys=['img'])
         if 'keys' in transform and transform['keys'] == ['lq']:
             transform['keys'] = ['img']
         if 'key' in transform and transform['key'] == 'lq':

--- a/tests/test_csrc/preprocess/test_default_format_bundle.cpp
+++ b/tests/test_csrc/preprocess/test_default_format_bundle.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+#include "catch.hpp"
+#include "core/tensor.h"
+#include "core/utils/device_utils.h"
+#include "opencv_utils.h"
+#include "preprocess/transform/transform.h"
+#include "test_resource.h"
+#include "test_utils.h"
+
+using namespace mmdeploy;
+using namespace mmdeploy::test;
+using namespace std;
+
+void TestDefaultFormatBundle(const Value& cfg, const cv::Mat& mat) {
+  auto gResource = MMDeployTestResources::Get();
+  for (auto const& device_name : gResource.device_names()) {
+    Device device{device_name.c_str()};
+    Stream stream{device};
+    auto transform = CreateTransform(cfg, device, stream);
+    REQUIRE(transform != nullptr);
+
+    vector<cv::Mat> channel_mats(mat.channels());
+    for (auto i = 0; i < mat.channels(); ++i) {
+      cv::extractChannel(mat, channel_mats[i], i);
+    }
+
+    auto res = transform->Process({{"img", cpu::CVMat2Tensor(mat)}});
+    REQUIRE(!res.has_error());
+    auto res_tensor = res.value()["img"].get<Tensor>();
+    REQUIRE(res_tensor.device() == device);
+    auto shape = res_tensor.desc().shape;
+    REQUIRE(shape == std::vector<int64_t>{1, mat.channels(), mat.rows, mat.cols});
+
+    const Device kHost{"cpu"};
+    auto host_tensor = MakeAvailableOnDevice(res_tensor, kHost, stream);
+    REQUIRE(stream.Wait());
+
+    // mat's shape is {h, w, c}, while res_tensor's shape is {1, c, h, w}
+    // compare each channel between `res_tensor` and `mat`
+    auto step = shape[2] * shape[3] * mat.elemSize1();
+    auto data = host_tensor.value().data<uint8_t>();
+    for (auto i = 0; i < mat.channels(); ++i) {
+      cv::Mat _mat{mat.rows, mat.cols, CV_MAKETYPE(mat.depth(), 1), data};
+      REQUIRE(::mmdeploy::cpu::Compare(channel_mats[i], _mat));
+      data += step;
+    }
+  }
+}
+
+TEST_CASE("transform DefaultFormatBundle", "[img2tensor]") {
+  auto gResource = MMDeployTestResources::Get();
+  auto img_list = gResource.LocateImageResources("transform");
+  REQUIRE(!img_list.empty());
+
+  auto img_path = img_list.front();
+  cv::Mat bgr_mat = cv::imread(img_path, cv::IMREAD_COLOR);
+  cv::Mat gray_mat = cv::imread(img_path, cv::IMREAD_GRAYSCALE);
+  cv::Mat bgr_float_mat;
+  cv::Mat gray_float_mat;
+  bgr_mat.convertTo(bgr_float_mat, CV_32FC3);
+  gray_mat.convertTo(gray_float_mat, CV_32FC1);
+
+  Value cfg{{"type", "DefaultFormatBundle"}, {"keys", {"img"}}};
+  vector<cv::Mat> mats{bgr_mat, gray_mat, bgr_float_mat, gray_float_mat};
+  for (auto& mat : mats) {
+    TestDefaultFormatBundle(cfg, mat);
+  }
+}


### PR DESCRIPTION
## Motivation

To add DefaultFormatBundle to preprocess for SDK.

## Changed
**modified**
- csrc/preprocess/cpu/CMakeLists.txt
- csrc/preprocess/cuda/CMakeLists.txt
- mmdeploy/utils/export_info.py: remove the replacement from *DefaultFormatBundle* to *Image2Tensor*
**Added**
- csrc/preprocess/cuda/default_format_bundle_impl.cpp
- csrc/preprocess/cpu/default_format_bundle_impl.cpp
- csrc/preprocess/transform/default_format_bundle.cpp
- csrc/preprocess/transform/default_format_bundle.h
- tests/test_csrc/preprocess/test_default_format_bundle.cpp

## Note
I am not sure but I just dismissed `DC` part and label stuff for the **DefaultFormatBundle** in mmdet preprocess. Codes are below:
```python
    def __call__(self, results):
        """Call function to transform and format common fields in results.

        Args:
            results (dict): Result dict contains the data to convert.

        Returns:
            dict: The result dict contains the data that is formatted with \
                default bundle.
        """

        if 'img' in results:
            img = results['img']
            if self.img_to_float is True and img.dtype == np.uint8:
                # Normally, image is of uint8 type without normalization.
                # At this time, it needs to be forced to be converted to
                # flot32, otherwise the model training and inference
                # will be wrong. Only used for YOLOX currently .
                img = img.astype(np.float32)
            # add default meta keys
            results = self._add_default_meta_keys(results)
            if len(img.shape) < 3:
                img = np.expand_dims(img, -1)
            img = np.ascontiguousarray(img.transpose(2, 0, 1))
            results['img'] = DC(to_tensor(img), stack=True)
        for key in ['proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels']:
            if key not in results:
                continue
            results[key] = DC(to_tensor(results[key]))
        if 'gt_masks' in results:
            results['gt_masks'] = DC(results['gt_masks'], cpu_only=True)
        if 'gt_semantic_seg' in results:
            results['gt_semantic_seg'] = DC(
                to_tensor(results['gt_semantic_seg'][None, ...]), stack=True)
        return results

    def _add_default_meta_keys(self, results):
        """Add default meta keys.

        We set default meta keys including `pad_shape`, `scale_factor` and
        `img_norm_cfg` to avoid the case where no `Resize`, `Normalize` and
        `Pad` are implemented during the whole pipeline.

        Args:
            results (dict): Result dict contains the data to convert.

        Returns:
            results (dict): Updated result dict contains the data to convert.
        """
        img = results['img']
        results.setdefault('pad_shape', img.shape)
        results.setdefault('scale_factor', 1.0)
        num_channels = 1 if len(img.shape) < 3 else img.shape[2]
        results.setdefault(
            'img_norm_cfg',
            dict(
                mean=np.zeros(num_channels, dtype=np.float32),
                std=np.ones(num_channels, dtype=np.float32),
                to_rgb=False))
        return results
```