### PR TITLE
[BUG] Fix mmdet openvino dynamic 300x300 cfg base

### DIFF
--- a/configs/mmdet/detection/detection_openvino_dynamic-300x300.py
+++ b/configs/mmdet/detection/detection_openvino_dynamic-300x300.py
@@ -1,1 +1,1 @@
-_base_ = ['../_base_/base_openvino_dynamic.py']
+_base_ = ['../_base_/base_openvino_dynamic-300x300.py']


### PR DESCRIPTION
## Motivation

When using `configs/mmdet/detection/detection_openvino_dynamic-300x300.py` will trigger the error `../_base_/base_openvino_dynamic.py don't exist`.

## Modification

Fixed mmdet openvino dynamic 300x300 cfg base path.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
