### PR TITLE
fix wrong input mat type

### DIFF
--- a/csrc/apis/c/classifier.cpp
+++ b/csrc/apis/c/classifier.cpp
@@ -86,7 +86,7 @@ int mmdeploy_classifier_apply(mm_handle_t handle, const mm_mat_t* mats, int mat_
 
     Value input{Value::kArray};
     for (int i = 0; i < mat_count; ++i) {
-      mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
+      mmdeploy::Mat _mat{mats[i].height,         mats[i].width, PixelFormat(mats[i].format),
                          DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
       input.front().push_back({{"ori_img", _mat}});
     }

--- a/csrc/apis/c/classifier.cpp
+++ b/csrc/apis/c/classifier.cpp
@@ -87,7 +87,7 @@ int mmdeploy_classifier_apply(mm_handle_t handle, const mm_mat_t* mats, int mat_
     Value input{Value::kArray};
     for (int i = 0; i < mat_count; ++i) {
       mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
-                         DataType(mats->type), mats[i].data,  Device{"cpu"}};
+                         DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
       input.front().push_back({{"ori_img", _mat}});
     }
 

--- a/csrc/apis/c/detector.cpp
+++ b/csrc/apis/c/detector.cpp
@@ -86,7 +86,7 @@ int mmdeploy_detector_apply(mm_handle_t handle, const mm_mat_t* mats, int mat_co
     Value input{Value::kArray};
     for (int i = 0; i < mat_count; ++i) {
       mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
-                         DataType(mats->type), mats[i].data,  Device{"cpu"}};
+                         DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
       input.front().push_back({{"ori_img", _mat}});
     }
 

--- a/csrc/apis/c/detector.cpp
+++ b/csrc/apis/c/detector.cpp
@@ -85,7 +85,7 @@ int mmdeploy_detector_apply(mm_handle_t handle, const mm_mat_t* mats, int mat_co
 
     Value input{Value::kArray};
     for (int i = 0; i < mat_count; ++i) {
-      mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
+      mmdeploy::Mat _mat{mats[i].height,         mats[i].width, PixelFormat(mats[i].format),
                          DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
       input.front().push_back({{"ori_img", _mat}});
     }

--- a/csrc/apis/c/pose_detector.cpp
+++ b/csrc/apis/c/pose_detector.cpp
@@ -105,7 +105,7 @@ int mmdeploy_pose_detector_apply_bbox(mm_handle_t handle, const mm_mat_t* mats, 
     auto result_count = 0;
     for (int i = 0; i < mat_count; ++i) {
       mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
-                         DataType(mats->type), mats[i].data,  Device{"cpu"}};
+                         DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
 
       Value img_with_boxes;
       if (bboxes && bbox_count) {

--- a/csrc/apis/c/pose_detector.cpp
+++ b/csrc/apis/c/pose_detector.cpp
@@ -104,7 +104,7 @@ int mmdeploy_pose_detector_apply_bbox(mm_handle_t handle, const mm_mat_t* mats, 
     Value input{Value::kArray};
     auto result_count = 0;
     for (int i = 0; i < mat_count; ++i) {
-      mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
+      mmdeploy::Mat _mat{mats[i].height,         mats[i].width, PixelFormat(mats[i].format),
                          DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
 
       Value img_with_boxes;

--- a/csrc/apis/c/segmentor.cpp
+++ b/csrc/apis/c/segmentor.cpp
@@ -84,7 +84,7 @@ int mmdeploy_segmentor_apply(mm_handle_t handle, const mm_mat_t* mats, int mat_c
 
     Value input{Value::kArray};
     for (int i = 0; i < mat_count; ++i) {
-      mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
+      mmdeploy::Mat _mat{mats[i].height,         mats[i].width, PixelFormat(mats[i].format),
                          DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
       input.front().push_back({{"ori_img", _mat}});
     }

--- a/csrc/apis/c/segmentor.cpp
+++ b/csrc/apis/c/segmentor.cpp
@@ -85,7 +85,7 @@ int mmdeploy_segmentor_apply(mm_handle_t handle, const mm_mat_t* mats, int mat_c
     Value input{Value::kArray};
     for (int i = 0; i < mat_count; ++i) {
       mmdeploy::Mat _mat{mats[i].height,       mats[i].width, PixelFormat(mats[i].format),
-                         DataType(mats->type), mats[i].data,  Device{"cpu"}};
+                         DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
       input.front().push_back({{"ori_img", _mat}});
     }
 

--- a/csrc/apis/c/text_recognizer.cpp
+++ b/csrc/apis/c/text_recognizer.cpp
@@ -142,7 +142,7 @@ int mmdeploy_text_recognizer_apply_bbox(mm_handle_t handle, const mm_mat_t *imag
       }
 
       result_index[i] = static_cast<int>(input_images.size());
-      mmdeploy::Mat _mat{images[i].height,       images[i].width, PixelFormat(images[i].format),
+      mmdeploy::Mat _mat{images[i].height,         images[i].width, PixelFormat(images[i].format),
                          DataType(images[i].type), images[i].data,  Device{"cpu"}};
       input_images.push_back({{"ori_img", _mat}});
     }

--- a/csrc/apis/c/text_recognizer.cpp
+++ b/csrc/apis/c/text_recognizer.cpp
@@ -143,7 +143,7 @@ int mmdeploy_text_recognizer_apply_bbox(mm_handle_t handle, const mm_mat_t *imag
 
       result_index[i] = static_cast<int>(input_images.size());
       mmdeploy::Mat _mat{images[i].height,       images[i].width, PixelFormat(images[i].format),
-                         DataType(images->type), images[i].data,  Device{"cpu"}};
+                         DataType(images[i].type), images[i].data,  Device{"cpu"}};
       input_images.push_back({{"ori_img", _mat}});
     }
 


### PR DESCRIPTION
## Motivation

In sdk c api, the input mat type of some codebase always point to the first mat type, which I think is wrong.

## Modification

- [x] csrc/apis/c/classifier.cpp
- [x] csrc/apis/c/detector.cpp
- [x] csrc/apis/c/pose_detector.cpp
- [x] csrc/apis/c/segmentor.cpp
- [x] csrc/apis/c/text_recognizer.cpp
