### PR TITLE
[Feature] Regression test for mmdeploy

### DIFF
--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -5,9 +5,9 @@ globals:
   checkpoint_dir: ../mmdeploy_checkpoints
   images:
     img_snake: &img_snake ../mmclassification/demo/demo.JPEG
-    img_bird: &img_bird: ../mmclassification/demo/bird.JPEG
-    img_cat_dog: &img_cat_dog: ../mmclassification/demo/cat-dog.png
-    img_dog: &img_dog: ../mmclassification/demo/dog.jpg
+    img_bird: &img_bird ../mmclassification/demo/bird.JPEG
+    img_cat_dog: &img_cat_dog ../mmclassification/demo/cat-dog.png
+    img_dog: &img_dog ../mmclassification/demo/dog.jpg
     img_color_cat: &img_color_cat ../mmclassification/tests/data/color.jpg
     img_gray_cat: &img_gray_cat ../mmclassification/tests/data/gray.jpg
 

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -117,7 +117,7 @@ models:
   - name: ResNet
     metafile: configs/resnet/metafile.yml
     model_configs:
-      - configs/resnet/resnet18_8xb32_in1k.py
+      - configs/resnet/resnet18_8xb32_in1k.py # TODO Not benchmark config
     pipelines:
       - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp32
@@ -131,7 +131,7 @@ models:
   - name: ResNeXt
     metafile: configs/resnext/metafile.yml
     model_configs:
-      - configs/resnext/resnext50-32x4d_8xb32_in1k.py
+      - configs/resnext/resnext50-32x4d_8xb32_in1k.py # TODO Not benchmark config
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
@@ -143,7 +143,7 @@ models:
   - name: SE-ResNet
     metafile: configs/seresnet/metafile.yml
     model_configs:
-      - configs/seresnet/seresnet50_8xb32_in1k.py
+      - configs/seresnet/seresnet50_8xb32_in1k.py # TODO Not benchmark config
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
@@ -164,10 +164,10 @@ models:
       - *pipeline_ppl_dynamic_fp32
       - *pipeline_ts_fp32
 
-#  - name: ShuffleNetV1
+#  - name: ShuffleNetV1 # TODO Convert fail
 #    metafile: configs/shufflenet_v1/metafile.yml
 #    model_configs:
-#      - configs/shufflenet_v1/shufflenet-v1-1x_16xb64_in1k.py
+#      - configs/shufflenet_v1/shufflenet-v1-1x_16xb64_in1k.py # TODO Not benchmark config
 #    pipelines:
 #      - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp16
@@ -176,10 +176,10 @@ models:
 #      - *pipeline_ppl_dynamic_fp32
 #      - *pipeline_ts_fp32
 #
-#  - name: ShuffleNetV2
+#  - name: ShuffleNetV2 # TODO Convert fail
 #    metafile: configs/shufflenet_v2/metafile.yml
 #    model_configs:
-#      - configs/shufflenet_v2/shufflenet-v2-1x_16xb64_in1k.py
+#      - configs/shufflenet_v2/shufflenet-v2-1x_16xb64_in1k.py # TODO Not benchmark config
 #    pipelines:
 #      - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp16

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -36,6 +36,7 @@ onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_onnxruntime_static.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
@@ -100,7 +101,7 @@ ncnn:
 
 
 pplnn:
-  pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
+  pipeline_pplnn_dynamic_fp32: &pipeline_pplnn_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmcls/classification_pplnn_dynamic-224x224.py
@@ -125,7 +126,7 @@ models:
 #      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32
 
   - name: ResNeXt
@@ -137,7 +138,7 @@ models:
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32
 
   - name: SE-ResNet
@@ -149,7 +150,7 @@ models:
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32
 
   - name: MobileNetV2
@@ -161,7 +162,7 @@ models:
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32
 
 #  - name: ShuffleNetV1 # TODO Convert fail
@@ -173,7 +174,7 @@ models:
 #      - *pipeline_trt_dynamic_fp16
 #      - *pipeline_openvino_dynamic_fp32
 #      - *pipeline_ncnn_static_fp32
-#      - *pipeline_ppl_dynamic_fp32
+#      - *pipeline_pplnn_dynamic_fp32
 #      - *pipeline_ts_fp32
 #
 #  - name: ShuffleNetV2 # TODO Convert fail
@@ -185,5 +186,5 @@ models:
 #      - *pipeline_trt_dynamic_fp16
 #      - *pipeline_openvino_dynamic_fp32
 #      - *pipeline_ncnn_static_fp32
-#      - *pipeline_ppl_dynamic_fp32
+#      - *pipeline_pplnn_dynamic_fp32
 #      - *pipeline_ts_fp32

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -120,9 +120,9 @@ models:
       - configs/resnet/resnet18_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_trt_dynamic_int8
+#      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
@@ -134,9 +134,7 @@ models:
       - configs/resnext/resnext50-32x4d_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
@@ -148,9 +146,7 @@ models:
       - configs/seresnet/seresnet50_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
@@ -162,9 +158,7 @@ models:
       - configs/mobilenet_v2/mobilenet-v2_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
@@ -176,9 +170,7 @@ models:
 #      - configs/shufflenet_v1/shufflenet-v1-1x_16xb64_in1k.py
 #    pipelines:
 #      - *pipeline_ort_dynamic_fp32
-#      - *pipeline_trt_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp16
-#      - *pipeline_trt_dynamic_int8
 #      - *pipeline_openvino_dynamic_fp32
 #      - *pipeline_ncnn_static_fp32
 #      - *pipeline_ppl_dynamic_fp32
@@ -190,9 +182,7 @@ models:
 #      - configs/shufflenet_v2/shufflenet-v2-1x_16xb64_in1k.py
 #    pipelines:
 #      - *pipeline_ort_dynamic_fp32
-#      - *pipeline_trt_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp16
-#      - *pipeline_trt_dynamic_int8
 #      - *pipeline_openvino_dynamic_fp32
 #      - *pipeline_ncnn_static_fp32
 #      - *pipeline_ppl_dynamic_fp32

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -5,7 +5,12 @@ globals:
   checkpoint_dir: ../mmdeploy_checkpoints
   images:
     img_snake: &img_snake ../mmclassification/demo/demo.JPEG
-    img_cat: &img_cat ../mmclassification/tests/data/color.jpg
+    img_bird: &img_bird: ../mmclassification/demo/bird.JPEG
+    img_cat_dog: &img_cat_dog: ../mmclassification/demo/cat-dog.png
+    img_dog: &img_dog: ../mmclassification/demo/dog.jpg
+    img_color_cat: &img_color_cat ../mmclassification/tests/data/color.jpg
+    img_gray_cat: &img_gray_cat ../mmclassification/tests/data/gray.jpg
+
   metric_info: &metric_info
     Top 1 Accuracy: # named after metafile.Results.Metrics
       eval_name: accuracy # test.py --metrics args

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -15,13 +15,13 @@ globals:
     Top 1 Accuracy: # named after metafile.Results.Metrics
       eval_name: accuracy # test.py --metrics args
       metric_key: accuracy_top-1 # eval Dict key name
-      tolerance: 0.5
+      tolerance: 1
       task_name: Image Classification # metafile.Results.Task
       dataset: ImageNet-1k # metafile.Results.Dataset
     Top 5 Accuracy:
       eval_name: accuracy
       metric_key: accuracy_top-5
-      tolerance: 0.5
+      tolerance: 1
       task_name: Image Classification
       dataset: ImageNet-1k
   convert_image: &convert_image

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -26,7 +26,7 @@ globals:
       dataset: ImageNet-1k
   convert_image: &convert_image
     input_img: *img_snake
-    test_img: *img_cat
+    test_img: *img_color_cat
   backend_test: &default_backend_test True
   sdk:
     sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmcls/classification_sdk_dynamic.py

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -41,6 +41,16 @@ tensorrt:
     backend_test: *default_backend_test
     deploy_config: configs/mmcls/classification_tensorrt_static-224x224.py
 
+  pipeline_trt_static_fp16: &pipeline_trt_static_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmcls/classification_tensorrt-fp16_static-224x224.py
+
+  pipeline_trt_static_int8: &pipeline_trt_static_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmcls/classification_tensorrt-int8_static-224x224.py
+
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -15,13 +15,13 @@ globals:
     Top 1 Accuracy: # named after metafile.Results.Metrics
       eval_name: accuracy # test.py --metrics args
       metric_key: accuracy_top-1 # eval Dict key name
-      tolerance: 1
+      tolerance: 1 # metric ±n%
       task_name: Image Classification # metafile.Results.Task
       dataset: ImageNet-1k # metafile.Results.Dataset
     Top 5 Accuracy:
       eval_name: accuracy
       metric_key: accuracy_top-5
-      tolerance: 1
+      tolerance: 1 # metric ±n%
       task_name: Image Classification
       dataset: ImageNet-1k
   convert_image: &convert_image

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -29,14 +29,14 @@ globals:
     test_img: *img_color_cat
   backend_test: &default_backend_test True
   sdk:
-    sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmcls/classification_sdk_dynamic.py
+    sdk_dynamic: &sdk_dynamic configs/mmcls/classification_sdk_dynamic.py
 
 
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmcls/classification_onnxruntime_static.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
@@ -64,20 +64,20 @@ tensorrt:
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmcls/classification_tensorrt_dynamic-224x224-224x224.py
 
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmcls/classification_tensorrt-fp16_dynamic-224x224-224x224.py
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image
     calib_dataset_cfg:
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmcls/classification_tensorrt-int8_dynamic-224x224-224x224.py
 
 

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -68,8 +68,8 @@ tensorrt:
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt-fp16_dynamic-224x224-224x224.py
     metric_tolerance:
-      Top 1 Accuracy: 0.5
-      Top 5 Accuracy: 0.5
+      Top 1 Accuracy: 1
+      Top 5 Accuracy: 1
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image
@@ -108,10 +108,70 @@ torchscript:
     deploy_config: configs/mmcls/classification_torchscript.py
 
 models:
-  - name: mobilenet_v2
+  - name: ResNet
+    metafile: configs/resnet/metafile.yml
+    model_configs:
+      - configs/resnet/resnet18_b32x8_imagenet.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: ResNeXt
+    metafile: configs/resnext/metafile.yml
+    model_configs:
+      - configs/resnext/resnext50_32x4d_b32x8_imagenet.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: SE-ResNet
+    metafile: configs/seresnet/metafile.yml
+    model_configs:
+      - configs/seresnet/seresnet50_b32x8_imagenet.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: MobileNetV2
     metafile: configs/mobilenet_v2/metafile.yml
     model_configs:
       - configs/mobilenet_v2/mobilenet-v2_8xb32_in1k.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: ShuffleNetV1
+    metafile: configs/shufflenet_v1/metafile.yml
+    model_configs:
+      - configs/shufflenet_v1/shufflenet_v1_1x_b64x16_linearlr_bn_nowd_imagenet.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: ShuffleNetV2
+    metafile: configs/shufflenet_v2/metafile.yml
+    model_configs:
+      - configs/shufflenet_v2/shufflenet_v2_1x_b64x16_linearlr_bn_nowd_imagenet.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -31,6 +31,7 @@ globals:
   sdk:
     sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmcls/classification_sdk_dynamic.py
 
+
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
@@ -41,9 +42,7 @@ onnxruntime:
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmcls/classification_onnxruntime_dynamic.py
-    metric_tolerance:
-      Top 1 Accuracy: 0.02
-      Top 5 Accuracy: 0.09
+
 
 tensorrt:
   pipeline_trt_static_fp32: &pipeline_trt_static_fp32
@@ -66,18 +65,12 @@ tensorrt:
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt_dynamic-224x224-224x224.py
-    metric_tolerance:
-      Top 1 Accuracy: 0.02
-      Top 5 Accuracy: 0.09
 
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt-fp16_dynamic-224x224-224x224.py
-    metric_tolerance:
-      Top 1 Accuracy: 0.04
-      Top 5 Accuracy: 0.10
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image
@@ -85,15 +78,14 @@ tensorrt:
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt-int8_dynamic-224x224-224x224.py
-    metric_tolerance:
-      Top 1 Accuracy: 0.95
-      Top 5 Accuracy: 0.57
+
 
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmcls/classification_openvino_dynamic-224x224.py
+
 
 ncnn:
   pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32
@@ -106,23 +98,20 @@ ncnn:
     backend_test: False
     deploy_config: configs/mmcls/classification_ncnn_dynamic.py
 
+
 pplnn:
   pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmcls/classification_pplnn_dynamic-224x224.py
-    metric_tolerance:
-      Top 1 Accuracy: 0.04
-      Top 5 Accuracy: 0.09
+
 
 torchscript:
   pipeline_ts_fp32: &pipeline_ts_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmcls/classification_torchscript.py
-    metric_tolerance:
-      Top 1 Accuracy: 0.00
-      Top 5 Accuracy: 0.00
+
 
 models:
   - name: ResNet

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -67,6 +67,9 @@ tensorrt:
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt-fp16_dynamic-224x224-224x224.py
+    metric_tolerance:
+      Top 1 Accuracy: 0.5
+      Top 5 Accuracy: 0.5
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -34,11 +34,16 @@ globals:
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
+    backend_test: *default_backend_test
     deploy_config: configs/mmcls/classification_onnxruntime_static.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
     convert_image: *convert_image
+    backend_test: False
     deploy_config: configs/mmcls/classification_onnxruntime_dynamic.py
+    metric_tolerance:
+      Top 1 Accuracy: 0.02
+      Top 5 Accuracy: 0.09
 
 tensorrt:
   pipeline_trt_static_fp32: &pipeline_trt_static_fp32
@@ -61,6 +66,9 @@ tensorrt:
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt_dynamic-224x224-224x224.py
+    metric_tolerance:
+      Top 1 Accuracy: 0.02
+      Top 5 Accuracy: 0.09
 
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
@@ -68,8 +76,8 @@ tensorrt:
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt-fp16_dynamic-224x224-224x224.py
     metric_tolerance:
-      Top 1 Accuracy: 1
-      Top 5 Accuracy: 1
+      Top 1 Accuracy: 0.04
+      Top 5 Accuracy: 0.10
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image
@@ -77,6 +85,9 @@ tensorrt:
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmcls/classification_tensorrt-int8_dynamic-224x224-224x224.py
+    metric_tolerance:
+      Top 1 Accuracy: 0.95
+      Top 5 Accuracy: 0.57
 
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
@@ -100,21 +111,29 @@ pplnn:
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmcls/classification_pplnn_dynamic-224x224.py
+    metric_tolerance:
+      Top 1 Accuracy: 0.04
+      Top 5 Accuracy: 0.09
 
 torchscript:
   pipeline_ts_fp32: &pipeline_ts_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmcls/classification_torchscript.py
+    metric_tolerance:
+      Top 1 Accuracy: 0.00
+      Top 5 Accuracy: 0.00
 
 models:
   - name: ResNet
     metafile: configs/resnet/metafile.yml
     model_configs:
-      - configs/resnet/resnet18_b32x8_imagenet.py
+      - configs/resnet/resnet18_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
@@ -123,10 +142,12 @@ models:
   - name: ResNeXt
     metafile: configs/resnext/metafile.yml
     model_configs:
-      - configs/resnext/resnext50_32x4d_b32x8_imagenet.py
+      - configs/resnext/resnext50-32x4d_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
@@ -135,10 +156,12 @@ models:
   - name: SE-ResNet
     metafile: configs/seresnet/metafile.yml
     model_configs:
-      - configs/seresnet/seresnet50_b32x8_imagenet.py
+      - configs/seresnet/seresnet50_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
@@ -150,32 +173,38 @@ models:
       - configs/mobilenet_v2/mobilenet-v2_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_trt_dynamic_int8
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
       - *pipeline_ts_fp32
 
-  - name: ShuffleNetV1
-    metafile: configs/shufflenet_v1/metafile.yml
-    model_configs:
-      - configs/shufflenet_v1/shufflenet_v1_1x_b64x16_linearlr_bn_nowd_imagenet.py
-    pipelines:
-      - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
-      - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
-      - *pipeline_ts_fp32
-
-  - name: ShuffleNetV2
-    metafile: configs/shufflenet_v2/metafile.yml
-    model_configs:
-      - configs/shufflenet_v2/shufflenet_v2_1x_b64x16_linearlr_bn_nowd_imagenet.py
-    pipelines:
-      - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
-      - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
-      - *pipeline_ts_fp32
+#  - name: ShuffleNetV1
+#    metafile: configs/shufflenet_v1/metafile.yml
+#    model_configs:
+#      - configs/shufflenet_v1/shufflenet-v1-1x_16xb64_in1k.py
+#    pipelines:
+#      - *pipeline_ort_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp16
+#      - *pipeline_trt_dynamic_int8
+#      - *pipeline_openvino_dynamic_fp32
+#      - *pipeline_ncnn_static_fp32
+#      - *pipeline_ppl_dynamic_fp32
+#      - *pipeline_ts_fp32
+#
+#  - name: ShuffleNetV2
+#    metafile: configs/shufflenet_v2/metafile.yml
+#    model_configs:
+#      - configs/shufflenet_v2/shufflenet-v2-1x_16xb64_in1k.py
+#    pipelines:
+#      - *pipeline_ort_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp16
+#      - *pipeline_trt_dynamic_int8
+#      - *pipeline_openvino_dynamic_fp32
+#      - *pipeline_ncnn_static_fp32
+#      - *pipeline_ppl_dynamic_fp32
+#      - *pipeline_ts_fp32

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -120,71 +120,71 @@ models:
     model_configs:
       - configs/resnet/resnet18_8xb32_in1k.py # TODO Not benchmark config
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
 #      - *pipeline_trt_dynamic_int8
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: ResNeXt
     metafile: configs/resnext/metafile.yml
     model_configs:
       - configs/resnext/resnext50-32x4d_8xb32_in1k.py # TODO Not benchmark config
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: SE-ResNet
     metafile: configs/seresnet/metafile.yml
     model_configs:
       - configs/seresnet/seresnet50_8xb32_in1k.py # TODO Not benchmark config
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: MobileNetV2
     metafile: configs/mobilenet_v2/metafile.yml
     model_configs:
       - configs/mobilenet_v2/mobilenet-v2_8xb32_in1k.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
 #  - name: ShuffleNetV1 # TODO Convert fail
 #    metafile: configs/shufflenet_v1/metafile.yml
 #    model_configs:
 #      - configs/shufflenet_v1/shufflenet-v1-1x_16xb64_in1k.py # TODO Not benchmark config
 #    pipelines:
