### PR TITLE
[Bug] compatible with torch 1.11

### DIFF
--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -32,6 +32,8 @@ def torch2onnx_impl(model: torch.nn.Module, input: torch.Tensor,
     output_names = onnx_cfg['output_names']
     axis_names = input_names + output_names
     dynamic_axes = get_dynamic_axes(deploy_cfg, axis_names)
+    verbose = not onnx_cfg.get('strip_doc_string', True) or onnx_cfg.get(
+        'verbose', False)
 
     # patch model
     patched_model = patch_model(model, cfg=deploy_cfg, backend=backend)
@@ -50,7 +52,7 @@ def torch2onnx_impl(model: torch.nn.Module, input: torch.Tensor,
             dynamic_axes=dynamic_axes,
             keep_initializers_as_inputs=onnx_cfg[
                 'keep_initializers_as_inputs'],
-            strip_doc_string=onnx_cfg.get('strip_doc_string', True))
+            verbose=verbose)
 
 
 def torch2onnx(img: Any,


### PR DESCRIPTION
Use `verbose` instead of `strip_doc_string` for onnx export according to [official docstring](https://pytorch.org/docs/master/onnx.html#functions)

Related issue #268.