### PR TITLE
[Enhancement] Switch to statically typed Value::Any

### DIFF
--- a/csrc/core/mpl/static_any.h
+++ b/csrc/core/mpl/static_any.h
@@ -1,0 +1,498 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef MMDEPLOY_CSRC_CORE_MPL_STATIC_ANY_H_
+#define MMDEPLOY_CSRC_CORE_MPL_STATIC_ANY_H_
+
+// re-implementation of std::any, relies on static type id instead of RTTI.
+// adjusted from libc++-10
+
+namespace mmdeploy {
+
+namespace traits {
+
+using type_id_t = uint64_t;
+
+template <class T>
+struct TypeId {
+  static constexpr type_id_t value = 0;
+};
+
+template <>
+struct TypeId<void> {
+  static constexpr auto value = static_cast<type_id_t>(-1);
+};
+
+// ! This only works when calling inside mmdeploy namespace
+#define MMDEPLOY_REGISTER_TYPE_ID(type, id) \
+  namespace traits {                        \
+  template <>                               \
+  struct TypeId<type> {                     \
+    static constexpr type_id_t value = id;  \
+  };                                        \
+  }
+
+}  // namespace traits
+
+namespace detail {
+
+template <typename T>
+struct is_in_place_type_impl : std::false_type {};
+
+template <typename T>
+struct is_in_place_type_impl<std::in_place_type_t<T>> : std::true_type {};
+
+template <typename T>
+struct is_in_place_type : public is_in_place_type_impl<T> {};
+
+}  // namespace detail
+
+class BadAnyCast : public std::bad_cast {
+ public:
+  const char* what() const noexcept override { return "BadAnyCast"; }
+};
+
+[[noreturn]] inline void ThrowBadAnyCast() {
+#if __cpp_exceptions
+  throw BadAnyCast{};
+#else
+  std::abort();
+#endif
+}
+
+// Forward declarations
+class StaticAny;
+
+template <class ValueType>
+std::add_pointer_t<std::add_const_t<ValueType>> static_any_cast(const StaticAny*) noexcept;
+
+template <class ValueType>
+std::add_pointer_t<ValueType> static_any_cast(StaticAny*) noexcept;
+
+namespace __static_any_impl {
+
+using _Buffer = std::aligned_storage_t<3 * sizeof(void*), std::alignment_of_v<void*>>;
+
+template <class T>
+using _IsSmallObject =
+    std::integral_constant<bool, sizeof(T) <= sizeof(_Buffer) &&
+                                     std::alignment_of_v<_Buffer> % std::alignment_of_v<T> == 0 &&
+                                     std::is_nothrow_move_constructible_v<T>>;
+
+enum class _Action { _Destroy, _Copy, _Move, _Get, _TypeInfo };
+
+union _Ret {
+  void* ptr_;
+  traits::type_id_t type_id_;
+};
+
+template <class T>
+struct _SmallHandler;
+template <class T>
+struct _LargeHandler;
+
+template <class T>
+struct __unique_typeinfo {
+  static constexpr int __id = 0;
+};
+// N4649, [class.static.data], this usage is redundant and deprecated
+template <class T>
+constexpr int __unique_typeinfo<T>::__id;  // NOLINT
+
+template <class T>
+constexpr const void* __get_fallback_typeid() {
+  return &__unique_typeinfo<std::decay_t<T>>::__id;
+}
+
+template <class T>
+inline bool __compare_typeid(const void* __fallback_id) {
+  if (__fallback_id == __static_any_impl::__get_fallback_typeid<T>()) {
+    return true;
+  }
+  return false;
+}
+
+template <class T>
+using _Handler = std::conditional_t<_IsSmallObject<T>::value, _SmallHandler<T>, _LargeHandler<T>>;
+
+}  // namespace __static_any_impl
+
+class StaticAny {
+ public:
+  constexpr StaticAny() noexcept : h_(nullptr) {}
+
+  StaticAny(const StaticAny& other) : h_(nullptr) {
+    if (other.h_) {
+      other.__call(_Action::_Copy, this);
+    }
+  }
+
+  StaticAny(StaticAny&& other) noexcept : h_(nullptr) {
+    if (other.h_) {
+      other.__call(_Action::_Move, this);
+    }
+  }
+
+  template <class ValueType, class T = std::decay_t<ValueType>,
+            class = std::enable_if_t<!std::is_same<T, StaticAny>::value &&
+                                     !detail::is_in_place_type<ValueType>::value &&
+                                     std::is_copy_constructible<T>::value>>
+  explicit StaticAny(ValueType&& value);
+
+  template <class ValueType, class... Args, class T = std::decay_t<ValueType>,
+            class = std::enable_if_t<std::is_constructible<T, Args...>::value &&
+                                     std::is_copy_constructible<T>::value>>
+  explicit StaticAny(std::in_place_type_t<ValueType>, Args&&... args);
+
+  template <class ValueType, class U, class... Args, class T = std::decay_t<ValueType>,
+            class = std::enable_if_t<
+                std::is_constructible<T, std::initializer_list<U>&, Args...>::value &&
+                std::is_copy_constructible<T>::value>>
+  explicit StaticAny(std::in_place_type_t<ValueType>, std::initializer_list<U>, Args&&... args);
+
+  ~StaticAny() { this->reset(); }
+
+  StaticAny& operator=(const StaticAny& rhs) {
+    StaticAny(rhs).swap(*this);
+    return *this;
+  }
+
+  StaticAny& operator=(StaticAny&& rhs) noexcept {
+    StaticAny(std::move(rhs)).swap(*this);
+    return *this;
+  }
+
+  template <class ValueType, class T = std::decay_t<ValueType>,
+            class = std::enable_if_t<!std::is_same<T, StaticAny>::value &&
+                                     std::is_copy_constructible<T>::value>>
+  StaticAny& operator=(ValueType&& v);
+
+  template <class ValueType, class... Args, class T = std::decay_t<ValueType>,
+            class = std::enable_if_t<std::is_constructible<T, Args...>::value &&
+                                     std::is_copy_constructible<T>::value>>
+  T& emplace(Args&&... args);
+
+  template <class ValueType, class U, class... Args, class T = std::decay_t<ValueType>,
+            class = std::enable_if_t<
+                std::is_constructible<T, std::initializer_list<U>&, Args...>::value &&
+                std::is_copy_constructible<T>::value>>
+  T& emplace(std::initializer_list<U>, Args&&...);
+
+  void reset() noexcept {
+    if (h_) {
+      this->__call(_Action::_Destroy);
+    }
+  }
+
+  void swap(StaticAny& rhs) noexcept;
+
+  bool has_value() const noexcept { return h_ != nullptr; }
+
+  traits::type_id_t type() const noexcept {
+    if (h_) {
+      return this->__call(_Action::_TypeInfo).type_id_;
+    } else {
+      return traits::TypeId<void>::value;
+    }
+  }
+
+ private:
+  using _Action = __static_any_impl::_Action;
+  using _Ret = __static_any_impl::_Ret;
+  using _HandleFuncPtr = _Ret (*)(_Action, const StaticAny*, StaticAny*, traits::type_id_t info,
+                                  const void* fallback_info);
+
+  union _Storage {
+    constexpr _Storage() : ptr_(nullptr) {}
+    void* ptr_;
+    __static_any_impl::_Buffer buf_;
+  };
+
+  _Ret __call(_Action a, StaticAny* other = nullptr, traits::type_id_t info = 0,
+              const void* fallback_info = nullptr) const {
+    return h_(a, this, other, info, fallback_info);
+  }
+
+  _Ret __call(_Action a, StaticAny* other = nullptr, traits::type_id_t info = 0,
+              const void* fallback_info = nullptr) {
+    return h_(a, this, other, info, fallback_info);
+  }
+
+  template <class>
+  friend struct __static_any_impl::_SmallHandler;
+
+  template <class>
+  friend struct __static_any_impl::_LargeHandler;
+
+  template <class ValueType>
+  friend std::add_pointer_t<std::add_const_t<ValueType>> static_any_cast(const StaticAny*) noexcept;
+
+  template <class ValueType>
+  friend std::add_pointer_t<ValueType> static_any_cast(StaticAny*) noexcept;
+
+  _HandleFuncPtr h_ = nullptr;
+  _Storage s_;
+};
+
+namespace __static_any_impl {
+
+template <class T>
+struct _SmallHandler {
+  static _Ret __handle(_Action action, const StaticAny* self, StaticAny* other,
+                       traits::type_id_t info, const void* fallback_info) {
+    _Ret ret;
+    ret.ptr_ = nullptr;
+    switch (action) {
+      case _Action::_Destroy:
+        __destroy(const_cast<StaticAny&>(*self));
+        break;
+      case _Action::_Copy:
+        __copy(*self, *other);
+        break;
+      case _Action::_Move:
+        __move(const_cast<StaticAny&>(*self), *other);
+        break;
+      case _Action::_Get:
+        ret.ptr_ = __get(const_cast<StaticAny&>(*self), info, fallback_info);
+        break;
+      case _Action::_TypeInfo:
+        ret.type_id_ = __type_info();
+        break;
+    }
+    return ret;
+  }
+
+  template <class... Args>
+  static T& __create(StaticAny& dest, Args&&... args) {
+    T* ret = ::new (static_cast<void*>(&dest.s_.buf_)) T(std::forward<Args>(args)...);
+    dest.h_ = &_SmallHandler::__handle;
+    return *ret;
+  }
+
+ private:
+  template <class... Args>
+  static void __destroy(StaticAny& self) {
+    T& value = *static_cast<T*>(static_cast<void*>(&self.s_.buf_));
+    value.~T();
+    self.h_ = nullptr;
+  }
+
+  template <class... Args>
+  static void __copy(const StaticAny& self, StaticAny& dest) {
+    _SmallHandler::__create(dest, *static_cast<const T*>(static_cast<const void*>(&self.s_.buf_)));
+  }
+
+  static void __move(StaticAny& self, StaticAny& dest) {
+    _SmallHandler::__create(dest, std::move(*static_cast<T*>(static_cast<void*>(&self.s_.buf_))));
+    __destroy(self);
+  }
+
+  static void* __get(StaticAny& self, traits::type_id_t info, const void* fallback_id) {
+    if (info && info == __type_info() || __static_any_impl::__compare_typeid<T>(fallback_id)) {
+      return static_cast<void*>(&self.s_.buf_);
+    }
+    return nullptr;
+  }
+
+  static traits::type_id_t __type_info() { return traits::TypeId<T>::value; }
+};
+
+template <class T>
+struct _LargeHandler {
+  static _Ret __handle(_Action action, const StaticAny* self, StaticAny* other,
+                       traits::type_id_t info, const void* fallback_info) {
+    _Ret ret;
+    ret.ptr_ = nullptr;
+    switch (action) {
+      case _Action::_Destroy:
+        __destroy(const_cast<StaticAny&>(*self));
+        break;
+      case _Action::_Copy:
+        __copy(*self, *other);
+        break;
+      case _Action::_Move:
+        __move(const_cast<StaticAny&>(*self), *other);
+        break;
+      case _Action::_Get:
+        ret.ptr_ = __get(const_cast<StaticAny&>(*self), info, fallback_info);
+        break;
+      case _Action::_TypeInfo:
+        ret.type_id_ = __type_info();
+        break;
+    }
+    return ret;
+  }
+
+  template <class... Args>
+  static T& __create(StaticAny& dest, Args&&... args) {
+    using _Alloc = std::allocator<T>;
+    _Alloc alloc;
+    auto dealloc = [&](T* p) { alloc.deallocate(p, 1); };
+    std::unique_ptr<T, decltype(dealloc)> hold(alloc.allocate(1), dealloc);
+    T* ret = ::new ((void*)hold.get()) T(std::forward<Args>(args)...);
+    dest.s_.ptr_ = hold.release();
+    dest.h_ = &_LargeHandler::__handle;
+    return *ret;
+  }
+
+ private:
+  static void __destroy(StaticAny& self) {
+    delete static_cast<T*>(self.s_.ptr_);
+    self.h_ = nullptr;
+  }
+
+  static void __copy(const StaticAny& self, StaticAny& dest) {
+    _LargeHandler::__create(dest, *static_cast<const T*>(self.s_.ptr_));
+  }
+
+  static void __move(StaticAny& self, StaticAny& dest) {
+    dest.s_.ptr_ = self.s_.ptr_;
+    dest.h_ = &_LargeHandler::__handle;
+    self.h_ = nullptr;
+  }
+
+  static void* __get(StaticAny& self, traits::type_id_t info, const void* fallback_info) {
+    if (info && info == __type_info() || __static_any_impl::__compare_typeid<T>(fallback_info)) {
+      return static_cast<void*>(self.s_.ptr_);
+    }
+    return nullptr;
+  }
+
+  static traits::type_id_t __type_info() { return traits::TypeId<T>::value; }
+};
+
+}  // namespace __static_any_impl
+
+template <class ValueType, class T, class>
+StaticAny::StaticAny(ValueType&& v) : h_(nullptr) {
+  __static_any_impl::_Handler<T>::__create(*this, std::forward<ValueType>(v));
+}
+
+template <class ValueType, class... Args, class T, class>
+StaticAny::StaticAny(std::in_place_type_t<ValueType>, Args&&... args) {
+  __static_any_impl::_Handler<T>::__create(*this, std::forward<Args>(args)...);
+}
+
+template <class ValueType, class U, class... Args, class T, class>
+StaticAny::StaticAny(std::in_place_type_t<ValueType>, std::initializer_list<U> il, Args&&... args) {
+  __static_any_impl::_Handler<T>::__create(*this, il, std::forward<Args>(args)...);
+}
+
+template <class ValueType, class, class>
+inline StaticAny& StaticAny::operator=(ValueType&& v) {
+  StaticAny(std::forward<ValueType>(v)).swap(*this);
+  return *this;
+}
+
+template <class ValueType, class... Args, class T, class>
+inline T& StaticAny::emplace(Args&&... args) {
+  reset();
+  return __static_any_impl::_Handler<T>::__create(*this, std::forward<Args>(args)...);
+}
+
+template <class ValueType, class U, class... Args, class T, class>
+inline T& StaticAny::emplace(std::initializer_list<U> il, Args&&... args) {
+  reset();
+  return __static_any_impl::_Handler<T>::_create(*this, il, std::forward<Args>(args)...);
+}
+
+inline void StaticAny::swap(StaticAny& rhs) noexcept {
+  if (this == &rhs) {
+    return;
+  }
+  if (h_ && rhs.h_) {
+    StaticAny tmp;
+    rhs.__call(_Action::_Move, &tmp);
+    this->__call(_Action::_Move, &rhs);
+    tmp.__call(_Action::_Move, this);
+  } else if (h_) {
+    this->__call(_Action::_Move, &rhs);
+  } else if (rhs.h_) {
+    rhs.__call(_Action::_Move, this);
+  }
+}
+
+inline void swap(StaticAny& lhs, StaticAny& rhs) noexcept { lhs.swap(rhs); }
+
+template <class T, class... Args>
+inline StaticAny make_static_any(Args&&... args) {
+  return StaticAny(std::in_place_type<T>, std::forward<Args>(args)...);
+}
+
+template <class T, class U, class... Args>
+StaticAny make_static_any(std::initializer_list<U> il, Args&&... args) {
+  return StaticAny(std::in_place_type<T>, il, std::forward<Args>(args)...);
+}
+
+template <class ValueType>
+ValueType static_any_cast(const StaticAny& v) {
+  using _RawValueType = std::remove_cv_t<std::remove_reference_t<ValueType>>;
+  static_assert(std::is_constructible<ValueType, const _RawValueType&>::value,
+                "ValueType is required to be a const lvalue reference "
+                "or a CopyConstructible type");
+  auto tmp = static_any_cast<std::add_const_t<_RawValueType>>(&v);
+  if (tmp == nullptr) {
+    ThrowBadAnyCast();
+  }
+  return static_cast<ValueType>(*tmp);
+}
+
+template <class ValueType>
+inline ValueType static_any_cast(StaticAny& v) {
+  using _RawValueType = std::remove_cv_t<std::remove_reference_t<ValueType>>;
+  static_assert(std::is_constructible<ValueType, _RawValueType&>::value,
+                "ValueType is required to be an lvalue reference "
+                "or a CopyConstructible type");
+  auto tmp = static_any_cast<_RawValueType>(&v);
+  if (tmp == nullptr) {
+    ThrowBadAnyCast();
+  }
+  return static_cast<ValueType>(*tmp);
+}
+
+template <class ValueType>
+inline ValueType static_any_cast(StaticAny&& v) {
+  using _RawValueType = std::remove_cv_t<std::remove_reference_t<ValueType>>;
+  static_assert(std::is_constructible<ValueType, _RawValueType>::value,
+                "ValueType is required to be an rvalue reference "
+                "or a CopyConstructible type");
+  auto tmp = static_any_cast<_RawValueType>(&v);
+  if (tmp == nullptr) {
+    ThrowBadAnyCast();
+  }
+  return static_cast<ValueType>(std::move(*tmp));
+}
+
+template <class ValueType>
+inline std::add_pointer_t<std::add_const_t<ValueType>> static_any_cast(
+    const StaticAny* __any) noexcept {
+  static_assert(!std::is_reference<ValueType>::value, "ValueType may not be a reference.");
+  return static_any_cast<ValueType>(const_cast<StaticAny*>(__any));
+}
+
+template <class RetType>
+inline RetType __pointer_or_func_test(void* p, std::false_type) noexcept {
+  return static_cast<RetType>(p);
+}
+
+template <class RetType>
+inline RetType __pointer_or_func_test(void*, std::true_type) noexcept {
+  return nullptr;
+}
+
+template <class ValueType>
+std::add_pointer_t<ValueType> static_any_cast(StaticAny* any) noexcept {
+  using __static_any_impl::_Action;
+  static_assert(!std::is_reference<ValueType>::value, "ValueType may not be a reference.");
+  using ReturnType = std::add_pointer_t<ValueType>;
+  if (any && any->h_) {
+    void* p = any->__call(_Action::_Get, nullptr, traits::TypeId<ValueType>::value,
+                          __static_any_impl::__get_fallback_typeid<ValueType>())
+                  .ptr_;
+    return __pointer_or_func_test<ReturnType>(p, std::is_function<ValueType>{});
+  }
+  return nullptr;
+}
+
+}  // namespace mmdeploy
+
+#endif  // MMDEPLOY_CSRC_CORE_MPL_STATIC_ANY_H_