+#      - *pipeline_ts_fp32
 #      - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp16
-#      - *pipeline_openvino_dynamic_fp32
 #      - *pipeline_ncnn_static_fp32
 #      - *pipeline_pplnn_dynamic_fp32
-#      - *pipeline_ts_fp32
+#      - *pipeline_openvino_dynamic_fp32
 #
 #  - name: ShuffleNetV2 # TODO Convert fail
 #    metafile: configs/shufflenet_v2/metafile.yml
 #    model_configs:
 #      - configs/shufflenet_v2/shufflenet-v2-1x_16xb64_in1k.py # TODO Not benchmark config
 #    pipelines:
+#      - *pipeline_ts_fp32
 #      - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp16
-#      - *pipeline_openvino_dynamic_fp32
 #      - *pipeline_ncnn_static_fp32
 #      - *pipeline_pplnn_dynamic_fp32
-#      - *pipeline_ts_fp32
+#      - *pipeline_openvino_dynamic_fp32

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -92,9 +92,8 @@ torchscript:
 models:
   - name: mobilenet_v2
     metafile: configs/mobilenet_v2/metafile.yml
-    codebase_model_config_dir: ./configs/mobilenet_v2
     model_configs:
-      - mobilenet-v2_8xb32_in1k.py
+      - configs/mobilenet_v2/mobilenet-v2_8xb32_in1k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16

--- a/configs/mmcls/mmcls_regression_test.yaml
+++ b/configs/mmcls/mmcls_regression_test.yaml
@@ -165,26 +165,26 @@ models:
       - *pipeline_pplnn_dynamic_fp32
       - *pipeline_openvino_dynamic_fp32
 
-#  - name: ShuffleNetV1 # TODO Convert fail
-#    metafile: configs/shufflenet_v1/metafile.yml
-#    model_configs:
-#      - configs/shufflenet_v1/shufflenet-v1-1x_16xb64_in1k.py # TODO Not benchmark config
-#    pipelines:
-#      - *pipeline_ts_fp32
-#      - *pipeline_ort_dynamic_fp32
-#      - *pipeline_trt_dynamic_fp16
-#      - *pipeline_ncnn_static_fp32
+  - name: ShuffleNetV1
+    metafile: configs/shufflenet_v1/metafile.yml
+    model_configs:
+      - configs/shufflenet_v1/shufflenet-v1-1x_16xb64_in1k.py
+    pipelines:
+      - *pipeline_ts_fp32
+#      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_fp16
+      - *pipeline_ncnn_static_fp32
 #      - *pipeline_pplnn_dynamic_fp32
 #      - *pipeline_openvino_dynamic_fp32
-#
-#  - name: ShuffleNetV2 # TODO Convert fail
-#    metafile: configs/shufflenet_v2/metafile.yml
-#    model_configs:
-#      - configs/shufflenet_v2/shufflenet-v2-1x_16xb64_in1k.py # TODO Not benchmark config
-#    pipelines:
-#      - *pipeline_ts_fp32
-#      - *pipeline_ort_dynamic_fp32
-#      - *pipeline_trt_dynamic_fp16
-#      - *pipeline_ncnn_static_fp32
+
+  - name: ShuffleNetV2
+    metafile: configs/shufflenet_v2/metafile.yml
+    model_configs:
+      - configs/shufflenet_v2/shufflenet-v2-1x_16xb64_in1k.py
+    pipelines:
+      - *pipeline_ts_fp32
+#      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_fp16
+      - *pipeline_ncnn_static_fp32
 #      - *pipeline_pplnn_dynamic_fp32
 #      - *pipeline_openvino_dynamic_fp32

--- a/configs/mmdet/detection/detection_openvino_dynamic-300x300.py
+++ b/configs/mmdet/detection/detection_openvino_dynamic-300x300.py
@@ -1,1 +1,1 @@
-_base_ = ['../_base_/base_openvino_dynamic.py']
+_base_ = ['../_base_/base_openvino_dynamic-300x300.py']

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -30,13 +30,13 @@ globals:
     test_img: *test_img
   backend_test: &default_backend_test True
   sdk:
-    sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmdet/detection/detection_sdk_dynamic.py
+    sdk_dynamic: &sdk_dynamic configs/mmdet/detection/detection_sdk_dynamic.py
 
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmdet/detection/detection_onnxruntime_static.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
@@ -71,25 +71,25 @@ tensorrt:
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmdet/detection/detection_tensorrt_dynamic-320x320-1344x1344.py
 
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmdet/detection/detection_tensorrt-fp16_dynamic-320x320-1344x1344.py
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmdet/detection/detection_tensorrt-int8_dynamic-320x320-1344x1344.py
 
   pipeline_seg_trt_dynamic_fp16: &pipeline_seg_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt-fp16_dynamic-320x320-1344x1344.py
 
 openvino:

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -16,8 +16,8 @@ globals:
       dataset: COCO # metafile.Results.Dataset
     mask AP:
       eval_name: segm
-      metric_key: '?'
-      tolerance: 0.1 # metric ±n%
+      metric_key: segm_mAP
+      tolerance: 1 # metric ±n%
       task_name: Instance Segmentation
       dataset: COCO
     PQ:
@@ -117,7 +117,7 @@ tensorrt:
   pipeline_seg_trt_dynamic_fp32: &pipeline_seg_trt_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_seg_dynamic
+#    sdk_config: *sdk_seg_dynamic
     deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt_dynamic-320x320-1344x1344.py
 
   pipeline_seg_trt_dynamic_fp16: &pipeline_seg_trt_dynamic_fp16
@@ -300,5 +300,5 @@ models:
     pipelines:
       - *pipeline_seg_ts_fp32
       - *pipeline_seg_ort_dynamic_fp32
-      - *pipeline_seg_trt_dynamic_fp16
+      - *pipeline_seg_trt_dynamic_fp32
       - *pipeline_seg_openvino_dynamic_fp32

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -4,9 +4,8 @@ globals:
   checkpoint_force_download: False
   checkpoint_dir: ../mmdeploy_checkpoints
   images:
-    img_coco_320x320: &img_coco_320x320 ./tests/data/tiger.jpeg
-    img_coco_300x300: &img_coco_300x300
-    img_coco_800x1344: &img_coco_800x1344
+    input_img: &input_img ../mmdetection/demo/demo.jpg
+    test_img: &test_img ./tests/data/tiger.jpeg
     img_blank: &img_blank
   metric_info: &metric_info
     box AP: # named after metafile.Results.Metrics
@@ -27,8 +26,8 @@ globals:
       tolerance: 0.1
       task_name: Panoptic Segmentation
   convert_image: &convert_image
-    input_img: *img_coco_320x320
-    test_img: *img_coco_300x300
+    input_img: *input_img
+    test_img: *test_img
   backend_test: &default_backend_test True
   sdk:
     sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmdet/detection/detection_sdk_dynamic.py
@@ -37,16 +36,36 @@ onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
     deploy_config: configs/mmdet/detection/detection_onnxruntime_static.py
+    backend_test: False
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
     convert_image: *convert_image
     deploy_config: configs/mmdet/detection/detection_onnxruntime_dynamic.py
+    backend_test: False
+
+  pipeline_seg_ort_static_fp32: &pipeline_seg_ort_static_fp32
+    convert_image: *convert_image
+    deploy_config: configs/mmdet/instance-seg/instance-seg_onnxruntime_static.py
+
+  pipeline_seg_ort_dynamic_fp32: &pipeline_seg_ort_dynamic_fp32
+    convert_image: *convert_image
+    deploy_config: configs/mmdet/instance-seg/instance-seg_onnxruntime_dynamic.py
 
 tensorrt:
   pipeline_trt_static_fp32: &pipeline_trt_static_fp32
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmdet/detection/detection_tensorrt_static-800x1344.py
+
+  pipeline_trt_static_fp16: &pipeline_trt_static_fp16
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmdet/detection/detection_tensorrt-fp16_static-800x1344.py
+
+  pipeline_trt_static_int8: &pipeline_trt_static_int8
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmdet/detection/detection_tensorrt-int8_static-800x1344.py
 
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
     convert_image: *convert_image
@@ -64,19 +83,25 @@ tensorrt:
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
-    deploy_config: configs/mmdet/detection/detection_tensorrt-int8_dynamic-300x300-512x512.py
+    deploy_config: configs/mmdet/detection/detection_tensorrt-int8_dynamic-320x320-1344x1344.py
+
+  pipeline_seg_trt_dynamic_fp16: &pipeline_seg_trt_dynamic_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt-fp16_dynamic-320x320-1344x1344.py
 
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    deploy_config: configs/mmdet/detection/detection_openvino_dynamic-300x300.py
+    deploy_config: configs/mmdet/detection/detection_openvino_dynamic-800x1344.py
 
 ncnn:
   pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32
     convert_image: *convert_image
     backend_test: False
-    deploy_config: configs/mmdet/detection/single-stage_ncnn_static-416x416.py
+    deploy_config: configs/mmdet/detection/single-stage_ncnn_static-800x1344.py
 
   pipeline_ncnn_dynamic_fp32: &pipeline_ncnn_dynamic_fp32
     convert_image: *convert_image
@@ -108,3 +133,18 @@ models:
       - *pipeline_ncnn_static_fp32
       - *pipeline_ppl_dynamic_fp32
       - *pipeline_ts_fp32
+  - name: ssd
+    metafile: configs/ssd/metafile.yml
+    model_configs:
+      - configs/ssd/ssd300_coco.py
+    pipelines: # special cases
+      - deploy_config: configs/mmdet/detection/detection_tensorrt-fp16_dynamic-300x300-512x512.py
+        convert_image: *convert_image
+      - deploy_config: configs/mmdet/detection/single-stage_ncnn_static-300x300.py
+        convert_image: *convert_image
+  - name: mask_rcnn
+    metafile: configs/mask_rcnn/metafile.yml
+    model_configs:
+      - configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py
+    pipelines:
+      - *pipeline_seg_trt_dynamic_fp16

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -31,7 +31,10 @@ globals:
     test_img: *test_img
   backend_test: &default_backend_test True
   sdk:
+    sdk_static: &sdk_static configs/mmdet/detection/detection_sdk_static.py
     sdk_dynamic: &sdk_dynamic configs/mmdet/detection/detection_sdk_dynamic.py
+#    sdk_seg_static: &sdk_seg_static configs/mmdet/instance-seg/instance-seg_sdk_static.py
+    sdk_seg_dynamic: &sdk_seg_dynamic configs/mmdet/instance-seg/instance-seg_sdk_dynamic.py
 
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
@@ -42,14 +45,20 @@ onnxruntime:
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
     convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmdet/detection/detection_onnxruntime_dynamic.py
 
   pipeline_seg_ort_static_fp32: &pipeline_seg_ort_static_fp32
     convert_image: *convert_image
+    backend_test: *default_backend_test
+#    sdk_config: *sdk_seg_static
     deploy_config: configs/mmdet/instance-seg/instance-seg_onnxruntime_static.py
 
   pipeline_seg_ort_dynamic_fp32: &pipeline_seg_ort_dynamic_fp32
     convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_seg_dynamic
     deploy_config: configs/mmdet/instance-seg/instance-seg_onnxruntime_dynamic.py
 
 tensorrt:
@@ -86,17 +95,53 @@ tensorrt:
     sdk_config: *sdk_dynamic
     deploy_config: configs/mmdet/detection/detection_tensorrt-int8_dynamic-320x320-1344x1344.py
 
+  # ============= seg ================
+  pipeline_seg_trt_static_fp32: &pipeline_seg_trt_static_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_seg_dynamic
+    deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt_static-800x1344.py
+
+  pipeline_seg_trt_static_fp16: &pipeline_seg_trt_static_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_seg_dynamic
+    deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt-fp16_static-800x1344.py
+
+  pipeline_seg_trt_static_int8: &pipeline_seg_trt_static_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_seg_dynamic
+    deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt-int8_static-800x1344.py
+
+  pipeline_seg_trt_dynamic_fp32: &pipeline_seg_trt_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_seg_dynamic
+    deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt_dynamic-320x320-1344x1344.py
+
   pipeline_seg_trt_dynamic_fp16: &pipeline_seg_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic
+    sdk_config: *sdk_seg_dynamic
     deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt-fp16_dynamic-320x320-1344x1344.py
+
+  pipeline_seg_trt_dynamic_int8: &pipeline_seg_trt_dynamic_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_seg_dynamic
+    deploy_config: configs/mmdet/instance-seg/instance-seg_tensorrt-int8_dynamic-320x320-1344x1344.py
 
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmdet/detection/detection_openvino_dynamic-800x1344.py
+
+  pipeline_seg_openvino_dynamic_fp32: &pipeline_seg_openvino_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmdet/instance-seg/instance-seg_openvino_dynamic-800x1344.py
 
 ncnn:
   pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32
@@ -115,12 +160,21 @@ pplnn:
     backend_test: *default_backend_test
     deploy_config: configs/mmdet/detection/detection_pplnn_dynamic-800x1344.py
 
+  pipeline_seg_pplnn_dynamic_fp32: &pipeline_seg_pplnn_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmdet/instance-seg/instance-seg_pplnn_dynamic-800x1344.py
+
 torchscript:
   pipeline_ts_fp32: &pipeline_ts_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmdet/detection/detection_torchscript.py
 
+  pipeline_seg_ts_fp32: &pipeline_seg_ts_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmdet/instance-seg/instance-seg_torchscript.py
 
 models:
   - name: YOLOV3
@@ -241,7 +295,7 @@ models:
     model_configs:
       - configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py
     pipelines:
-      - *pipeline_ts_fp32
-      - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_seg_ts_fp32
+#      - *pipeline_seg_ort_dynamic_fp32
+      - *pipeline_seg_trt_dynamic_fp16
+      - *pipeline_seg_openvino_dynamic_fp32

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -138,6 +138,7 @@ openvino:
     backend_test: False
     deploy_config: configs/mmdet/detection/detection_openvino_dynamic-800x1344.py
 
+  # ============= seg ================
   pipeline_seg_openvino_dynamic_fp32: &pipeline_seg_openvino_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
@@ -160,6 +161,7 @@ pplnn:
     backend_test: *default_backend_test
     deploy_config: configs/mmdet/detection/detection_pplnn_dynamic-800x1344.py
 
+  # ============= seg ================
   pipeline_seg_pplnn_dynamic_fp32: &pipeline_seg_pplnn_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
@@ -171,6 +173,7 @@ torchscript:
     backend_test: False
     deploy_config: configs/mmdet/detection/detection_torchscript.py
 
+  # ============= seg ================
   pipeline_seg_ts_fp32: &pipeline_seg_ts_fp32
     convert_image: *convert_image
     backend_test: False
@@ -296,6 +299,6 @@ models:
       - configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py
     pipelines:
       - *pipeline_seg_ts_fp32
-#      - *pipeline_seg_ort_dynamic_fp32
+      - *pipeline_seg_ort_dynamic_fp32
       - *pipeline_seg_trt_dynamic_fp16
       - *pipeline_seg_openvino_dynamic_fp32

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -128,84 +128,85 @@ models:
     model_configs:
       - configs/yolo/yolov3_d53_320_273e_coco.py
     pipelines:
-#      - *pipeline_ort_dynamic_fp32
+      - *pipeline_ts_fp32
+      - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
 #      - *pipeline_trt_dynamic_int8
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
 #      - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: SSD
     metafile: configs/ssd/metafile.yml
     model_configs:
       - configs/ssd/ssd300_coco.py
     pipelines: # special cases
+      - *pipeline_ts_fp32
       - *pipeline_ort_static_fp32
-#      - *pipeline_trt_static_fp32
       - deploy_config: configs/mmdet/detection/detection_tensorrt-fp16_dynamic-300x300-512x512.py
         convert_image: *convert_image
-#      - *pipeline_trt_static_int8
       - deploy_config: configs/mmdet/detection/single-stage_ncnn_static-300x300.py
         convert_image: *convert_image
