### PR TITLE
[Fix] MMEditing cannot save results when testing

### DIFF
--- a/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
+++ b/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
@@ -90,7 +90,6 @@ class End2EndModel(BaseBackendModel):
                      lq: torch.Tensor,
                      gt: Optional[torch.Tensor] = None,
                      meta=None,
-                     save_image=False,
                      save_path=None,
                      *args,
                      **kwargs):
@@ -100,7 +99,6 @@ class End2EndModel(BaseBackendModel):
             lq (torch.Tensor): The input low-quality image of the model.
             gt (torch.Tensor): The ground truth of input image. Defaults to
                 `None`.
-            save_image (bool): Whether to save image. Default: False.
             save_path (str): Path to save image. Default: None.
             *args: Other arguments.
             **kwargs: Other key-pair arguments.
@@ -112,7 +110,7 @@ class End2EndModel(BaseBackendModel):
         result = self.test_post_process(outputs, lq, gt)
 
         # Align to mmediting BasicRestorer
-        if save_image and save_path:
+        if save_path:
             outputs = [torch.from_numpy(i) for i in outputs]
 
             lq_path = meta[0]['lq_path']

--- a/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
+++ b/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
 from typing import List, Optional, Sequence, Union
 
 import mmcv
@@ -6,7 +7,6 @@ import numpy as np
 import torch
 from mmcv.utils import Registry
 from mmedit.core import psnr, ssim, tensor2img
-import os.path as osp
 
 from mmdeploy.codebase.base import BaseBackendModel
 from mmdeploy.utils import (Backend, get_backend, get_codebase_config,

--- a/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
+++ b/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
@@ -108,7 +108,6 @@ class End2EndModel(BaseBackendModel):
         Returns:
             dict: Evaluation results.
         """
-        gt = (gt + 1) / 2.0
         outputs = self.forward_dummy(lq)
         result = self.test_post_process(outputs, lq, gt)
 

--- a/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
+++ b/mmdeploy/codebase/mmedit/deploy/super_resolution_model.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
-from typing import List, Optional, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import mmcv
 import numpy as np
@@ -89,7 +89,7 @@ class End2EndModel(BaseBackendModel):
     def forward_test(self,
                      lq: torch.Tensor,
                      gt: Optional[torch.Tensor] = None,
-                     meta=None,
+                     meta: List[Dict] = None,
                      save_path=None,
                      *args,
                      **kwargs):
@@ -99,6 +99,7 @@ class End2EndModel(BaseBackendModel):
             lq (torch.Tensor): The input low-quality image of the model.
             gt (torch.Tensor): The ground truth of input image. Defaults to
                 `None`.
+            meta (List[Dict]): The meta infomations of MMEditing.
             save_path (str): Path to save image. Default: None.
             *args: Other arguments.
             **kwargs: Other key-pair arguments.


### PR DESCRIPTION
## Motivation

We can save results when using `tools/test.py`. However, MMEditing fails to do this because we lack some codes.

## Modification

Copy the codes related to save results from `mmedit.basic_restorer.py`  to `mmdeploy.super_resolution_model.py`