--- a/csrc/core/mpl/static_any.h
+++ b/csrc/core/mpl/static_any.h
@@ -3,6 +3,12 @@
 #ifndef MMDEPLOY_CSRC_CORE_MPL_STATIC_ANY_H_
 #define MMDEPLOY_CSRC_CORE_MPL_STATIC_ANY_H_
 
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
 // re-implementation of std::any, relies on static type id instead of RTTI.
 // adjusted from libc++-10
 

--- a/csrc/core/mpl/static_any.h
+++ b/csrc/core/mpl/static_any.h
@@ -120,20 +120,21 @@ class StaticAny {
   }
 
   template <class ValueType, class T = std::decay_t<ValueType>,
-            class = std::enable_if_t<!std::is_same<T, StaticAny>::value &&
-                                     !detail::is_in_place_type<ValueType>::value &&
-                                     std::is_copy_constructible<T>::value>>
+            class = std::enable_if_t<
+                !std::is_same<T, StaticAny>::value && !detail::is_in_place_type<ValueType>::value &&
+                std::is_copy_constructible<T>::value && traits::TypeId<T>::value>>
   explicit StaticAny(ValueType&& value);
 
-  template <class ValueType, class... Args, class T = std::decay_t<ValueType>,
-            class = std::enable_if_t<std::is_constructible<T, Args...>::value &&
-                                     std::is_copy_constructible<T>::value>>
+  template <
+      class ValueType, class... Args, class T = std::decay_t<ValueType>,
+      class = std::enable_if_t<std::is_constructible<T, Args...>::value &&
+                               std::is_copy_constructible<T>::value && traits::TypeId<T>::value>>
   explicit StaticAny(std::in_place_type_t<ValueType>, Args&&... args);
 
   template <class ValueType, class U, class... Args, class T = std::decay_t<ValueType>,
             class = std::enable_if_t<
                 std::is_constructible<T, std::initializer_list<U>&, Args...>::value &&