-      - *pipeline_ts_fp32
+#      - *pipeline_openvino_static_fp32
 
   - name: RetinaNet
     metafile: configs/retinanet/metafile.yml
     model_configs:
       - configs/retinanet/retinanet_r50_fpn_1x_coco.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: FCOS
     metafile: configs/fcos/metafile.yml
     model_configs:
       - configs/fcos/fcos_r50_caffe_fpn_gn-head_1x_coco.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: FSAF
     metafile: configs/fsaf/metafile.yml
     model_configs:
       - configs/fsaf/fsaf_r50_fpn_1x_coco.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: YOLOX
     metafile: configs/yolox/metafile.yml
     model_configs:
       - configs/yolox/yolox_s_8x8_300e_coco.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: Faster R-CNN
     metafile: configs/faster_rcnn/metafile.yml
     model_configs:
       - configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_openvino_dynamic_fp32
-      - *pipeline_ts_fp32
 
   - name: ATSS
     metafile: configs/atss/metafile.yml
@@ -215,7 +216,6 @@ models:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
-      - *pipeline_ts_fp32
 
   - name: Cascade R-CNN
     metafile: configs/cascade_rcnn/metafile.yml
@@ -224,9 +224,8 @@ models:
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: GFL
     metafile: configs/gfl/metafile.yml
@@ -242,7 +241,7 @@ models:
     model_configs:
       - configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
-      - *pipeline_ts_fp32

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -25,6 +25,7 @@ globals:
       metric_key: '?'
       tolerance: 0.1
       task_name: Panoptic Segmentation
+      dataset: COCO
   convert_image: &convert_image
     input_img: *input_img
     test_img: *test_img

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -95,7 +95,7 @@ tensorrt:
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmdet/detection/detection_openvino_dynamic-800x1344.py
 
 ncnn:

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -11,19 +11,19 @@ globals:
     box AP: # named after metafile.Results.Metrics
       eval_name: bbox # test.py --metrics args
       metric_key: bbox_mAP # eval OrderedDict key name
-      tolerance: 0.2
+      tolerance: 0.2 # metric ±n%
       task_name: Object Detection # metafile.Results.Task
       dataset: COCO # metafile.Results.Dataset
     mask AP:
       eval_name: segm
       metric_key: '?'
-      tolerance: 0.1
+      tolerance: 0.1 # metric ±n%
       task_name: Instance Segmentation
       dataset: COCO
     PQ:
       eval_name: proposal
       metric_key: '?'
-      tolerance: 0.1
+      tolerance: 0.1 # metric ±n%
       task_name: Panoptic Segmentation
       dataset: COCO
   convert_image: &convert_image

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -67,9 +67,33 @@ tensorrt:
     deploy_config: configs/mmdet/detection/detection_tensorrt-int8_dynamic-300x300-512x512.py
 
 openvino:
+  pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmdet/detection/detection_openvino_dynamic-300x300.py
+
 ncnn:
+  pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmdet/detection/single-stage_ncnn_static-416x416.py
+
+  pipeline_ncnn_dynamic_fp32: &pipeline_ncnn_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmdet/detection/single-stage_ncnn_dynamic.py
+
 pplnn:
+  pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmdet/detection/detection_pplnn_dynamic-800x1344.py
+
 torchscript:
+  pipeline_ts_fp32: &pipeline_ts_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmdet/detection/detection_torchscript.py
 
 
 models:
@@ -81,3 +105,7 @@ models:
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -99,9 +99,8 @@ torchscript:
 models:
   - name: retinanet
     metafile: configs/retinanet/metafile.yml
-    codebase_model_config_dir: ./configs/retinanet
     model_configs:
-      - retinanet_r50_fpn_1x_coco.py
+      - configs/retinanet/retinanet_r50_fpn_1x_coco.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -42,7 +42,6 @@ onnxruntime:
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
     convert_image: *convert_image
     deploy_config: configs/mmdet/detection/detection_onnxruntime_dynamic.py
-    backend_test: False
 
   pipeline_seg_ort_static_fp32: &pipeline_seg_ort_static_fp32
     convert_image: *convert_image
@@ -118,7 +117,7 @@ pplnn:
 torchscript:
   pipeline_ts_fp32: &pipeline_ts_fp32
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmdet/detection/detection_torchscript.py
 
 

--- a/configs/mmdet/mmdet_regression_test.yaml
+++ b/configs/mmdet/mmdet_regression_test.yaml
@@ -11,7 +11,7 @@ globals:
     box AP: # named after metafile.Results.Metrics
       eval_name: bbox # test.py --metrics args
       metric_key: bbox_mAP # eval OrderedDict key name
-      tolerance: 0.1
+      tolerance: 0.2
       task_name: Object Detection # metafile.Results.Task
       dataset: COCO # metafile.Results.Dataset
     mask AP:
@@ -35,8 +35,9 @@ globals:
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmdet/detection/detection_onnxruntime_static.py
-    backend_test: False
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
     convert_image: *convert_image
@@ -109,7 +110,7 @@ ncnn:
     deploy_config: configs/mmdet/detection/single-stage_ncnn_dynamic.py
 
 pplnn:
-  pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
+  pipeline_pplnn_dynamic_fp32: &pipeline_pplnn_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
     deploy_config: configs/mmdet/detection/detection_pplnn_dynamic-800x1344.py
@@ -122,7 +123,35 @@ torchscript:
 
 
 models:
-  - name: retinanet
+  - name: YOLOV3
+    metafile: configs/yolo/metafile.yml
+    model_configs:
+      - configs/yolo/yolov3_d53_320_273e_coco.py
+    pipelines:
+#      - *pipeline_ort_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+#      - *pipeline_trt_dynamic_int8
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+#      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: SSD
+    metafile: configs/ssd/metafile.yml
+    model_configs:
+      - configs/ssd/ssd300_coco.py
+    pipelines: # special cases
+      - *pipeline_ort_static_fp32
+#      - *pipeline_trt_static_fp32
+      - deploy_config: configs/mmdet/detection/detection_tensorrt-fp16_dynamic-300x300-512x512.py
+        convert_image: *convert_image
+#      - *pipeline_trt_static_int8
+      - deploy_config: configs/mmdet/detection/single-stage_ncnn_static-300x300.py
+        convert_image: *convert_image
+      - *pipeline_ts_fp32
+
+  - name: RetinaNet
     metafile: configs/retinanet/metafile.yml
     model_configs:
       - configs/retinanet/retinanet_r50_fpn_1x_coco.py
@@ -131,20 +160,89 @@ models:
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32
-  - name: ssd
-    metafile: configs/ssd/metafile.yml
+
+  - name: FCOS
+    metafile: configs/fcos/metafile.yml
     model_configs:
-      - configs/ssd/ssd300_coco.py
-    pipelines: # special cases
-      - deploy_config: configs/mmdet/detection/detection_tensorrt-fp16_dynamic-300x300-512x512.py
-        convert_image: *convert_image
-      - deploy_config: configs/mmdet/detection/single-stage_ncnn_static-300x300.py
-        convert_image: *convert_image
-  - name: mask_rcnn
+      - configs/fcos/fcos_r50_caffe_fpn_gn-head_1x_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ts_fp32
+
+  - name: FSAF
+    metafile: configs/fsaf/metafile.yml
+    model_configs:
+      - configs/fsaf/fsaf_r50_fpn_1x_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: YOLOX
+    metafile: configs/yolox/metafile.yml
+    model_configs:
+      - configs/yolox/yolox_s_8x8_300e_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ts_fp32
+
+  - name: Faster R-CNN
+    metafile: configs/faster_rcnn/metafile.yml
+    model_configs:
+      - configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: ATSS
+    metafile: configs/atss/metafile.yml
+    model_configs:
+      - configs/atss/atss_r50_fpn_1x_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: Cascade R-CNN
+    metafile: configs/cascade_rcnn/metafile.yml
+    model_configs:
+      - configs/cascade_rcnn/cascade_rcnn_r50_caffe_fpn_1x_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: GFL
+    metafile: configs/gfl/metafile.yml
+    model_configs:
+      - configs/gfl/gfl_r50_fpn_1x_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: Mask R-CNN
     metafile: configs/mask_rcnn/metafile.yml
     model_configs:
       - configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py
     pipelines:
-      - *pipeline_seg_trt_dynamic_fp16
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ts_fp32

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -43,10 +43,28 @@ tensorrt:
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-fp16_dynamic-32x32-512x512.py
 
 openvino:
-ncnn:
-pplnn:
-torchscript:
+  pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmedit/super-resolution/super-resolution_openvino_dynamic-256x256.py
 
+ncnn:
+  pipeline_ncnn_dynamic_fp32: &pipeline_ncnn_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmedit/super-resolution/super-resolution_ncnn_dynamic.py
+
+pplnn:
+  pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmedit/super-resolution/super-resolution_pplnn_dynamic-32x32.py
+
+torchscript:
+  pipeline_ts_fp32: &pipeline_ts_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmedit/super-resolution/super-resolution_torchscript.py
 
 models:
   - name: srcnn
@@ -57,3 +75,7 @@ models:
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_dynamic_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -104,14 +104,14 @@ models:
     model_configs:
       - configs/restorers/srcnn/srcnn_x4k915_g1_1000k_div2k.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
 #      - *pipeline_trt_dynamic_int8
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_dynamic_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: ESRGAN
     metafile: configs/restorers/esrgan/metafile.yml
@@ -119,12 +119,12 @@ models:
       - configs/restorers/esrgan/esrgan_x4c64b23g32_g1_400k_div2k.py
       - configs/restorers/esrgan/esrgan_psnr_x4c64b23g32_g1_1000k_div2k.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_dynamic_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: SRGAN
     metafile: configs/restorers/srresnet_srgan/metafile.yml
@@ -132,32 +132,32 @@ models:
       - configs/restorers/srresnet_srgan/srgan_x4c64b16_g1_1000k_div2k.py
       - configs/restorers/srresnet_srgan/msrresnet_x4c64b16_g1_1000k_div2k.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_dynamic_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: Real-ESRNet
     metafile: configs/restorers/real_esrgan/metafile.yml
     model_configs:
       - configs/restorers/real_esrgan/realesrnet_c64b23g32_12x4_lr2e-4_1000k_df2k_ost.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_dynamic_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: EDSR
     metafile: configs/restorers/edsr/metafile.yml
     model_configs:
       - configs/restorers/edsr/edsr_x4c64b16_g1_300k_div2k.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -85,7 +85,7 @@ ncnn:
     deploy_config: configs/mmedit/super-resolution/super-resolution_ncnn_dynamic.py
 
 pplnn:
-  pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
+  pipeline_pplnn_dynamic_fp32: &pipeline_pplnn_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmedit/super-resolution/super-resolution_pplnn_dynamic-32x32.py
@@ -106,5 +106,5 @@ models:
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_dynamic_fp32
-      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -10,13 +10,13 @@ globals:
     PSNR: # named after metafile.Results.Metrics
       eval_name: PSNR # test.py --metrics args
       metric_key: Eval-PSNR # eval log key name
-      tolerance: 0.4
+      tolerance: 4 # metric ±n%
       task_name: Restorers # metafile.Results.Task
       dataset: Set5 # metafile.Results.Dataset
     SSIM:
       eval_name: SSIM
       metric_key: Eval-SSIM
-      tolerance: 0.02
+      tolerance: 0.02 # metric ±n
       task_name: Restorers
       dataset: Set5
   convert_image: &convert_image

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -10,13 +10,13 @@ globals:
     PSNR: # named after metafile.Results.Metrics
       eval_name: PSNR # test.py --metrics args
       metric_key: Eval-PSNR # eval log key name
-      tolerance: 1
+      tolerance: 0.4
       task_name: Restorers # metafile.Results.Task
       dataset: DIV2K # metafile.Results.Dataset
     SSIM:
       eval_name: SSIM
       metric_key: Eval-SSIM
-      tolerance: 0.1
+      tolerance: 0.02
       task_name: Restorers
       dataset: DIV2K
   convert_image: &convert_image
@@ -29,6 +29,8 @@ globals:
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmedit/super-resolution/super-resolution_onnxruntime_static.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
@@ -75,7 +77,7 @@ tensorrt:
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmedit/super-resolution/super-resolution_openvino_dynamic-256x256.py
 
 ncnn:
@@ -97,14 +99,65 @@ torchscript:
     deploy_config: configs/mmedit/super-resolution/super-resolution_torchscript.py
 
 models:
-  - name: srcnn
+  - name: SRCNN
     metafile: configs/restorers/srcnn/metafile.yml
     model_configs:
       - configs/restorers/srcnn/srcnn_x4k915_g1_1000k_div2k.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+#      - *pipeline_trt_dynamic_int8
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: ESRGAN
+    metafile: configs/restorers/esrgan/metafile.yml
+    model_configs:
+      - configs/restorers/esrgan/esrgan_x4c64b23g32_g1_400k_div2k.py
+      - configs/restorers/esrgan/esrgan_psnr_x4c64b23g32_g1_1000k_div2k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_dynamic_fp32
       - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: SRGAN
+    metafile: configs/restorers/srresnet_srgan/metafile.yml
+    model_configs:
+      - configs/restorers/srresnet_srgan/srgan_x4c64b16_g1_1000k_div2k.py
+      - configs/restorers/srresnet_srgan/msrresnet_x4c64b16_g1_1000k_div2k.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: Real-ESRNet
+    metafile: configs/restorers/real_esrgan/metafile.yml
+    model_configs:
+      - configs/restorers/real_esrgan/realesrnet_c64b23g32_12x4_lr2e-4_1000k_df2k_ost.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: EDSR
+    metafile: configs/restorers/edsr/metafile.yml
+    model_configs:
+      - configs/restorers/edsr/edsr_x4c64b16_g1_300k_div2k.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_dynamic_fp32
       - *pipeline_ts_fp32

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -36,11 +36,41 @@ onnxruntime:
     deploy_config: configs/mmedit/super-resolution/super-resolution_onnxruntime_dynamic.py
 
 tensorrt:
+  pipeline_trt_static_fp32: &pipeline_trt_static_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt_static-256x256.py
+
+  pipeline_trt_static_fp16: &pipeline_trt_static_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-fp16_static-256x256.py
+
+  pipeline_trt_static_int8: &pipeline_trt_static_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-int8_static-256x256.py
+
+  pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt_dynamic-32x32-512x512.py
+
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-fp16_dynamic-32x32-512x512.py
+
+  pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-int8_dynamic-32x32-512x512.py
 
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -24,13 +24,13 @@ globals:
     test_img: *img_bg
   backend_test: &default_backend_test True
   sdk:
-    sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmedit/super-resolution/super-resolution_sdk_dynamic.py
+    sdk_dynamic: &sdk_dynamic configs/mmedit/super-resolution/super-resolution_sdk_dynamic.py
 
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmedit/super-resolution/super-resolution_onnxruntime_static.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
@@ -41,37 +41,37 @@ tensorrt:
   pipeline_trt_static_fp32: &pipeline_trt_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt_static-256x256.py
 
   pipeline_trt_static_fp16: &pipeline_trt_static_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-fp16_static-256x256.py
 
   pipeline_trt_static_int8: &pipeline_trt_static_int8
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-int8_static-256x256.py
 
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt_dynamic-32x32-512x512.py
 
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-fp16_dynamic-32x32-512x512.py
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmedit/super-resolution/super-resolution_tensorrt-int8_dynamic-32x32-512x512.py
 
 openvino:

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -69,9 +69,8 @@ torchscript:
 models:
   - name: srcnn
     metafile: configs/restorers/srcnn/metafile.yml
-    codebase_model_config_dir: configs/restorers/srcnn
     model_configs:
-      - srcnn_x4k915_g1_1000k_div2k.py
+      - configs/restorers/srcnn/srcnn_x4k915_g1_1000k_div2k.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -4,8 +4,8 @@ globals:
   checkpoint_force_download: False
   checkpoint_dir: ../mmdeploy_checkpoints
   images:
-    img_320x320: &img_320x320 ./tests/data/tiger.jpeg
-    img_blank: &img_blank
+    img_face: &img_face ../mmediting/tests/data/face/000001.png
+    img_bg: &img_bg ../mmediting/tests/data/bg/GT26r.jpg
   metric_info: &metric_info
     PSNR: # named after metafile.Results.Metrics
       eval_name: PSNR # test.py --metrics args
@@ -20,8 +20,8 @@ globals:
       task_name: Restorers
       dataset: DIV2K
   convert_image: &convert_image
-    input_img: *img_320x320
-    test_img: *img_blank
+    input_img: *img_face
+    test_img: *img_bg
   backend_test: &default_backend_test True
   sdk:
     sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmedit/super-resolution/super-resolution_sdk_dynamic.py

--- a/configs/mmedit/mmedit_regression_test.yaml
+++ b/configs/mmedit/mmedit_regression_test.yaml
@@ -12,13 +12,13 @@ globals:
       metric_key: Eval-PSNR # eval log key name
       tolerance: 0.4
       task_name: Restorers # metafile.Results.Task
-      dataset: DIV2K # metafile.Results.Dataset
+      dataset: Set5 # metafile.Results.Dataset
     SSIM:
       eval_name: SSIM
       metric_key: Eval-SSIM
       tolerance: 0.02
       task_name: Restorers
-      dataset: DIV2K
+      dataset: Set5
   convert_image: &convert_image
     input_img: *img_face
     test_img: *img_bg
