### PR TITLE
suppress CMAKE_CUDA_ARCHITECTURES warning

### DIFF
--- a/csrc/backend_ops/tensorrt/CMakeLists.txt
+++ b/csrc/backend_ops/tensorrt/CMakeLists.txt
@@ -4,7 +4,6 @@ include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake NO_POLICY_SCOPE)
 project(mmdeploy_tensorrt_ops CUDA CXX)
 
 include(${CMAKE_SOURCE_DIR}/cmake/MMDeploy.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake NO_POLICY_SCOPE)
 include(${CMAKE_SOURCE_DIR}/cmake/tensorrt.cmake NO_POLICY_SCOPE)
 
 # cub

--- a/csrc/device/cuda/CMakeLists.txt
+++ b/csrc/device/cuda/CMakeLists.txt
@@ -4,11 +4,6 @@ cmake_minimum_required(VERSION 3.14)
 include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake NO_POLICY_SCOPE)
 project(mmdeploy_cuda_device CUDA CXX)
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
-    # suppress 'CMAKE_CUDA_ARCHITECTURES' warning
-    cmake_policy(SET CMP0104 OLD)
-endif ()
-
 include(${CMAKE_SOURCE_DIR}/cmake/MMDeploy.cmake)
 
 set(SRCS

--- a/csrc/net/trt/CMakeLists.txt
+++ b/csrc/net/trt/CMakeLists.txt
@@ -1,11 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 cmake_minimum_required(VERSION 3.14)
+include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake NO_POLICY_SCOPE)
 project(mmdeploy_trt_net)
-
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
-    # suppress 'CMAKE_CUDA_ARCHITECTURES' warning
-    cmake_policy(SET CMP0104 OLD)
-endif ()
 
 include(${CMAKE_SOURCE_DIR}/cmake/MMDeploy.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/tensorrt.cmake)

--- a/csrc/net/trt/CMakeLists.txt
+++ b/csrc/net/trt/CMakeLists.txt
@@ -2,6 +2,11 @@
 cmake_minimum_required(VERSION 3.14)
 project(mmdeploy_trt_net)
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+    # suppress 'CMAKE_CUDA_ARCHITECTURES' warning
+    cmake_policy(SET CMP0104 OLD)
+endif ()
+
 include(${CMAKE_SOURCE_DIR}/cmake/MMDeploy.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/tensorrt.cmake)
 

--- a/csrc/preprocess/cuda/CMakeLists.txt
+++ b/csrc/preprocess/cuda/CMakeLists.txt
@@ -1,11 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 cmake_minimum_required(VERSION 3.14)
+include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake NO_POLICY_SCOPE)
 project(mmdeploy_cuda_transform_impl CUDA CXX)
-
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
-    # suppress 'CMAKE_CUDA_ARCHITECTURES' warning
-    cmake_policy(SET CMP0104 OLD)
-endif ()
 
 find_package(pplcv REQUIRED)
 


### PR DESCRIPTION
## Motivation

suppress 'CMAKE_CUDA_ARCHITECTURES' empty warning when building trt backend. #269 

## Modification

- [x] csrc/net/trt/CMakeLists.txt
- [x] /csrc/backend_ops/tensorrt/CMakeLists.txt
- [x] /csrc/device/cuda/CMakeLists.txt
- [x] /csrc/preprocess/cuda/CMakeLists.txt