-                std::is_copy_constructible<T>::value>>
+                std::is_copy_constructible<T>::value && traits::TypeId<T>::value>>
   explicit StaticAny(std::in_place_type_t<ValueType>, std::initializer_list<U>, Args&&... args);
 
   ~StaticAny() { this->reset(); }
@@ -148,20 +149,22 @@ class StaticAny {
     return *this;
   }
 
-  template <class ValueType, class T = std::decay_t<ValueType>,
-            class = std::enable_if_t<!std::is_same<T, StaticAny>::value &&
-                                     std::is_copy_constructible<T>::value>>
+  template <
+      class ValueType, class T = std::decay_t<ValueType>,
+      class = std::enable_if_t<!std::is_same<T, StaticAny>::value &&
+                               std::is_copy_constructible<T>::value && traits::TypeId<T>::value>>
   StaticAny& operator=(ValueType&& v);
 
-  template <class ValueType, class... Args, class T = std::decay_t<ValueType>,
-            class = std::enable_if_t<std::is_constructible<T, Args...>::value &&
-                                     std::is_copy_constructible<T>::value>>
+  template <
+      class ValueType, class... Args, class T = std::decay_t<ValueType>,
+      class = std::enable_if_t<std::is_constructible<T, Args...>::value &&
+                               std::is_copy_constructible<T>::value && traits::TypeId<T>::value>>
   T& emplace(Args&&... args);
 
   template <class ValueType, class U, class... Args, class T = std::decay_t<ValueType>,
             class = std::enable_if_t<
                 std::is_constructible<T, std::initializer_list<U>&, Args...>::value &&