@@ -95,7 +95,7 @@ pplnn:
 torchscript:
   pipeline_ts_fp32: &pipeline_ts_fp32
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmedit/super-resolution/super-resolution_torchscript.py
 
 models:

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -4,10 +4,10 @@ globals:
   checkpoint_force_download: False
   checkpoint_dir: ../mmdeploy_checkpoints
   images:
-    img_224x224: &img_224x224 ./tests/data/tiger.jpeg
-    img_300x300: &img_300x300
-    img_800x1344: &img_cityscapes_800x1344
-    img_blank: &img_blank
+    img_densetext_det: &img_densetext_det ../mmocr/demo/demo_densetext_det.jpg
+    img_demo_text_det: &img_demo_text_det ../mmocr/demo/demo_text_det.jpg
+    img_demo_text_ocr: &img_demo_text_ocr ../mmocr/demo/demo_text_ocr.jpg
+    img_demo_text_recog: &img_demo_text_recog ../mmocr/demo/demo_text_recog.jpg
   metric_info: &metric_info
     hmean-iou: # named after metafile.Results.Metrics
       eval_name: hmean-iou # test.py --metrics args
@@ -21,9 +21,12 @@ globals:
       tolerance: 0.2
       task_name: Text Recognition
       dataset: IIIT5K
-  convert_image: &convert_image
-    input_img: *img_224x224
-    test_img: *img_300x300
+  convert_image_det: &convert_image_det
+    input_img: *img_densetext_det
+    test_img: *img_demo_text_det
+  convert_image_rec: &convert_image_rec
+    input_img: *img_demo_text_recog
+    test_img: *img_demo_text_recog
   backend_test: &default_backend_test True
   sdk:
     sdk_detection_dynamic: &sdk_detection_dynamic configs/mmocr/text-detection/text-detection_sdk_dynamic.py
@@ -32,22 +35,22 @@ globals:
 onnxruntime:
   # ======= detection =======
   pipeline_ort_detection_static_fp32: &pipeline_ort_detection_static_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     deploy_config: configs/mmocr/text-detection/text-detection_onnxruntime_static.py
 
   pipeline_ort_detection_dynamic_fp32: &pipeline_ort_detection_dynamic_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_onnxruntime_dynamic.py
 
   # ======= recognition =======
   pipeline_ort_recognition_static_fp32: &pipeline_ort_recognition_static_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_static.py
 
   pipeline_ort_recognition_dynamic_fp32: &pipeline_ort_recognition_dynamic_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_dynamic.py
@@ -55,119 +58,119 @@ onnxruntime:
 tensorrt:
   # ======= detection =======
   pipeline_trt_detection_static_fp32: &pipeline_trt_detection_static_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt_static-512x512.py
 
   pipeline_trt_detection_static_fp16: &pipeline_trt_detection_static_fp16
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-fp16_static-512x512.py
 
   pipeline_trt_detection_static_int8: &pipeline_trt_detection_static_int8
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-int8_static-512x512.py
 
   pipeline_trt_detection_dynamic_fp32: &pipeline_trt_detection_dynamic_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt_dynamic-320x320-1024x1824.py
 
   pipeline_trt_detection_dynamic_fp16: &pipeline_trt_detection_dynamic_fp16
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-fp16_dynamic-320x320-1024x1824.py
 
   pipeline_trt_detection_dynamic_int8: &pipeline_trt_detection_dynamic_int8
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-int8_dynamic-320x320-1024x1824.py
 
   # ======= recognition =======
   pipeline_trt_recognition_static_fp32: &pipeline_trt_recognition_static_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt_static-1x32x32.py
 
   pipeline_trt_recognition_static_fp16: &pipeline_trt_recognition_static_fp16
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-fp16_static-1x32x32.py
 
   pipeline_trt_recognition_static_int8: &pipeline_trt_recognition_static_int8
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-int8_static-1x32x32.py
 
   pipeline_trt_recognition_dynamic_fp32: &pipeline_trt_recognition_dynamic_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt_dynamic-1x32x32-1x32x640.py
 
   pipeline_trt_recognition_dynamic_fp16: &pipeline_trt_recognition_dynamic_fp16
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-fp16_dynamic-1x32x32-1x32x640.py
 
   pipeline_trt_recognition_dynamic_int8: &pipeline_trt_recognition_dynamic_int8
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-int8_dynamic-1x32x32-1x32x640.py
 
 openvino:
   pipeline_openvino_detection_dynamic_fp32: &pipeline_openvino_detection_dynamic_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     deploy_config: configs/mmocr/text-detection/text-detection_openvino_dynamic-640x640.py
 
 #  pipeline_openvino_recognition_dynamic_fp32: &pipeline_openvino_recognition_dynamic_fp32
-#    convert_image: *convert_image
+#    convert_image: *convert_image_rec
 #    backend_test: *default_backend_test
 #    deploy_config:
 
 ncnn:
   pipeline_ncnn_detection_static_fp32: &pipeline_ncnn_detection_static_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: False
     deploy_config: configs/mmocr/text-detection/text-detection_ncnn_static.py
 
   pipeline_ncnn_recognition_static_fp32: &pipeline_ncnn_recognition_static_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: False
     deploy_config: configs/mmocr/text-recognition/text-recognition_ncnn_static.py
 
 pplnn:
   pipeline_pplnn_detection_dynamic_fp32: &pipeline_pplnn_detection_dynamic_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: False
     deploy_config: configs/mmocr/text-detection/text-detection_pplnn_dynamic-640x640.py
 
   pipeline_pplnn_recognition_dynamic_fp32: &pipeline_pplnn_recognition_dynamic_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: False
     deploy_config: configs/mmocr/text-recognition/text-recognition_pplnn_dynamic-1x32x32.py
 
 torchscript:
   pipeline_ts_detection_fp32: &pipeline_ts_detection_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_det
     backend_test: *default_backend_test
     deploy_config: configs/mmocr/text-detection/text-detection_torchscript.py
 
   pipeline_ts_recognition_fp32: &pipeline_ts_recognition_fp32
-    convert_image: *convert_image
+    convert_image: *convert_image_rec
     backend_test: *default_backend_test
     deploy_config: configs/mmocr/text-recognition/text-recognition_torchscript.py
 

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -58,9 +58,28 @@ tensorrt:
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-fp16_dynamic-320x320-1024x1824.py
 
 openvino:
+  pipeline_openvino_detection_dynamic_fp32: &pipeline_openvino_detection_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmocr/text-detection/text-detection_openvino_dynamic-640x640.py
+
 ncnn:
+  pipeline_ncnn_detection_static_fp32: &pipeline_ncnn_detection_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmocr/text-detection/text-detection_ncnn_static.py
+
 pplnn:
+  pipeline_ppl_detection_dynamic_fp32: &pipeline_ppl_detection_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmocr/text-detection/text-detection_pplnn_dynamic-640x640.py
+
 torchscript:
+  pipeline_ts_detection_fp32: &pipeline_ts_detection_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmocr/text-detection/text-detection_torchscript.py
 
 
 models:
@@ -80,3 +99,7 @@ models:
     pipelines:
       - *pipeline_ort_detection_dynamic_fp32
       - *pipeline_trt_detection_dynamic_fp16
+      - *pipeline_openvino_detection_dynamic_fp32
+      - *pipeline_ncnn_detection_static_fp32
+      - *pipeline_ppl_detection_dynamic_fp32
+      - *pipeline_ts_detection_fp32

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -42,8 +42,6 @@ onnxruntime:
 
   pipeline_ort_detection_dynamic_fp32: &pipeline_ort_detection_dynamic_fp32
     convert_image: *convert_image_det
-    backend_test: *default_backend_test
-    sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_onnxruntime_dynamic.py
 
   # ======= recognition =======
@@ -53,8 +51,6 @@ onnxruntime:
 
   pipeline_ort_recognition_dynamic_fp32: &pipeline_ort_recognition_dynamic_fp32
     convert_image: *convert_image_rec
-    backend_test: *default_backend_test
-    sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_dynamic.py
 
 tensorrt:
@@ -168,12 +164,12 @@ pplnn:
 torchscript:
   pipeline_ts_detection_fp32: &pipeline_ts_detection_fp32
     convert_image: *convert_image_det
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmocr/text-detection/text-detection_torchscript.py
 
   pipeline_ts_recognition_fp32: &pipeline_ts_recognition_fp32
     convert_image: *convert_image_rec
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmocr/text-recognition/text-recognition_torchscript.py
 
 

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -12,13 +12,13 @@ globals:
     hmean-iou: # named after metafile.Results.Metrics
       eval_name: hmean-iou # test.py --metrics args
       metric_key: 0_hmean-iou:hmean # eval key name
-      tolerance: 0.1
+      tolerance: 1.5
       task_name: Text Detection # metafile.Results.Task
       dataset: ICDAR2015 # metafile.Results.Dataset
     word_acc:
       eval_name: acc
       metric_key: 0_word_acc_ignore_case
-      tolerance: 0.2
+      tolerance: 0.05
       task_name: Text Recognition
       dataset: IIIT5K
   convert_image_det: &convert_image_det
@@ -36,6 +36,8 @@ onnxruntime:
   # ======= detection =======
   pipeline_ort_detection_static_fp32: &pipeline_ort_detection_static_fp32
     convert_image: *convert_image_det
+    backend_test: *default_backend_test
+    sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_onnxruntime_static.py
 
   pipeline_ort_detection_dynamic_fp32: &pipeline_ort_detection_dynamic_fp32
@@ -176,21 +178,35 @@ torchscript:
 
 
 models:
-  - name: crnn
-    metafile: configs/textrecog/crnn/metafile.yml
-    model_configs:
-      - configs/textrecog/crnn/crnn_academic_dataset.py
-    pipelines:
-      - *pipeline_ort_recognition_dynamic_fp32
-
-  - name: dbnet
+  - name: DBNet
     metafile: configs/textdet/dbnet/metafile.yml
     model_configs:
       - configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
     pipelines:
       - *pipeline_ort_detection_dynamic_fp32
+#      - *pipeline_trt_detection_dynamic_fp32
       - *pipeline_trt_detection_dynamic_fp16
+#      - *pipeline_trt_detection_dynamic_int8
       - *pipeline_openvino_detection_dynamic_fp32
       - *pipeline_ncnn_detection_static_fp32
       - *pipeline_pplnn_detection_dynamic_fp32
       - *pipeline_ts_detection_fp32
+
+  - name: CRNN
+    metafile: configs/textrecog/crnn/metafile.yml
+    model_configs:
+      - configs/textrecog/crnn/crnn_academic_dataset.py
+    pipelines:
+      - *pipeline_ort_recognition_dynamic_fp32
+      - *pipeline_trt_recognition_dynamic_fp16
+#      - *pipeline_openvino_recognition_dynamic_fp32
+      - *pipeline_ncnn_recognition_static_fp32
+      - *pipeline_pplnn_recognition_dynamic_fp32
+      - *pipeline_ts_recognition_fp32
+
+  - name: SAR
+    metafile: configs/textrecog/sar/metafile.yml
+    model_configs:
+      - configs/textrecog/sar/sar_r31_parallel_decoder_academic.py
+    pipelines:
+      - *pipeline_ort_recognition_dynamic_fp32

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -12,13 +12,13 @@ globals:
     hmean-iou: # named after metafile.Results.Metrics
       eval_name: hmean-iou # test.py --metrics args
       metric_key: 0_hmean-iou:hmean # eval key name
-      tolerance: 1.5
+      tolerance: 0.15 # metric ±n%
       task_name: Text Detection # metafile.Results.Task
       dataset: ICDAR2015 # metafile.Results.Dataset
     word_acc:
       eval_name: acc
       metric_key: 0_word_acc_ignore_case
-      tolerance: 0.05
+      tolerance: 0.05 # metric ±n%
       task_name: Text Recognition
       dataset: IIIT5K
   convert_image_det: &convert_image_det

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -183,26 +183,25 @@ models:
     model_configs:
       - configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
     pipelines:
+      - *pipeline_ts_detection_fp32
       - *pipeline_ort_detection_dynamic_fp32
 #      - *pipeline_trt_detection_dynamic_fp32
       - *pipeline_trt_detection_dynamic_fp16
 #      - *pipeline_trt_detection_dynamic_int8
-      - *pipeline_openvino_detection_dynamic_fp32
       - *pipeline_ncnn_detection_static_fp32
       - *pipeline_pplnn_detection_dynamic_fp32
-      - *pipeline_ts_detection_fp32
+      - *pipeline_openvino_detection_dynamic_fp32
 
   - name: CRNN
     metafile: configs/textrecog/crnn/metafile.yml
     model_configs:
       - configs/textrecog/crnn/crnn_academic_dataset.py
     pipelines:
+      - *pipeline_ts_recognition_fp32
       - *pipeline_ort_recognition_dynamic_fp32
       - *pipeline_trt_recognition_dynamic_fp16
-#      - *pipeline_openvino_recognition_dynamic_fp32
       - *pipeline_ncnn_recognition_static_fp32
       - *pipeline_pplnn_recognition_dynamic_fp32
-      - *pipeline_ts_recognition_fp32
 
   - name: SAR
     metafile: configs/textrecog/sar/metafile.yml

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -85,17 +85,15 @@ torchscript:
 models:
   - name: crnn
     metafile: configs/textrecog/crnn/metafile.yml
-    codebase_model_config_dir: configs/textrecog/crnn
     model_configs:
-      - crnn_academic_dataset.py
+      - configs/textrecog/crnn/crnn_academic_dataset.py
     pipelines:
       - *pipeline_ort_recognition_dynamic_fp32
 
   - name: dbnet
     metafile: configs/textdet/dbnet/metafile.yml
-    codebase_model_config_dir: configs/textdet/dbnet
     model_configs:
-      - dbnet_r18_fpnc_1200e_icdar2015.py
+      - configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
     pipelines:
       - *pipeline_ort_detection_dynamic_fp32
       - *pipeline_trt_detection_dynamic_fp16

--- a/configs/mmocr/mmocr_regression_test.yaml
+++ b/configs/mmocr/mmocr_regression_test.yaml
@@ -26,10 +26,22 @@ globals:
     test_img: *img_300x300
   backend_test: &default_backend_test True
   sdk:
-    sdk_detection_dynamic_fp32: &sdk_detection_dynamic_fp32 configs/mmocr/text-detection/text-detection_sdk_dynamic.py
-    sdk_recognition_dynamic_fp32: &sdk_recognition_dynamic_fp32 configs/mmocr/text-recognition/text-recognition_sdk_dynamic.py
+    sdk_detection_dynamic: &sdk_detection_dynamic configs/mmocr/text-detection/text-detection_sdk_dynamic.py
+    sdk_recognition_dynamic: &sdk_recognition_dynamic configs/mmocr/text-recognition/text-recognition_sdk_dynamic.py
 
 onnxruntime:
+  # ======= detection =======
+  pipeline_ort_detection_static_fp32: &pipeline_ort_detection_static_fp32
+    convert_image: *convert_image
+    deploy_config: configs/mmocr/text-detection/text-detection_onnxruntime_static.py
+
+  pipeline_ort_detection_dynamic_fp32: &pipeline_ort_detection_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_recognition_dynamic
+    deploy_config: configs/mmocr/text-detection/text-detection_onnxruntime_dynamic.py
+
+  # ======= recognition =======
   pipeline_ort_recognition_static_fp32: &pipeline_ort_recognition_static_fp32
     convert_image: *convert_image
     deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_static.py
@@ -37,25 +49,83 @@ onnxruntime:
   pipeline_ort_recognition_dynamic_fp32: &pipeline_ort_recognition_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_recognition_dynamic_fp32
+    sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_dynamic.py
 
-  pipeline_ort_detection_dynamic_fp32: &pipeline_ort_detection_dynamic_fp32
-    convert_image: *convert_image
-    deploy_config: configs/mmocr/text-detection/text-detection_onnxruntime_dynamic.py
-
 tensorrt:
-  pipeline_trt_recognition_dynamic_fp16: &pipeline_trt_recognition_dynamic_fp16
+  # ======= detection =======
+  pipeline_trt_detection_static_fp32: &pipeline_trt_detection_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_recognition_dynamic_fp32
-    deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-fp16_dynamic-1x32x32-1x32x640.py
+    sdk_config: *sdk_detection_dynamic
+    deploy_config: configs/mmocr/text-detection/text-detection_tensorrt_static-512x512.py
+
+  pipeline_trt_detection_static_fp16: &pipeline_trt_detection_static_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_detection_dynamic
+    deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-fp16_static-512x512.py
+
+  pipeline_trt_detection_static_int8: &pipeline_trt_detection_static_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_detection_dynamic
+    deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-int8_static-512x512.py
+
+  pipeline_trt_detection_dynamic_fp32: &pipeline_trt_detection_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_detection_dynamic
+    deploy_config: configs/mmocr/text-detection/text-detection_tensorrt_dynamic-320x320-1024x1824.py
 
   pipeline_trt_detection_dynamic_fp16: &pipeline_trt_detection_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_detection_dynamic_fp32
+    sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-fp16_dynamic-320x320-1024x1824.py
+
+  pipeline_trt_detection_dynamic_int8: &pipeline_trt_detection_dynamic_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_detection_dynamic
+    deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-int8_dynamic-320x320-1024x1824.py
+
+  # ======= recognition =======
+  pipeline_trt_recognition_static_fp32: &pipeline_trt_recognition_static_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_recognition_dynamic
+    deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt_static-1x32x32.py
+
+  pipeline_trt_recognition_static_fp16: &pipeline_trt_recognition_static_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_recognition_dynamic
+    deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-fp16_static-1x32x32.py
+
+  pipeline_trt_recognition_static_int8: &pipeline_trt_recognition_static_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_recognition_dynamic
+    deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-int8_static-1x32x32.py
+
+  pipeline_trt_recognition_dynamic_fp32: &pipeline_trt_recognition_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_recognition_dynamic
+    deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt_dynamic-1x32x32-1x32x640.py
+
+  pipeline_trt_recognition_dynamic_fp16: &pipeline_trt_recognition_dynamic_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_recognition_dynamic
+    deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-fp16_dynamic-1x32x32-1x32x640.py
+
+  pipeline_trt_recognition_dynamic_int8: &pipeline_trt_recognition_dynamic_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_recognition_dynamic
+    deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-int8_dynamic-1x32x32-1x32x640.py
 
 openvino:
   pipeline_openvino_detection_dynamic_fp32: &pipeline_openvino_detection_dynamic_fp32
@@ -63,23 +133,43 @@ openvino:
     backend_test: *default_backend_test
     deploy_config: configs/mmocr/text-detection/text-detection_openvino_dynamic-640x640.py
 
+#  pipeline_openvino_recognition_dynamic_fp32: &pipeline_openvino_recognition_dynamic_fp32
+#    convert_image: *convert_image
+#    backend_test: *default_backend_test
+#    deploy_config:
+
 ncnn:
   pipeline_ncnn_detection_static_fp32: &pipeline_ncnn_detection_static_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmocr/text-detection/text-detection_ncnn_static.py
 
+  pipeline_ncnn_recognition_static_fp32: &pipeline_ncnn_recognition_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmocr/text-recognition/text-recognition_ncnn_static.py
+
 pplnn:
-  pipeline_ppl_detection_dynamic_fp32: &pipeline_ppl_detection_dynamic_fp32
+  pipeline_pplnn_detection_dynamic_fp32: &pipeline_pplnn_detection_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmocr/text-detection/text-detection_pplnn_dynamic-640x640.py
+
+  pipeline_pplnn_recognition_dynamic_fp32: &pipeline_pplnn_recognition_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmocr/text-recognition/text-recognition_pplnn_dynamic-1x32x32.py
 
 torchscript:
   pipeline_ts_detection_fp32: &pipeline_ts_detection_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
     deploy_config: configs/mmocr/text-detection/text-detection_torchscript.py
+
+  pipeline_ts_recognition_fp32: &pipeline_ts_recognition_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmocr/text-recognition/text-recognition_torchscript.py
 
 
 models:
@@ -99,5 +189,5 @@ models:
       - *pipeline_trt_detection_dynamic_fp16
       - *pipeline_openvino_detection_dynamic_fp32
       - *pipeline_ncnn_detection_static_fp32
-      - *pipeline_ppl_detection_dynamic_fp32
+      - *pipeline_pplnn_detection_dynamic_fp32
       - *pipeline_ts_detection_fp32

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -25,7 +25,7 @@ globals:
     test_img: *img_human_pose_256x192
   backend_test: &default_backend_test True
   sdk:
-    sdk_static_fp32: &sdk_static_fp32 configs/mmpose/pose-detection_sdk_static.py
+    sdk_static: &sdk_static configs/mmpose/pose-detection_sdk_static.py
 
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
@@ -36,17 +36,17 @@ tensorrt:
   pipeline_trt_static_fp32: &pipeline_trt_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_static_fp32
+    sdk_config: *sdk_static
     deploy_config: configs/mmpose/pose-detection_tensorrt_static-256x192.py
   pipeline_trt_static_fp16: &pipeline_trt_static_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_static_fp32
+    sdk_config: *sdk_static
     deploy_config: configs/mmpose/pose-detection_tensorrt-fp16_static-256x192.py
   pipeline_trt_static_int8: &pipeline_trt_static_int8
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_static_fp32
+    sdk_config: *sdk_static
     deploy_config: configs/mmpose/pose-detection_tensorrt-int8_static-256x192.py
 
 openvino:

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -62,7 +62,7 @@ ncnn:
     deploy_config: configs/mmpose/pose-detection_ncnn_static-256x192.py
 
 pplnn:
-  pipeline_ppl_static_fp32: &pipeline_ppl_static_fp32
+  pipeline_pplnn_static_fp32: &pipeline_pplnn_static_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmpose/pose-detection_pplnn_static-256x192.py
@@ -74,7 +74,7 @@ torchscript:
     deploy_config: configs/mmpose/pose-detection_torchscript.py
 
 models:
-  - name: hrnet
+  - name: HRNET
     metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_coco.yml
     model_configs:
       - configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192.py
@@ -83,10 +83,8 @@ models:
       - *pipeline_trt_static_fp16
       - *pipeline_openvino_static_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_static_fp32
-      - *pipeline_ts_fp32
 
-  - name: litehrnet
+  - name: LiteHRNet
     metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_coco.yml
     model_configs:
       - configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_30_coco_256x192.py
@@ -94,10 +92,8 @@ models:
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp32
       - *pipeline_openvino_static_fp32
-      - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_static_fp32
 
-  - name: mspn
+  - name: MSPN
     metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn_coco.yml
     model_configs:
       - configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/4xmspn50_coco_256x192.py
@@ -106,4 +102,3 @@ models:
       - *pipeline_trt_static_fp16
       - *pipeline_openvino_static_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_static_fp32

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -4,9 +4,8 @@ globals:
   checkpoint_force_download: False
   checkpoint_dir: ../mmdeploy_checkpoints
   images:
-    img_224x224: &img_224x224 ./tests/data/tiger.jpeg
-    img_300x300: &img_300x300
-    img_800x1344: &img_800x1344
+    img_human_pose: &img_human_pose ../mmpose/tests/data/coco/000000000785.jpg
+    img_human_pose_256x192: &img_human_pose_256x192 ./demo/resources/human-pose.jpg
     img_blank: &img_blank
   metric_info: &metric_info
     AP: # named after metafile.Results.Metrics
@@ -22,8 +21,8 @@ globals:
       task_name: Body 2D Keypoint
       dataset:
   convert_image: &convert_image
-    input_img: *img_224x224
-    test_img: *img_300x300
+    input_img: *img_human_pose
+    test_img: *img_human_pose_256x192
   backend_test: &default_backend_test True
   sdk:
     sdk_static_fp32: &sdk_static_fp32 configs/mmpose/pose-detection_sdk_static.py
@@ -34,11 +33,21 @@ onnxruntime:
     deploy_config: configs/mmpose/pose-detection_onnxruntime_static.py
 
 tensorrt:
+  pipeline_trt_static_fp32: &pipeline_trt_static_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_static_fp32
+    deploy_config: configs/mmpose/pose-detection_tensorrt_static-256x192.py
   pipeline_trt_static_fp16: &pipeline_trt_static_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_static_fp32
     deploy_config: configs/mmpose/pose-detection_tensorrt-fp16_static-256x192.py
+  pipeline_trt_static_int8: &pipeline_trt_static_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_static_fp32
+    deploy_config: configs/mmpose/pose-detection_tensorrt-int8_static-256x192.py
 
 openvino:
   pipeline_openvino_static_fp32: &pipeline_openvino_static_fp32
@@ -59,13 +68,39 @@ pplnn:
     deploy_config: configs/mmpose/pose-detection_pplnn_static-256x192.py
 
 torchscript:
-
+  pipeline_ts_static_fp32: &pipeline_ts_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmpose/pose-detection_torchscript.py
 
 models:
   - name: hrnet
     metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_coco.yml
     model_configs:
       - configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192.py
+    pipelines:
+      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_fp16
+      - *pipeline_openvino_static_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_static_fp32
+      - *pipeline_ts_fp32
+
+  - name: litehrnet
+    metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_coco.yml
+    model_configs:
+      - configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_30_coco_256x192.py
+    pipelines:
+      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_fp32
+      - *pipeline_openvino_static_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_static_fp32
+
+  - name: mspn
+    metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/mspn_coco.yml
+    model_configs:
+      - configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/4xmspn50_coco_256x192.py
     pipelines:
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp16

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -81,8 +81,8 @@ models:
     pipelines:
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp16
-      - *pipeline_openvino_static_fp32
       - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_static_fp32
 
   - name: LiteHRNet
     metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/litehrnet_coco.yml
@@ -100,5 +100,5 @@ models:
     pipelines:
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp16
-      - *pipeline_openvino_static_fp32
       - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_static_fp32

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -13,13 +13,13 @@ globals:
       metric_key: AP # eval OrderedDict key name
       tolerance: 0.01
       task_name: Body 2D Keypoint # metafile.Results.Task
-      dataset: # metafile.Results.Dataset
+      dataset: COCO # metafile.Results.Dataset
     AR:
       eval_name: AR
       metric_key: AR
       tolerance: 0.01
       task_name: Body 2D Keypoint
-      dataset:
+      dataset: COCO
   convert_image: &convert_image
     input_img: *img_human_pose
     test_img: *img_human_pose_256x192

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -11,13 +11,13 @@ globals:
     AP: # named after metafile.Results.Metrics
       eval_name: mAP # test.py --metrics args
       metric_key: AP # eval key name
-      tolerance: 0.01
+      tolerance: 0.10 # metric ±n
       task_name: Body 2D Keypoint # metafile.Results.Task
       dataset: COCO # metafile.Results.Dataset
     AR:
       eval_name: mAP
       metric_key: AR
-      tolerance: 0.01
+      tolerance: 0.08 # metric ±n
       task_name: Body 2D Keypoint
       dataset: COCO
   convert_image: &convert_image

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -64,9 +64,8 @@ torchscript:
 models:
   - name: hrnet
     metafile: configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_coco.yml
-    codebase_model_config_dir: ./configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco
     model_configs:
-      - hrnet_w48_coco_256x192.py
+      - configs/body/2d_kpt_sview_rgb_img/topdown_heatmap/coco/hrnet_w48_coco_256x192.py
     pipelines:
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp16

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -41,8 +41,23 @@ tensorrt:
     deploy_config: configs/mmpose/pose-detection_tensorrt-fp16_static-256x192.py
 
 openvino:
+  pipeline_openvino_static_fp32: &pipeline_openvino_static_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmpose/pose-detection_openvino_static-256x192.py
+
 ncnn:
+  pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmpose/pose-detection_ncnn_static-256x192.py
+
 pplnn:
+  pipeline_ppl_static_fp32: &pipeline_ppl_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmpose/pose-detection_pplnn_static-256x192.py
+
 torchscript:
 
 
@@ -55,3 +70,6 @@ models:
     pipelines:
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp16
+      - *pipeline_openvino_static_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_static_fp32

--- a/configs/mmpose/mmpose_regression_test.yaml
+++ b/configs/mmpose/mmpose_regression_test.yaml
@@ -9,13 +9,13 @@ globals:
     img_blank: &img_blank
   metric_info: &metric_info
     AP: # named after metafile.Results.Metrics
-      eval_name: AP # test.py --metrics args
-      metric_key: AP # eval OrderedDict key name
+      eval_name: mAP # test.py --metrics args
+      metric_key: AP # eval key name
       tolerance: 0.01
       task_name: Body 2D Keypoint # metafile.Results.Task
       dataset: COCO # metafile.Results.Dataset
     AR:
-      eval_name: AR
+      eval_name: mAP
       metric_key: AR
       tolerance: 0.01
       task_name: Body 2D Keypoint

--- a/configs/mmpose/pose-detection_torchscript.py
+++ b/configs/mmpose/pose-detection_torchscript.py
@@ -1,0 +1,6 @@
+_base_ = [
+    '../_base_/torchscript_config.py', '../_base_/backends/torchscript.py'
+]
+
+codebase_config = dict(type='mmpose', task='PoseDetection')
+ir_config = dict(input_shape=[192, 256])

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -32,11 +32,23 @@ onnxruntime:
     deploy_config: configs/mmseg/segmentation_onnxruntime_dynamic.py
 
 tensorrt:
+  pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmseg/segmentation_tensorrt_dynamic-512x1024-2048x2048.py
+
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic_fp32
     deploy_config: configs/mmseg/segmentation_tensorrt-fp16_dynamic-512x1024-2048x2048.py
+
+  pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmseg/segmentation_tensorrt-int8_dynamic-512x1024-2048x2048.py
 
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
@@ -44,17 +56,27 @@ openvino:
     backend_test: *default_backend_test
     deploy_config: configs/mmseg/segmentation_openvino_dynamic-1024x2048.py
 
+  pipeline_openvino_static_fp32: &pipeline_openvino_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmseg/segmentation_openvino_static-512x512.py
+
 ncnn:
   pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32
     convert_image: *convert_image
     backend_test: False
-    deploy_config: configs/mmseg/segmentation_ncnn_static-1024x2048.py
+    deploy_config: configs/mmseg/segmentation_ncnn_static-512x512.py
 
 pplnn:
   pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmseg/segmentation_pplnn_dynamic-1024x2048.py
+
+  pipeline_ppl_static_fp32: &pipeline_ppl_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmseg/segmentation_pplnn_static-512x512.py
 
 torchscript:
   pipeline_ts_fp32: &pipeline_ts_fp32

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -89,7 +89,7 @@ ncnn:
     deploy_config: configs/mmseg/segmentation_ncnn_static-512x512.py
 
 pplnn:
-  pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
+  pipeline_pplnn_dynamic_fp32: &pipeline_pplnn_dynamic_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmseg/segmentation_pplnn_dynamic-1024x2048.py
@@ -116,5 +116,5 @@ models:
       - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
-      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -14,7 +14,7 @@ globals:
     mIoU: # named after metafile.Results.Metrics
       eval_name: mIoU # test.py --metrics args
       metric_key: mIoU # eval OrderedDict key name
-      tolerance: 5
+      tolerance: 5 # metric ±n%
       task_name: Semantic Segmentation # metafile.Results.Task
       dataset: Cityscapes # metafile.Results.Dataset
   convert_image: &convert_image

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -29,7 +29,7 @@ onnxruntime:
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic
-    deploy_config: configs/mmseg/segmentation_onnxruntime_static-512x512.py
+    deploy_config: configs/mmseg/segmentation_onnxruntime_static-1024x2048.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
     convert_image: *convert_image
@@ -40,19 +40,19 @@ tensorrt:
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic
-    deploy_config: configs/mmseg/segmentation_tensorrt_static-1024x1024.py
+    deploy_config: configs/mmseg/segmentation_tensorrt_static-1024x2048.py
 
   pipeline_trt_static_fp16: &pipeline_trt_static_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic
-    deploy_config: configs/mmseg/segmentation_tensorrt-fp16_static-1024x1024.py
+    deploy_config: configs/mmseg/segmentation_tensorrt-fp16_static-1024x2048.py
 
   pipeline_trt_static_int8: &pipeline_trt_static_int8
     convert_image: *convert_image
     backend_test: *default_backend_test
     sdk_config: *sdk_dynamic
-    deploy_config: configs/mmseg/segmentation_tensorrt-int8_static-1024x1024.py
+    deploy_config: configs/mmseg/segmentation_tensorrt-int8_static-1024x2048.py
 
 
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
@@ -82,7 +82,7 @@ openvino:
   pipeline_openvino_static_fp32: &pipeline_openvino_static_fp32
     convert_image: *convert_image
     backend_test: False
-    deploy_config: configs/mmseg/segmentation_openvino_static-512x512.py
+    deploy_config: configs/mmseg/segmentation_openvino_static-1024x2048.py
 
 ncnn:
   pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -196,7 +196,7 @@ models:
       - configs/apcnet/apcnet_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
 
   - name: BiSeNetV1
@@ -205,7 +205,7 @@ models:
       - configs/bisenetv1/bisenetv1_r18-d32_4x4_1024x1024_160k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -215,7 +215,7 @@ models:
       - configs/bisenetv2/bisenetv2_fcn_4x4_1024x1024_160k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -225,7 +225,7 @@ models:
       - configs/cgnet/cgnet_512x1024_60k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -235,7 +235,7 @@ models:
       - configs/emanet/emanet_r50-d8_512x1024_80k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
 
   - name: EncNet
@@ -244,7 +244,7 @@ models:
       - configs/encnet/encnet_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
 
   - name: ERFNet
@@ -253,7 +253,7 @@ models:
       - configs/erfnet/erfnet_fcn_4x4_512x1024_160k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -263,7 +263,7 @@ models:
       - configs/fastfcn/fastfcn_r50-d32_jpu_aspp_512x1024_80k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -273,7 +273,7 @@ models:
       - configs/gcnet/gcnet_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
 
   - name: ICNet
     metafile: configs/icnet/icnet.yml
@@ -281,7 +281,7 @@ models:
       - configs/icnet/icnet_r18-d8_832x832_80k_cityscapes.py
     pipelines:
       - *pipeline_ort_static_fp32
-      - *pipeline_trt_static_int8
+      - *pipeline_trt_static_fp16
       - *pipeline_openvino_static_fp32
 
   - name: ISANet
@@ -290,7 +290,7 @@ models:
       - configs/isanet/isanet_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
 
   - name: OCRNet
@@ -299,7 +299,7 @@ models:
       - configs/ocrnet/ocrnet_hr18s_512x1024_40k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -309,7 +309,7 @@ models:
       - configs/point_rend/pointrend_r50_512x1024_80k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_openvino_dynamic_fp32
 
   - name: Semantic FPN