-                std::is_copy_constructible<T>::value>>
+                std::is_copy_constructible<T>::value && traits::TypeId<T>::value>>
   T& emplace(std::initializer_list<U>, Args&&...);
 
   void reset() noexcept {

--- a/csrc/core/mpl/static_any.h
+++ b/csrc/core/mpl/static_any.h
@@ -104,7 +104,10 @@ constexpr const void* __get_fallback_typeid() {
 }
 
 template <class T>
-inline bool __compare_typeid(const void* __fallback_id) {
+inline bool __compare_typeid(traits::type_id_t __id, const void* __fallback_id) {
+  if (__id && __id == traits::TypeId<T>::value) {
+    return true;
+  }
   if (__fallback_id == __static_any_impl::__get_fallback_typeid<T>()) {
     return true;
   }
@@ -287,7 +290,7 @@ struct _SmallHandler {
   }
 
   static void* __get(StaticAny& self, traits::type_id_t info, const void* fallback_id) {
-    if (info && info == __type_info() || __static_any_impl::__compare_typeid<T>(fallback_id)) {
+    if (__static_any_impl::__compare_typeid<T>(info, fallback_id)) {
       return static_cast<void*>(&self.s_.buf_);
     }
     return nullptr;
@@ -351,7 +354,7 @@ struct _LargeHandler {
   }
 
   static void* __get(StaticAny& self, traits::type_id_t info, const void* fallback_info) {
-    if (info && info == __type_info() || __static_any_impl::__compare_typeid<T>(fallback_info)) {
+    if (__static_any_impl::__compare_typeid<T>(info, fallback_info)) {
       return static_cast<void*>(self.s_.ptr_);
     }
     return nullptr;

--- a/csrc/core/value.h
+++ b/csrc/core/value.h
@@ -3,7 +3,6 @@
 #ifndef MMDEPLOY_TYPES_VALUE_H_
 #define MMDEPLOY_TYPES_VALUE_H_
 
-#include <any>
 #include <cassert>
 #include <cstdint>
 #include <iostream>
@@ -16,6 +15,7 @@
 #include "core/logger.h"
 #include "core/status_code.h"
 #include "mpl/priority_tag.h"
+#include "mpl/static_any.h"
 #include "mpl/type_traits.h"
 
 namespace mmdeploy {
@@ -164,6 +164,14 @@ struct is_cast_by_erasure<Tensor> : std::true_type {};
 template <>
 struct is_cast_by_erasure<Mat> : std::true_type {};
 
+MMDEPLOY_REGISTER_TYPE_ID(Device, 1);
+MMDEPLOY_REGISTER_TYPE_ID(Buffer, 2);
+MMDEPLOY_REGISTER_TYPE_ID(Stream, 3);
+MMDEPLOY_REGISTER_TYPE_ID(Event, 4);
+MMDEPLOY_REGISTER_TYPE_ID(Model, 5);
+MMDEPLOY_REGISTER_TYPE_ID(Tensor, 6);
+MMDEPLOY_REGISTER_TYPE_ID(Mat, 7);
+
 template <typename T>
 struct is_value : std::is_same<T, Value> {};
 
@@ -204,8 +212,8 @@ class Value {
   using Array = std::vector<Value>;
   using Object = std::map<std::string, Value>;
   using Pointer = std::shared_ptr<Value>;
-  using Dynamic = mmdeploy::Dynamic;
-  using Any = std::any;
+  using Dynamic = ::mmdeploy::Dynamic;
+  using Any = ::mmdeploy::StaticAny;
   using ValueRef = detail::ValueRef;
 
   static constexpr const auto kNull = ValueType::kNull;
@@ -349,7 +357,7 @@ class Value {
     if constexpr (std::is_void_v<T>) {
       return true;
     } else {
-      return typeid(T) == data_.any->type();
+      return traits::TypeId<T>::value == data_.any->type();
     }
   }
 
@@ -440,11 +448,11 @@ class Value {
 
   template <typename T>
   T* get_erased_ptr(EraseType<T>*) noexcept {
-    return _is_any() ? std::any_cast<T>(data_.any) : nullptr;
+    return _is_any() ? static_any_cast<T>(data_.any) : nullptr;
   }
   template <typename T>
   const T* get_erased_ptr(const EraseType<T>*) const noexcept {
-    return _is_any() ? std::any_cast<T>(const_cast<const std::any*>(data_.any)) : nullptr;
+    return _is_any() ? static_any_cast<T>(const_cast<const Any*>(data_.any)) : nullptr;
   }
 
   template <typename T, typename This>

--- a/tests/test_csrc/core/test_value.cpp
+++ b/tests/test_csrc/core/test_value.cpp
@@ -283,12 +283,22 @@ struct Doge {
   int value;
 };
 
+namespace mmdeploy {
+
+MMDEPLOY_REGISTER_TYPE_ID(Meow, 1234);
+MMDEPLOY_REGISTER_TYPE_ID(Doge, 3456);
+
+}  // namespace mmdeploy
+
 template <>
 struct mmdeploy::is_cast_by_erasure<Meow> : std::true_type {};
 
 TEST_CASE("test dynamic interface for value", "[value]") {
   Value meow(Meow{100});
   REQUIRE(meow.is_any());
+  REQUIRE(meow.is_any<Meow>());
+  REQUIRE_FALSE(meow.is_any<int>());
+  REQUIRE_FALSE(meow.is_any<Doge>());
   REQUIRE(meow.get<Meow>().value == 100);
   REQUIRE(meow.get_ref<Meow&>().value == 100);
   REQUIRE(meow.get_ptr<Meow*>() == &meow.get_ref<Meow&>());


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`std::any` is not guaranteed to work on multi-dll or dynamic module loading configuration. Switched to a statically typed version (by specializing `mmdeploy::traits::TypeId<T>`) of `std::any` based on libc++'s implementation.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