@@ -318,7 +318,7 @@ models:
       - configs/sem_fpn/fpn_r50_512x1024_80k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -329,7 +329,7 @@ models:
       - configs/stdc/stdc2_in1k-pre_512x1024_80k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
-      - *pipeline_trt_dynamic_int8
+      - *pipeline_trt_dynamic_fp16
       - *pipeline_ncnn_static_fp32
       - *pipeline_openvino_dynamic_fp32
 
@@ -339,4 +339,4 @@ models:
       - configs/upernet/upernet_r50_512x1024_40k_cityscapes.py
     pipelines:
       - *pipeline_ort_static_fp32
-      - *pipeline_trt_static_int8
+      - *pipeline_trt_static_fp16

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -99,12 +99,12 @@ pplnn:
   pipeline_pplnn_static_fp32: &pipeline_pplnn_static_fp32
     convert_image: *convert_image
     backend_test: False
-    deploy_config: configs/mmseg/segmentation_pplnn_static-512x512.py
+    deploy_config: configs/mmseg/segmentation_pplnn_static-1024x2048.py
 
 torchscript:
   pipeline_ts_fp32: &pipeline_ts_fp32
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmseg/segmentation_torchscript.py
 
 

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -39,9 +39,28 @@ tensorrt:
     deploy_config: configs/mmseg/segmentation_tensorrt-fp16_dynamic-512x1024-2048x2048.py
 
 openvino:
+  pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmseg/segmentation_openvino_dynamic-1024x2048.py
+
 ncnn:
+  pipeline_ncnn_static_fp32: &pipeline_ncnn_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmseg/segmentation_ncnn_static-1024x2048.py
+
 pplnn:
+  pipeline_ppl_dynamic_fp32: &pipeline_ppl_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmseg/segmentation_pplnn_dynamic-1024x2048.py
+
 torchscript:
+  pipeline_ts_fp32: &pipeline_ts_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmseg/segmentation_torchscript.py
 
 
 models:
@@ -53,3 +72,7 @@ models:
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_ppl_dynamic_fp32
+      - *pipeline_ts_fp32

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -4,10 +4,12 @@ globals:
   checkpoint_force_download: False
   checkpoint_dir: ../mmdeploy_checkpoints
   images:
-    img_cityscapes_224x224: &img_cityscapes_224x224 ./tests/data/tiger.jpeg
-    img_cityscapes_300x300: &img_cityscapes_300x300
-    img_cityscapes_800x1344: &img_cityscapes_800x1344
-    img_blank: &img_blank
+    img_leftImg8bit: &img_leftImg8bit ../mmsegmentation/tests/data/pseudo_cityscapes_dataset/leftImg8bit/frankfurt_000000_000294_leftImg8bit.png
+    img_loveda_0: &img_loveda_0 ../mmsegmentation/tests/data/pseudo_loveda_dataset/img_dir/0.png
+    img_loveda_1: &img_loveda_1 ../mmsegmentation/tests/data/pseudo_loveda_dataset/img_dir/1.png
+    img_loveda_2: &img_loveda_2 ../mmsegmentation/tests/data/pseudo_loveda_dataset/img_dir/2.png
+    img_potsdam: &img_potsdam ../mmsegmentation/tests/data/pseudo_potsdam_dataset/img_dir/2_10_0_0_512_512.png
+    img_vaihingen: &img_vaihingen ../mmsegmentation/tests/data/pseudo_vaihingen_dataset/img_dir/area1_0_0_512_512.png
   metric_info: &metric_info
     mIoU: # named after metafile.Results.Metrics
       eval_name: mIoU # test.py --metrics args
@@ -16,8 +18,8 @@ globals:
       task_name: Semantic Segmentation # metafile.Results.Task
       dataset: Cityscapes # metafile.Results.Dataset
   convert_image: &convert_image
-    input_img: *img_cityscapes_224x224
-    test_img: *img_cityscapes_300x300
+    input_img: *img_leftImg8bit
+    test_img: *img_loveda_0
   backend_test: &default_backend_test True
   sdk:
     sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmseg/segmentation_sdk_dynamic.py

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -14,7 +14,7 @@ globals:
     mIoU: # named after metafile.Results.Metrics
       eval_name: mIoU # test.py --metrics args
       metric_key: mIoU # eval OrderedDict key name
-      tolerance: 0.1
+      tolerance: 5
       task_name: Semantic Segmentation # metafile.Results.Task
       dataset: Cityscapes # metafile.Results.Dataset
   convert_image: &convert_image
@@ -22,11 +22,13 @@ globals:
     test_img: *img_loveda_0
   backend_test: &default_backend_test True
   sdk:
-    sdk_dynamic_fp32: &sdk_dynamic_fp32 configs/mmseg/segmentation_sdk_dynamic.py
+    sdk_dynamic: &sdk_dynamic configs/mmseg/segmentation_sdk_dynamic.py
 
 onnxruntime:
   pipeline_ort_static_fp32: &pipeline_ort_static_fp32
     convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmseg/segmentation_onnxruntime_static-512x512.py
 
   pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
@@ -37,44 +39,44 @@ tensorrt:
   pipeline_trt_static_fp32: &pipeline_trt_static_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmseg/segmentation_tensorrt_static-1024x1024.py
 
   pipeline_trt_static_fp16: &pipeline_trt_static_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmseg/segmentation_tensorrt-fp16_static-1024x1024.py
 
   pipeline_trt_static_int8: &pipeline_trt_static_int8
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmseg/segmentation_tensorrt-int8_static-1024x1024.py
 
 
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmseg/segmentation_tensorrt_dynamic-512x1024-2048x2048.py
 
   pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmseg/segmentation_tensorrt-fp16_dynamic-512x1024-2048x2048.py
 
   pipeline_trt_dynamic_int8: &pipeline_trt_dynamic_int8
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_dynamic_fp32
+    sdk_config: *sdk_dynamic
     deploy_config: configs/mmseg/segmentation_tensorrt-int8_dynamic-512x1024-2048x2048.py
 
 openvino:
   pipeline_openvino_dynamic_fp32: &pipeline_openvino_dynamic_fp32
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmseg/segmentation_openvino_dynamic-1024x2048.py
 
   pipeline_openvino_static_fp32: &pipeline_openvino_static_fp32
@@ -94,7 +96,7 @@ pplnn:
     backend_test: False
     deploy_config: configs/mmseg/segmentation_pplnn_dynamic-1024x2048.py
 
-  pipeline_ppl_static_fp32: &pipeline_ppl_static_fp32
+  pipeline_pplnn_static_fp32: &pipeline_pplnn_static_fp32
     convert_image: *convert_image
     backend_test: False
     deploy_config: configs/mmseg/segmentation_pplnn_static-512x512.py
@@ -107,10 +109,36 @@ torchscript:
 
 
 models:
+  - name: FCN
+    metafile: configs/fcn/fcn.yml
+    model_configs:
+      - configs/fcn/fcn_r50-d8_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+#      - *pipeline_trt_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+#      - *pipeline_trt_dynamic_int8
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: PSPNet
+    metafile: configs/pspnet/pspnet.yml
+    model_configs:
+      - configs/pspnet/pspnet_r50-d8_512x1024_80k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_fp16
+      - *pipeline_openvino_static_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_pplnn_static_fp32
+      - *pipeline_ts_fp32
+
   - name: deeplabv3
     metafile: configs/deeplabv3/deeplabv3.yml
     model_configs:
-      - configs/deeplabv3/deeplabv3_r18-d8_512x1024_80k_cityscapes.py
+      - configs/deeplabv3/deeplabv3_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
@@ -118,3 +146,197 @@ models:
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
       - *pipeline_ts_fp32
+
+  - name: deeplabv3+
+    metafile: configs/deeplabv3plus/deeplabv3plus.yml
+    model_configs:
+      - configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: Fast-SCNN
+    metafile: configs/fastscnn/fastscnn.yml
+    model_configs:
+      - configs/fastscnn/fast_scnn_lr0.12_8x4_160k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_fp16
+      - *pipeline_openvino_static_fp32
+      - *pipeline_pplnn_static_fp32
+      - *pipeline_ts_fp32
+
+  - name: UNet
+    metafile: configs/unet/unet.yml
+    model_configs:
+      - configs/unet/fcn_unet_s5-d16_4x4_512x1024_160k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_openvino_dynamic_fp32
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_pplnn_dynamic_fp32
+      - *pipeline_ts_fp32
+
+  - name: ANN
+    metafile: configs/ann/ann.yml
+    model_configs:
+      - configs/ann/ann_r50-d8_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_fp16
+
+  - name: APCNet
+    metafile: configs/apcnet/apcnet.yml
+    model_configs:
+      - configs/apcnet/apcnet_r50-d8_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+
+  - name: BiSeNetV1
+    metafile: configs/bisenetv1/bisenetv1.yml
+    model_configs:
+      - configs/bisenetv1/bisenetv1_r18-d32_4x4_1024x1024_160k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: BiSeNetV2
+    metafile: configs/bisenetv2/bisenetv2.yml
+    model_configs:
+      - configs/bisenetv2/bisenetv2_fcn_4x4_1024x1024_160k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: CGNet
+    metafile: configs/cgnet/cgnet.yml
+    model_configs:
+      - configs/cgnet/cgnet_512x1024_60k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: EMANet
+    metafile: configs/emanet/emanet.yml
+    model_configs:
+      - configs/emanet/emanet_r50-d8_512x1024_80k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: EncNet
+    metafile: configs/encnet/encnet.yml
+    model_configs:
+      - configs/encnet/encnet_r50-d8_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: ERFNet
+    metafile: configs/erfnet/erfnet.yml
+    model_configs:
+      - configs/erfnet/erfnet_fcn_4x4_512x1024_160k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: FastFCN
+    metafile: configs/fastfcn/fastfcn.yml
+    model_configs:
+      - configs/fastfcn/fastfcn_r50-d32_jpu_aspp_512x1024_80k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: GCNet
+    metafile: configs/gcnet/gcnet.yml
+    model_configs:
+      - configs/gcnet/gcnet_r50-d8_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+
+  - name: ICNet
+    metafile: configs/icnet/icnet.yml
+    model_configs:
+      - configs/icnet/icnet_r18-d8_832x832_80k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_int8
+      - *pipeline_openvino_static_fp32
+
+  - name: ISANet
+    metafile: configs/isanet/isanet.yml
+    model_configs:
+      - configs/isanet/isanet_r50-d8_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: OCRNet
+    metafile: configs/ocrnet/ocrnet.yml
+    model_configs:
+      - configs/ocrnet/ocrnet_hr18s_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: PointRend
+    metafile: configs/point_rend/point_rend.yml
+    model_configs:
+      - configs/point_rend/pointrend_r50_512x1024_80k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: Semantic FPN
+    metafile: configs/sem_fpn/sem_fpn.yml
+    model_configs:
+      - configs/sem_fpn/fpn_r50_512x1024_80k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: STDC
+    metafile: configs/stdc/stdc.yml
+    model_configs:
+      - configs/stdc/stdc1_in1k-pre_512x1024_80k_cityscapes.py
+      - configs/stdc/stdc2_in1k-pre_512x1024_80k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_int8
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32
+
+  - name: UPerNet
+    metafile: configs/upernet/upernet.yml
+    model_configs:
+      - configs/upernet/upernet_r50_512x1024_40k_cityscapes.py
+    pipelines:
+      - *pipeline_ort_static_fp32
+      - *pipeline_trt_static_int8

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -66,9 +66,8 @@ torchscript:
 models:
   - name: deeplabv3
     metafile: configs/deeplabv3/deeplabv3.yml
-    codebase_model_config_dir: ./configs/deeplabv3
     model_configs:
-      - deeplabv3_r18-d8_512x1024_80k_cityscapes.py
+      - configs/deeplabv3/deeplabv3_r18-d8_512x1024_80k_cityscapes.py
     pipelines:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -114,73 +114,73 @@ models:
     model_configs:
       - configs/fcn/fcn_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
 #      - *pipeline_trt_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
 #      - *pipeline_trt_dynamic_int8
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: PSPNet
     metafile: configs/pspnet/pspnet.yml
     model_configs:
       - configs/pspnet/pspnet_r50-d8_512x1024_80k_cityscapes.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp16
-      - *pipeline_openvino_static_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_static_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_static_fp32
 
   - name: deeplabv3
     metafile: configs/deeplabv3/deeplabv3.yml
     model_configs:
       - configs/deeplabv3/deeplabv3_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: deeplabv3+
     metafile: configs/deeplabv3plus/deeplabv3plus.yml
     model_configs:
       - configs/deeplabv3plus/deeplabv3plus_r50-d8_512x1024_40k_cityscapes.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: Fast-SCNN
     metafile: configs/fastscnn/fastscnn.yml
     model_configs:
       - configs/fastscnn/fast_scnn_lr0.12_8x4_160k_cityscapes.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_static_fp32
       - *pipeline_trt_static_fp16
-      - *pipeline_openvino_static_fp32
       - *pipeline_pplnn_static_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_static_fp32
 
   - name: UNet
     metafile: configs/unet/unet.yml
     model_configs:
       - configs/unet/fcn_unet_s5-d16_4x4_512x1024_160k_cityscapes.py
     pipelines:
+      - *pipeline_ts_fp32
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp16
-      - *pipeline_openvino_dynamic_fp32
       - *pipeline_ncnn_static_fp32
       - *pipeline_pplnn_dynamic_fp32
-      - *pipeline_ts_fp32
+      - *pipeline_openvino_dynamic_fp32
 
   - name: ANN
     metafile: configs/ann/ann.yml

--- a/configs/mmseg/mmseg_regression_test.yaml
+++ b/configs/mmseg/mmseg_regression_test.yaml
@@ -32,6 +32,25 @@ onnxruntime:
     deploy_config: configs/mmseg/segmentation_onnxruntime_dynamic.py
 
 tensorrt:
+  pipeline_trt_static_fp32: &pipeline_trt_static_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmseg/segmentation_tensorrt_static-1024x1024.py
+
+  pipeline_trt_static_fp16: &pipeline_trt_static_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmseg/segmentation_tensorrt-fp16_static-1024x1024.py
+
+  pipeline_trt_static_int8: &pipeline_trt_static_int8
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    sdk_config: *sdk_dynamic_fp32
+    deploy_config: configs/mmseg/segmentation_tensorrt-int8_static-1024x1024.py
+
+
   pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test

--- a/docs/zh_cn/tutorials/how_to_do_regression_test.md
+++ b/docs/zh_cn/tutorials/how_to_do_regression_test.md
@@ -42,6 +42,11 @@ python ./tools/regression_test.py \
 - `--log-level` : 设置日记的等级，选项包括`'CRITICAL'， 'FATAL'， 'ERROR'， 'WARN'， 'WARNING'， 'INFO'， 'DEBUG'， 'NOTSET'`。默认是`INFO`。
 - `--performance` : 是否测试精度，加上则测试转换+精度，不加上则只测试转换
 
+### 注意事项
+对于 Windows 用户：
+1. 要在 shell 命令中使用 `&&` 连接符，需要下载并使用 `PowerShell 7 Preview 5+`。
+2. 如果您使用 conda env，可能需要在 regression_test.py 中将 `python3` 更改为 `python`，因为 `%USERPROFILE%\AppData\Local\Microsoft\WindowsApps` 目录中有 `python3.exe`。
+
 ## 例子
 
 1. 测试 mmdet 和 mmpose 的所有 backend 的 转换+精度
@@ -112,18 +117,20 @@ globals:
     test_img: *img_300x300
   backend_test: &default_backend_test True # 是否对 backend 进行精度测试
   sdk: # SDK 配置文件
-    sdk_detection_dynamic_fp32: &sdk_detection_dynamic_fp32 configs/mmocr/text-detection/text-detection_sdk_dynamic.py
-    sdk_recognition_dynamic_fp32: &sdk_recognition_dynamic_fp32 configs/mmocr/text-recognition/text-recognition_sdk_dynamic.py
+    sdk_detection_dynamic: &sdk_detection_dynamic configs/mmocr/text-detection/text-detection_sdk_dynamic.py
+    sdk_recognition_dynamic: &sdk_recognition_dynamic configs/mmocr/text-recognition/text-recognition_sdk_dynamic.py
 
 onnxruntime:
   pipeline_ort_recognition_static_fp32: &pipeline_ort_recognition_static_fp32
-    convert_image: *convert_image
-    deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_static.py
+    convert_image: *convert_image # 转换过程中使用的图片
+    backend_test: *default_backend_test # 是否进行后端测试，存在则判断，不存在则视为 False
+    sdk_config: *sdk_recognition_dynamic # 是否进行SDK测试，存在则使用特定的 SDK config 进行测试，不存在则视为不进行 SDK 测试
+    deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_static.py # 使用的 deploy cfg 路径，基于 mmdeploy 的路径
 
   pipeline_ort_recognition_dynamic_fp32: &pipeline_ort_recognition_dynamic_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_recognition_dynamic_fp32
+    sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_onnxruntime_dynamic.py
 
   pipeline_ort_detection_dynamic_fp32: &pipeline_ort_detection_dynamic_fp32
@@ -134,19 +141,23 @@ tensorrt:
   pipeline_trt_recognition_dynamic_fp16: &pipeline_trt_recognition_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_recognition_dynamic_fp32
+    sdk_config: *sdk_recognition_dynamic
     deploy_config: configs/mmocr/text-recognition/text-recognition_tensorrt-fp16_dynamic-1x32x32-1x32x640.py
 
   pipeline_trt_detection_dynamic_fp16: &pipeline_trt_detection_dynamic_fp16
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_detection_dynamic_fp32
+    sdk_config: *sdk_detection_dynamic
     deploy_config: configs/mmocr/text-detection/text-detection_tensorrt-fp16_dynamic-320x320-1024x1824.py
 
 openvino:
+  # 此处省略，内容同上
 ncnn:
+  # 此处省略，内容同上
 pplnn:
+  # 此处省略，内容同上
 torchscript:
+  # 此处省略，内容同上
 
 
 models:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,4 +6,5 @@ isort==4.3.21
 openpyxl
 pandas
 pytest
+xlrd==1.2.0
 yapf

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -45,7 +45,7 @@ def parse_args():
         help='the dir to save logs and models',
         default='../mmdeploy_regression_working_dir')
     parser.add_argument(
-        '--device', type=str, help='`the CUDA device id', default='cuda')
+        '--device', type=str, help='Device type, cuda or cpu', default='cuda')
     parser.add_argument(
         '--log-level',
         help='set log level',

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -304,7 +304,7 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
         report_txt_path=report_txt_path)
 
     logger.info(f'Got {model_config_path} metric: {pytorch_metric}')
-    return pytorch_metric
+    return pytorch_metric, dataset_type
 
 
 def get_info_from_log_file(info_type: str, log_path: Path,
@@ -662,7 +662,8 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
                        pytorch_metric: dict, metric_info: dict,
                        report_dict: dict, test_type: str,
                        logger: logging.Logger, log_path: Path,
-                       backend_file_name: [str, list], report_txt_path: Path):
+                       backend_file_name: [str, list], report_txt_path: Path,
+                       metafile_dataset: str):
     """Convert model to onnx and then get metric.
 
     Args:
@@ -679,6 +680,7 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
         log_path (Path): Path for logger file.
         backend_file_name (str | list): backend file save name.
         report_txt_path (Path): report txt path.
+        metafile_dataset (str): Dataset type get from meatfile.
     """
     # get backend_test info
     backend_test = pipeline_info.get('backend_test', False)
@@ -776,7 +778,7 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
         dataset_type = \
             str(model_cfg.dataset_type).upper().replace('DATASET', '')
     else:
-        dataset_type = 'x'
+        dataset_type = metafile_dataset
 
     # Test the model
     if convert_result and test_type == 'precision':
@@ -1007,7 +1009,7 @@ def main():
                 assert checkpoint_path.exists()
 
                 # Get pytorch from metafile.yml
-                pytorch_metric = get_pytorch_result(
+                pytorch_metric, metafile_dataset = get_pytorch_result(
                     models.get('name'), model_metafile_info, checkpoint_path,
                     model_cfg_path, model_config, metric_info, report_dict,
                     logger, report_txt_path)
@@ -1028,7 +1030,7 @@ def main():
                                        pytorch_metric, metric_info,
                                        report_dict, test_type, logger,
                                        log_path, backend_file_name,
-                                       report_txt_path)
+                                       report_txt_path, metafile_dataset)
 
         save_report(report_dict, report_save_path, logger)
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -933,7 +933,7 @@ def main():
         # clear the log file
         with open(log_path, 'w') as f_log:
             f_log.write('')
-    logger.info(f'Savine log in {str(log_path.absolute().resolve())}')
+    logger.info(f'Saving log in {str(log_path.absolute().resolve())}')
 
     for deploy_yaml in args.deploy_yml:
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -58,28 +58,31 @@ def parse_args():
     return args
 
 
-def merge_report(work_dir: str):
+def merge_report(work_dir: str, logger: logging.Logger):
     """Merge all the report into one report.
 
     Args:
         work_dir (str): Work dir that including all reports.
+        logger (logging.Logger): Logger handler.
     """
     work_dir = Path(work_dir)
     res_file = work_dir.joinpath(
         f'mmdeploy_regression_test_{mmdeploy.version.__version__}.xlsx')
+    logger.info(f'Whole result report saving in {res_file}')
 
     if res_file.exists():
         # delete if it existed
         res_file.unlink()
 
     for report_file in work_dir.iterdir():
-        if '_report.xlsx' in report_file.name or \
+        if '_report.xlsx' not in report_file.name or \
                 report_file.name == res_file.name or \
                 not report_file.is_file():
             # skip other file
             continue
         # get info from report
-        df = pd.read_excel(report_file)
+        logger.info(f'Merging {report_file}')
+        df = pd.read_excel(str(report_file))
         df.rename(columns={'Unnamed: 0': 'Index'}, inplace=True)
 
         # get key then convert to list
@@ -111,7 +114,7 @@ def merge_report(work_dir: str):
             if ws.cell(1, 1).value is None:
                 wb.remove_sheet(ws)
         # save to file
-        wb.save(res_file)
+        wb.save(str(res_file))
 
 
 def get_model_metafile_info(global_info: dict, model_info: dict,
@@ -1144,7 +1147,7 @@ def main():
         save_report(report_dict, report_save_path, logger)
 
     # merge report
-    merge_report(str(work_dir))
+    merge_report(str(work_dir), logger)
 
 
 if __name__ == '__main__':

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -110,6 +110,7 @@ def get_model_metafile_info(global_info: dict, model_info: dict,
         weights_save_path = checkpoint_save_dir.joinpath(weights_name)
         if weights_save_path.exists() and \
                 not global_info.get('checkpoint_force_download', False):
+            logger.info(f'model {weights_name} exist, skip download it...')
             continue
 
         # Download weight
@@ -248,11 +249,14 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
             dataset = 'Set5'
 
         if (len(using_dataset) > 1) and (dataset not in using_dataset):
+            logger.debug(f'dataset not in {using_dataset}, skip it...')
             continue
         dataset_type += f'{dataset} | '
 
         if using_dataset.get(dataset) != task_name:
             # only add the metric with the correct dataset
+            logger.debug(f'task_name ({task_name}) is not '
+                         f'{using_dataset.get(dataset)}, skip it...')
             continue
         task_type += f'{task_name} | '
 
@@ -722,8 +726,11 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
     if metric_tolerance is not None:
         for metric, new_tolerance in metric_tolerance.items():
             if metric not in metric_info:
+                logger.debug(f'{metric} not in {metric_info},'
+                             'skip compare it...')
                 continue
             if new_tolerance is None:
+                logger.debug('new_tolerance is None, skip it ...')
                 continue
             metric_info[metric]['tolerance'] = new_tolerance
 
@@ -880,6 +887,7 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
             metric_list.append({metric: '-'})
             metric_task_name = metric_info.get(metric, {}).get('task_name', '')
             if metric_task_name in task_name:
+                logger.debug('metric_task_name exist, skip for adding it...')
                 continue
             task_name += f'{metric_task_name} | '
         if ' | ' == task_name[-3:]:
@@ -1026,6 +1034,7 @@ def main():
                 # Get backends info
                 pipelines_info = models.get('pipelines', None)
                 if pipelines_info is None:
+                    logger.warning('pipelines_info is None, skip it...')
                     continue
 
                 # Get model config path
@@ -1048,11 +1057,15 @@ def main():
                     deploy_config = pipeline.get('deploy_config')
                     backend_name = get_backend(deploy_config).name.lower()
                     if backend_name not in backend_list:
+                        logger.warning(f'backend_name ({backend_name}) not '
+                                       f'in {backend_list}, skip it...')
                         continue
 
                     backend_file_name = \
                         backend_file_info.get(backend_name, None)
                     if backend_file_name is None:
+                        logger.warning('backend_file_name is None, '
+                                       'skip it...')
                         continue
 
                     get_backend_result(pipeline, model_cfg_path,

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -200,7 +200,7 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
         meta_info (dict): Metafile info from model's metafile.yml.
         checkpoint_path (Path): Checkpoint path.
         model_config_path (Path): Model config path.
-        model_config_name (str): Name fo model config in meta_info.
+        model_config_name (str): Name of model config in meta_info.
         metric_name_info (dict): Metrics info.
         report_dict (dict): Report info dict.
         logger (logging.Logger): Logger.

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -702,6 +702,16 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
     if sdk_config is not None:
         sdk_config = Path(sdk_config)
 
+    # Overwrite metric tolerance
+    metric_tolerance = pipeline_info.get('metric_tolerance', None)
+    if metric_tolerance is not None:
+        for metric, new_tolerance in metric_tolerance.items():
+            if metric not in metric_info:
+                continue
+            if new_tolerance is None:
+                continue
+            metric_info[metric]['tolerance'] = new_tolerance
+
     if backend_test is False and sdk_config is None:
         test_type = 'convert'
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -63,7 +63,7 @@ def get_model_metafile_info(global_info: dict, model_info: dict,
     Args:
         global_info (dict): global info from deploy yaml.
         model_info (dict):  model info from deploy yaml.
-        logger (logging.Logger): Logger.
+        logger (logging.Logger): Logger handler.
 
     Returns:
         Dict: Meta info of each model config
@@ -522,7 +522,7 @@ def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
                            convert_result: bool, report_dict: dict,
                            infer_type: str, log_path: Path, dataset_type: str,
                            report_txt_path: Path):
-    """Get backend fps and metric
+    """Get backend fps and metric.
 
     Args:
         deploy_cfg_path (str): Deploy config path.

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -642,8 +642,9 @@ def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
               f'--log2file "{log_path}" ' \
               f'--speed-test '
 
-    # mmedit eval_name will get a 'PSNR'
-    if eval_name != 'PSNR':
+    codebase_name = get_codebase(str(deploy_cfg_path)).value
+    if codebase_name != 'mmedit':
+        # mmedit dont --metric
         cmd_str += f'--metrics {eval_name} '
 
     logger.info(f'Process cmd = {cmd_str}')
@@ -672,6 +673,13 @@ def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
     # update useless metric
     for metric in metric_useless:
         metric_list.append({metric: '-'})
+
+    if len(metrics_eval_list) > 1 and codebase_name == 'mmdet':
+        # one model has more than one task, like Mask R-CNN
+        for name in pytorch_metric:
+            if name in metric_useless or name == metric_name:
+                continue
+            metric_list.append({name: '-'})
 
     # update the report
     update_report(

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -637,9 +637,9 @@ def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
               'python3 tools/test.py ' \
               f'{deploy_cfg_path} ' \
               f'{str(model_cfg_path.absolute())} ' \
-              f'--model {convert_checkpoint_path} ' \
+              f'--model "{convert_checkpoint_path}" ' \
               f'--device {device_type} ' \
-              f'--log2file {log_path} ' \
+              f'--log2file "{log_path}" ' \
               f'--speed-test '
 
     # mmedit eval_name will get a 'PSNR'
@@ -836,9 +836,9 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
               'python3 ./tools/deploy.py ' \
               f'{str(deploy_cfg_path.absolute().resolve())} ' \
               f'{str(model_cfg_path.absolute().resolve())} ' \
-              f'{str(checkpoint_path.absolute().resolve())} ' \
-              f'{input_img_path} ' \
-              f'--work-dir {backend_output_path} ' \
+              f'"{str(checkpoint_path.absolute().resolve())}" ' \
+              f'"{input_img_path}" ' \
+              f'--work-dir "{backend_output_path}" ' \
               f'--device {device_type} ' \
               '--log-level INFO'
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -153,10 +153,9 @@ def update_report(report_dict: dict, model_name: str, model_config: str,
     if '.pth' not in model_checkpoint_name:
         # make model path shorter by cutting the work_dir_root
         work_dir_root = report_txt_path.parent.absolute().resolve()
-        model_checkpoint_abs = Path(model_checkpoint_name).absolute().resolve()
         model_checkpoint_name = \
-            str(model_checkpoint_abs).replace(str(work_dir_root),
-                                              '${WORK_DIR}')
+            str(model_checkpoint_name).replace(str(work_dir_root),
+                                               '${WORK_DIR}')
 
     # save to tmp file
     tmp_str = f'{model_name},{model_config},{task_name},' \
@@ -756,7 +755,8 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
         convert_checkpoint_path = ''
         for backend_file in backend_file_name:
             backend_path = backend_output_path.joinpath(backend_file)
-            convert_checkpoint_path += f' {str(backend_path)}'
+            backend_path = backend_path.absolute().resolve()
+            convert_checkpoint_path += f'{str(backend_path)} '
     else:
         convert_checkpoint_path = \
             str(backend_output_path.joinpath(backend_file_name))

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -73,8 +73,8 @@ def merge_report(work_dir: str):
         res_file.unlink()
 
     for report_file in work_dir.iterdir():
-        if report_file.suffix != '.xlsx' or \
-                report_file.name == res_file or \
+        if '_report.xlsx' in report_file.name or \
+                report_file.name == res_file.name or \
                 not report_file.is_file():
             # skip other file
             continue

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -153,6 +153,11 @@ def update_report(report_dict: dict, model_name: str, model_config: str,
     if '.pth' not in model_checkpoint_name:
         # make model path shorter by cutting the work_dir_root
         work_dir_root = report_txt_path.parent.absolute().resolve()
+
+        if ' ' not in model_checkpoint_name:
+            model_checkpoint_name = \
+                Path(model_checkpoint_name).absolute().resolve()
+
         model_checkpoint_name = \
             str(model_checkpoint_name).replace(str(work_dir_root),
                                                '${WORK_DIR}')

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -526,7 +526,7 @@ def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
                            precision_type: str, metric_useless: set,
                            convert_result: bool, report_dict: dict,
                            infer_type: str, log_path: Path, dataset_type: str,
-                           report_txt_path: Path):
+                           report_txt_path: Path, model_name: str):
     """Get backend fps and metric.
 
     Args:
@@ -548,6 +548,7 @@ def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
         log_path (Path): Logger save path.
         dataset_type (str): Dataset type.
         report_txt_path (Path): report txt save path.
+        model_name (str): Name of model in test yaml.
     """
     cmd_str = f'cd {str(Path(__file__).absolute().parent.parent)} && ' \
               'python3 tools/test.py ' \
@@ -592,7 +593,7 @@ def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
     # update the report
     update_report(
         report_dict=report_dict,
-        model_name=model_cfg_path.parent.name,
+        model_name=model_name,
         model_config=str(model_cfg_path),
         task_name=task_name,
         model_checkpoint_name=convert_checkpoint_path,
@@ -663,7 +664,7 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
                        report_dict: dict, test_type: str,
                        logger: logging.Logger, log_path: Path,
                        backend_file_name: [str, list], report_txt_path: Path,
-                       metafile_dataset: str):
+                       metafile_dataset: str, model_name: str):
     """Convert model to onnx and then get metric.
 
     Args:
@@ -680,7 +681,8 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
         log_path (Path): Path for logger file.
         backend_file_name (str | list): backend file save name.
         report_txt_path (Path): report txt path.
-        metafile_dataset (str): Dataset type get from meatfile.
+        metafile_dataset (str): Dataset type get from metafile.
+        model_name (str): Name of model in test yaml.
     """
     # get backend_test info
     backend_test = pipeline_info.get('backend_test', False)
@@ -814,7 +816,8 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
                     infer_type=infer_type,
                     log_path=log_path,
                     dataset_type=dataset_type,
-                    report_txt_path=report_txt_path)
+                    report_txt_path=report_txt_path,
+                    model_name=model_name)
 
             if sdk_config is not None:
 
@@ -840,7 +843,8 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
                     infer_type=infer_type,
                     log_path=log_path,
                     dataset_type=dataset_type,
-                    report_txt_path=report_txt_path)
+                    report_txt_path=report_txt_path,
+                    model_name=model_name)
     else:
         logger.info('Only test convert, saving to report...')
         metric_list = []
@@ -869,7 +873,7 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
         # update the report
         update_report(
             report_dict=report_dict,
-            model_name=model_cfg_path.parent.name,
+            model_name=model_name,
             model_config=str(model_cfg_path),
             task_name=task_name,
             model_checkpoint_name=report_checkpoint,
@@ -985,7 +989,8 @@ def main():
         models_info = yaml_info.get('models')
         for models in models_info:
             if 'model_configs' not in models:
-                logger.info(f'Skip {models.get("name")}')
+                logger.warning('Can not find field "model_configs", '
+                               f'skipping {models.get("name")}...')
                 continue
 
             model_metafile_info, checkpoint_save_dir, codebase_dir = \
@@ -1030,7 +1035,8 @@ def main():
                                        pytorch_metric, metric_info,
                                        report_dict, test_type, logger,
                                        log_path, backend_file_name,
-                                       report_txt_path, metafile_dataset)
+                                       report_txt_path, metafile_dataset,
+                                       models.get('name'))
 
         save_report(report_dict, report_save_path, logger)
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -235,7 +235,10 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
     for _, v in test_yaml_metric_info.items():
         if v.get('dataset') is None:
             continue
-        using_dataset.update({v.get('dataset'): v.get('task_name')})
+        dataset_tmp = using_dataset.get(v.get('dataset'), [])
+        if v.get('task_name') not in dataset_tmp:
+            dataset_tmp.append(v.get('task_name'))
+        using_dataset.update({v.get('dataset'): dataset_tmp})
 
     # Get metrics info from metafile
     for metafile_metric in metafile_metric_info:
@@ -249,14 +252,14 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
             dataset = 'Set5'
 
         if (len(using_dataset) > 1) and (dataset not in using_dataset):
-            logger.debug(f'dataset not in {using_dataset}, skip it...')
+            logger.info(f'dataset not in {using_dataset}, skip it...')
             continue
         dataset_type += f'{dataset} | '
 
-        if using_dataset.get(dataset) != task_name:
+        if task_name not in using_dataset.get(dataset):
             # only add the metric with the correct dataset
-            logger.debug(f'task_name ({task_name}) is not '
-                         f'{using_dataset.get(dataset)}, skip it...')
+            logger.info(f'task_name ({task_name}) is not in'
+                        f'{using_dataset.get(dataset)}, skip it...')
             continue
         task_type += f'{task_name} | '
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -859,13 +859,18 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
         for metric in metric_useless:
             metric_list.append({metric: '-'})
 
+        if convert_result:
+            report_checkpoint = convert_checkpoint_path
+        else:
+            report_checkpoint = str(checkpoint_path)
+
         # update the report
         update_report(
             report_dict=report_dict,
             model_name=model_cfg_path.parent.name,
             model_config=str(model_cfg_path),
             task_name=task_name,
-            model_checkpoint_name=str(checkpoint_path),
+            model_checkpoint_name=report_checkpoint,
             dataset=dataset_type,
             backend_name=backend_name,
             deploy_config=str(deploy_cfg_path),

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -900,7 +900,8 @@ def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
         # test the model metric
         for metric_name in metrics_eval_list:
             if backend_test:
-                log_path = gen_log_path(backend_output_path, 'backend_test.log')
+                log_path = \
+                    gen_log_path(backend_output_path, 'backend_test.log')
                 get_backend_fps_metric(
                     deploy_cfg_path=str(deploy_cfg_path),
                     model_cfg_path=model_cfg_path,
@@ -1138,7 +1139,7 @@ def main():
                                        pytorch_metric, metric_info,
                                        report_dict, test_type, logger,
                                        backend_file_name, report_txt_path,
-                                       metafile_dataset, odels.get('name'))
+                                       metafile_dataset, models.get('name'))
 
         save_report(report_dict, report_save_path, logger)
 

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -6,11 +6,13 @@ from collections import OrderedDict
 from pathlib import Path
 
 import mmcv
+import openpyxl
 import pandas as pd
 import yaml
 from torch.hub import download_url_to_file
 from torch.multiprocessing import set_start_method
 
+import mmdeploy.version
 from mmdeploy.utils import (get_backend, get_codebase, get_root_logger,
                             is_dynamic_shape, load_config)
 
@@ -54,6 +56,62 @@ def parse_args():
     args = parser.parse_args()
 
     return args
+
+
+def merge_report(work_dir: str):
+    """Merge all the report into one report.
+
+    Args:
+        work_dir (str): Work dir that including all reports.
+    """
+    work_dir = Path(work_dir)
+    res_file = work_dir.joinpath(
+        f'mmdeploy_regression_test_{mmdeploy.version.__version__}.xlsx')
+
+    if res_file.exists():
+        # delete if it existed
+        res_file.unlink()
+
+    for report_file in work_dir.iterdir():
+        if report_file.suffix != '.xlsx' or \
+                report_file.name == res_file or \
+                not report_file.is_file():
+            # skip other file
+            continue
+        # get info from report
+        df = pd.read_excel(report_file)
+        df.rename(columns={'Unnamed: 0': 'Index'}, inplace=True)
+
+        # get key then convert to list
+        keys = list(df.keys())
+        values = df.values.tolist()
+
+        # sheet name
+        sheet_name = report_file.stem.split('_')[0]
+
+        # begin to write
+        if res_file.exists():
+            # load if it existed
+            wb = openpyxl.load_workbook(str(res_file))
+        else:
+            wb = openpyxl.Workbook()
+
+        # delete if sheet already exist
+        if sheet_name in wb.sheetnames:
+            wb.remove_sheet(wb[sheet_name])
+        # create sheet
+        wb.create_sheet(title=sheet_name, index=0)
+        # write in row
+        wb[sheet_name].append(keys)
+        for value in values:
+            wb[sheet_name].append(value)
+        # delete the blank sheet
+        for name in wb.sheetnames:
+            ws = wb[name]
+            if ws.cell(1, 1).value is None:
+                wb.remove_sheet(ws)
+        # save to file
+        wb.save(res_file)
 
 
 def get_model_metafile_info(global_info: dict, model_info: dict,
@@ -1083,6 +1141,9 @@ def main():
                                        metafile_dataset, odels.get('name'))
 
         save_report(report_dict, report_save_path, logger)
+
+    # merge report
+    merge_report(str(work_dir))
 
 
 if __name__ == '__main__':

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -56,13 +56,14 @@ def parse_args():
     return args
 
 
-def get_model_metafile_info(global_info, model_info, logger):
+def get_model_metafile_info(global_info: dict, model_info: dict,
+                            logger: logging.Logger):
     """Get model metafile information.
 
     Args:
         global_info (dict): global info from deploy yaml.
         model_info (dict):  model info from deploy yaml.
-        logger (logging.Logger): logger.
+        logger (logging.Logger): Logger.
 
     Returns:
         Dict: Meta info of each model config
@@ -124,10 +125,12 @@ def get_model_metafile_info(global_info, model_info, logger):
     return model_meta_info, checkpoint_save_dir, codebase_dir
 
 
-def update_report(report_dict, model_name, model_config, task_name,
-                  model_checkpoint_name, dataset, backend_name, deploy_config,
-                  static_or_dynamic, precision_type, conversion_result, fps,
-                  metric_info, test_pass, report_txt_path):
+def update_report(report_dict: dict, model_name: str, model_config: str,
+                  task_name: str, model_checkpoint_name: str, dataset: str,
+                  backend_name: str, deploy_config: str,
+                  static_or_dynamic: str, precision_type: str,
+                  conversion_result: str, fps: str, metric_info: list,
+                  test_pass: str, report_txt_path: Path):
     """Update report information.
 
     Args:
@@ -187,9 +190,10 @@ def update_report(report_dict, model_name, model_config, task_name,
         f.write(tmp_str)
 
 
-def get_pytorch_result(model_name, meta_info, checkpoint_path,
-                       model_config_name, metric_name_info, report_dict,
-                       logger, report_txt_path):
+def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
+                       model_config_name: Path, metric_name_info: dict,
+                       report_dict: dict, logger: logging.Logger,
+                       report_txt_path: Path):
     """Get metric from metafile info of the model.
 
     Args:
@@ -299,20 +303,19 @@ def get_pytorch_result(model_name, meta_info, checkpoint_path,
     return pytorch_metric
 
 
-def get_info_from_log_file(info_type, log_path, yaml_metric_key, logger):
+def get_info_from_log_file(info_type: str, log_path: Path,
+                           yaml_metric_key: str, logger: logging.Logger):
     """Get fps and metric result from log file.
 
     Args:
         info_type (str): Get which type of info: 'FPS' or 'metric'.
-        log_path (str): Logger path.
+        log_path (Path): Logger path.
         yaml_metric_key (str): Name of metric from yaml metric_key.
-        logger (Logger): Logger handler.
+        logger (logger.Logger): Logger handler.
 
     Returns:
         Float: Info value which get from logger file.
     """
-    log_path = Path(log_path)
-
     if log_path.exists():
         with open(log_path, 'r') as f_log:
             lines = f_log.readlines()
@@ -407,7 +410,8 @@ def get_info_from_log_file(info_type, log_path, yaml_metric_key, logger):
     return info_value
 
 
-def compare_metric(metric_value, metric_name, pytorch_metric, metric_info):
+def compare_metric(metric_value: float, metric_name: str, pytorch_metric: dict,
+                   metric_info: dict):
     """Compare metric value with the pytorch metric value and the tolerance.
 
     Args:
@@ -432,9 +436,10 @@ def compare_metric(metric_value, metric_name, pytorch_metric, metric_info):
     return test_pass
 
 
-def get_fps_metric(shell_res, pytorch_metric, metric_key,
-                   yaml_metric_info_name, log_path, metrics_eval_list,
-                   metric_info, logger):
+def get_fps_metric(shell_res: int, pytorch_metric: dict, metric_key: str,
+                   yaml_metric_info_name: str, log_path: Path,
+                   metrics_eval_list: dict, metric_info: dict,
+                   logger: logging.Logger):
     """Get fps and metric.
 
     Args:
@@ -442,10 +447,10 @@ def get_fps_metric(shell_res, pytorch_metric, metric_key,
         pytorch_metric (dict): Metric info of pytorch metafile.
         metric_key (str):Metric info.
         yaml_metric_info_name (str): Name of metric info in test yaml.
-        log_path (str): Logger path.
+        log_path (Path): Logger path.
         metrics_eval_list (dict): Metric list from test yaml.
         metric_info (dict): Metric info.
-        logger (Logger): Logger handler.
+        logger (logger.Logger): Logger handler.
 
     Returns:
         Float: fps: FPS of the model.
@@ -508,11 +513,37 @@ def get_fps_metric(shell_res, pytorch_metric, metric_key,
     return fps, metric_list, test_pass
 
 
-def get_backend_fps_metric(
-        deploy_cfg_path, model_cfg_path, convert_checkpoint_path, device_type,
-        eval_name, logger, metrics_eval_list, pytorch_metric, metric_info,
-        backend_name, precision_type, metric_useless, convert_result,
-        report_dict, infer_type, log_path, dataset_type, report_txt_path):
+def get_backend_fps_metric(deploy_cfg_path: str, model_cfg_path: Path,
+                           convert_checkpoint_path: str, device_type: str,
+                           eval_name: str, logger: logging.Logger,
+                           metrics_eval_list: dict, pytorch_metric: dict,
+                           metric_info: dict, backend_name: str,
+                           precision_type: str, metric_useless: set,
+                           convert_result: bool, report_dict: dict,
+                           infer_type: str, log_path: Path, dataset_type: str,
+                           report_txt_path: Path):
+    """Get backend fps and metric
+
+    Args:
+        deploy_cfg_path (str): Deploy config path.
+        model_cfg_path (Path): Model config path.
+        convert_checkpoint_path (str): Converted checkpoint path.
+        device_type (str): Device for converting.
+        eval_name (str): Name of evaluation.
+        logger (logging.Logger): Logger handler.
+        metrics_eval_list (dict): Evaluation metric info dict.
+        pytorch_metric (dict): Pytorch metric info dict get from metafile.
+        metric_info (dict): Metric info from test yaml.
+        backend_name (str): Backend name.
+        precision_type (str): Precision type for evaluation.
+        metric_useless (set): Useless metric for specific the model.
+        convert_result (bool): Backend convert result.
+        report_dict (dict): Backend convert result.
+        infer_type (str): Infer type.
+        log_path (Path): Logger save path.
+        dataset_type (str): Dataset type.
+        report_txt_path (Path): report txt save path.
+    """
     cmd_str = f'cd {str(Path(__file__).absolute().parent.parent)} && ' \
               'python3 tools/test.py ' \
               f'{deploy_cfg_path} ' \
@@ -573,6 +604,14 @@ def get_backend_fps_metric(
 
 
 def get_precision_type(deploy_cfg_name: str):
+    """Get backend precision_type according to the name of deploy config.
+
+    Args:
+        deploy_cfg_name (str): Name of the deploy config.
+
+    Returns:
+        Str: precision_type: Precision type of the deployment name.
+    """
     if 'int8' in deploy_cfg_name:
         precision_type = 'int8'
     elif 'fp16' in deploy_cfg_name:
@@ -583,12 +622,13 @@ def get_precision_type(deploy_cfg_name: str):
     return precision_type
 
 
-def replace_top_in_pipeline_json(backend_output_path, logger):
+def replace_top_in_pipeline_json(backend_output_path: Path,
+                                 logger: logging.Logger):
     """Replace `topk` with `num_classes` in `pipeline.json`.
 
     Args:
         backend_output_path (Path): Backend convert result path.
-        logger (Logger): Logger handler.
+        logger (logger.Logger): Logger handler.
     """
 
     sdk_pipeline_json_path = backend_output_path.joinpath('pipeline.json')
@@ -612,10 +652,12 @@ def replace_top_in_pipeline_json(backend_output_path, logger):
     logger.info('replace done')
 
 
-def get_backend_result(pipeline_info, model_cfg_path, checkpoint_path,
-                       work_dir, device_type, pytorch_metric, metric_info,
-                       report_dict, test_type, logger, log_path,
-                       backend_file_name, report_txt_path):
+def get_backend_result(pipeline_info: dict, model_cfg_path: Path,
+                       checkpoint_path: Path, work_dir: Path, device_type: str,
+                       pytorch_metric: dict, metric_info: dict,
+                       report_dict: dict, test_type: str,
+                       logger: logging.Logger, log_path: Path,
+                       backend_file_name: [str, list], report_txt_path: Path):
     """Convert model to onnx and then get metric.
 
     Args:
@@ -627,7 +669,7 @@ def get_backend_result(pipeline_info, model_cfg_path, checkpoint_path,
         pytorch_metric (dict): All pytorch metric info.
         metric_info (dict): Metrics info.
         report_dict (dict): Report info dict.
-        test_type (sgr): Test type. 'precision' or 'convert'.
+        test_type (str): Test type. 'precision' or 'convert'.
         logger (logging.Logger): Logger.
         log_path (Path): Path for logger file.
         backend_file_name (str | list): backend file save name.
@@ -747,7 +789,7 @@ def get_backend_result(pipeline_info, model_cfg_path, checkpoint_path,
         for metric_name in metrics_eval_list:
             if backend_test:
                 get_backend_fps_metric(
-                    deploy_cfg_path=deploy_cfg_path,
+                    deploy_cfg_path=str(deploy_cfg_path),
                     model_cfg_path=model_cfg_path,
                     convert_checkpoint_path=convert_checkpoint_path,
                     device_type=device_type,
@@ -830,7 +872,8 @@ def get_backend_result(pipeline_info, model_cfg_path, checkpoint_path,
             report_txt_path=report_txt_path)
 
 
-def save_report(report_info, report_save_path, logger):
+def save_report(report_info: dict, report_save_path: Path,
+                logger: logging.Logger):
     """Convert model to onnx and then get metric.
 
     Args:

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -211,7 +211,8 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
     """
 
     if model_config_name not in meta_info:
-        logger.warning(f'{model_config_name} not in meta_info, which is {meta_info}')
+        logger.warning(
+            f'{model_config_name} not in meta_info, which is {meta_info}')
         return {}
 
     model_info = meta_info.get(model_config_name, None)
@@ -886,15 +887,16 @@ def save_report(report_info: dict, report_save_path: Path,
         report_save_path (Path): Report save path.
         logger (logging.Logger): Logger.
     """
-    logger.info(f'Save regression test report '
-                f'to {report_save_path}, pls wait...')
+    logger.info('Saving regression test report to '
+                f'{report_save_path.absolute().resolve()}, pls wait...')
     try:
         df = pd.DataFrame(report_info)
         df.to_excel(report_save_path)
     except ValueError:
         logger.info(f'Got error report_info = {report_info}')
 
-    logger.info(f'Saved regression test report to {report_save_path}.')
+    logger.info('Saved regression test report to '
+                f'{report_save_path.absolute().resolve()}.')
 
 
 def main():


### PR DESCRIPTION
I got some rebase problem on my previous PR #271, so I open another one. 😄 

## Motivation

Regression test for mmedploy.

## Modification

This PR is for mmdeploy regession test.

## New doc

New doc: `docs/zh_cn/tutorials/how_to_do_regression_test.md`

## Use cases

```shell
python ./tools/regression_test.py \
    --deploy-yml "${DEPLOY_YML_PATH}" \
    --backends "${BACKEND}" \
    --work-dir "${WORK_DIR}" \
    --device "${DEVICE}" \
    --log-level INFO \
    [--performance]
```

## Backends
- [x] ONNX Runtime
- [x] TensorRT
- [x] PPLNN
- [x] ncnn
- [x] OpenVINO
- [x] TorchScript
- [x] MMDeploy SDK

## Codebases & Metric
- [x] mmdet
  - [x] bbox
  - ~~segm~~
  - ~~PQ~~
- [x] mmcls
  - [x] accuracy
- [x] mmseg
  - [x] mIoU
- [x] mmpose
  - [x] AR
  - [x] AP
- [x] mmocr
  - [x] hmean
  - [x] acc
- [x] mmedit
  - [x] PSNR
  - [x] SSIM
- ~~mmdet3d~~

# Flow Chart

<div align=center>
<img src="https://user-images.githubusercontent.com/25873202/161053317-8c269afe-874c-475d-bba6-cba600769024.png"/>
</div>

# Test-yaml demo (part of it)
![image](https://user-images.githubusercontent.com/25873202/162599199-cf9da109-8e6d-4990-9ed2-e577a88f1c59.png)


# Report

This is all reports after the regrssion finish under `${WORK_DIR}`:
![image](https://user-images.githubusercontent.com/25873202/162599147-c61aa1e9-50a3-4c70-b456-957f742a45aa.png)


This is a mmocr report example:
![image](https://user-images.githubusercontent.com/25873202/162599237-f98cecd0-6b0b-4afe-a5d6-5ea53ba97546.png)



## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
