### PR TITLE
[Doc] Improve Jetson tutorial install doc

### DIFF
--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -121,23 +121,12 @@ MMCV_WITH_OPS=1 pip install -e .
 
 ### Update cmake
 
-We choose cmake version 20 as an example.
-```shell
-sudo apt remove cmake
-sudo apt purge --auto-remove cmake
-sudo apt-get install -y libssl-dev
-wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0.tar.gz
-tar -zxvf cmake-3.20.0.tar.gz
-cd cmake-3.20.0
-./bootstrap
-make -j$(nproc)
-sudo make install
-```
-Then we can check the cmake version through:
-```shell
-source ~/.bashrc
-cmake --version
-```
+We choose cmake version `v3.23.1` as an example. We use the pre-built cmake binary to update it.
+
+| Install type |
+| --- |
+| [cmake-3.23.1-linux-aarch64.sh](https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-aarch64.sh) |
+|[cmake-3.23.1-linux-aarch64.tar.gz](https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-aarch64.tar.gz)|
 
 ### Install spdlog
 ```shell

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -173,7 +173,7 @@ cd MMDeploy
 git submodule update --init --recursive
 ````
 
-We need the path of TensorRT and cuDNN path for MMDeploy installation.
+We need the path of TensorRT and cuDNN for MMDeploy installation.
 - for Jetson Nano:
 ```shell
 export TENSORRT_DIR=/usr/src/tensorrt

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -218,4 +218,4 @@ running the object detection example:
 
   **Q**: There 2 steps you need to do:
   1. Set `MAX N` mode and process `sudo nvpmodel -m 0 && sudo jetson_clocks`.
-  2. Reducing the number of `pre_top_k` in deploy config file like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. I reduse it to `1000` and it work.
+  2. Reducing the number of `pre_top_k` in deploy config file like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. I reduce it to `1000` and it work.

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -218,4 +218,4 @@ running the object detection example:
 
   **Q**: There 2 steps you need to do:
   1. Set `MAX N` mode and process `sudo nvpmodel -m 0 && sudo jetson_clocks`.
-  2. Reducing the number of `pre_top_k` like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. For Jetson Nano and TX2 I use `1000` to make it work.
+  2. Reducing the number of `pre_top_k` like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. For Jetson Nano and TX2, I use `1000` to make it work.

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -25,14 +25,22 @@ For the first method, if it always throws `Attention something went wrong...` ev
 
 Sometimes we just need to reboot the jetson device when it gets stuck in initializing the system.
 
-### Cuda
+### CUDA
 
-The Cuda is installed by default while the cudnn is not if we use the first method. We have to write the cuda path and lib to `$PATH` and `$LD_LIBRARY_PATH`:
+The CUDA is installed by default and we have to write the CUDA path and lib to `$PATH` and `$LD_LIBRARY_PATH`:
 ```shell
 export PATH=$PATH:/usr/local/cuda/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
 ```
 Then we can use `nvcc -V` the get the version of cuda we use.
+
+If you want to save CUDA env variables to bashrc, you could run 
+```bash
+echo '# set env for CUDA and cuDNN' >> ~/.bashrc
+echo 'export PATH=$PATH:/usr/local/cuda/bin' >> ~/.bashrc
+echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' >> ~/.bashrc
+source ~/.bashrc
+```
 
 ### Conda
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -60,7 +60,7 @@ conda create -n mmdeploy python=3.6
 conda activate mmdeploy
 ```
 
-### Move tensorrt to conda env
+### Make TensorRT available in your Conda env
 Then we have to move the pre-installed tensorrt package in Jetpack to the virtual env.
 
 First we use `find` to get where the tensorrt is
@@ -164,6 +164,11 @@ sudo apt-get install pkg-config libhdf5-100 libhdf5-dev
 pip install versioned-hdf5
 ```
 
+### Export TensorRT source dir
+```shell
+export TENSORRT_DIR=/usr/include/aarch64-linux-gnu
+```
+
 ### Install MMDeploy
 Using git to clone MMDeploy source code.
 ```shell
@@ -182,9 +187,7 @@ cmake .. \
     -DMMDEPLOY_TARGET_DEVICES="cuda;cpu" \
     -DMMDEPLOY_TARGET_BACKENDS="trt" \
     -DMMDEPLOY_CODEBASES=all \
-    -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl \
-    -DTENSORRT_DIR=/usr/include/aarch64-linux-gnu \
-    -DCUDNN_DIR=/usr/include/aarch64-linux-gnu
+    -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl
 
 make -j$(nproc) && make install
 ```
@@ -201,9 +204,7 @@ pip install -e .
 ```shell
 cd ${MMDEPLOY_DIR}/build/install/example
 mkdir -p build && cd build
-cmake .. \
-  -DMMDeploy_DIR=${MMDEPLOY_DIR}/build/install/lib/cmake/MMDeploy \
-  -DTENSORRT_DIR=/usr/include/aarch64-linux-gnu
+cmake .. -DMMDeploy_DIR=${MMDEPLOY_DIR}/build/install/lib/cmake/MMDeploy
 make -j$(nproc)
 ```
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -113,7 +113,7 @@ Install openssl first:
 ```shell
 sudo apt-get install -y libssl-dev
 ```
-Then install it from source, MMDeploy is using mmcv version is `1.4.0`:
+Since MMDeploy is using mmcv 1.4.0, you can install it from source as below:
 ```shell
 git clone https://github.com/open-mmlab/mmcv.git
 cd mmcv

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -42,7 +42,7 @@ source ~/.bashrc
 conda --version
 ```
 
-After we installed the Archiconda successfully, we can creat the virtual env `mmdeploy` using the command below. 
+After we installed the Archiconda successfully, we can create the virtual env `mmdeploy` using the command below. 
 ```shell
 conda create -n mmdeploy python=3.6  # must be python 3.6
 conda activate mmdeploy

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -179,7 +179,7 @@ cmake .. \
     -DMMDEPLOY_BUILD_SDK=ON \
     -DMMDEPLOY_BUILD_SDK_PYTHON_API=ON \
     -DMMDEPLOY_TARGET_DEVICES="cuda;cpu" \
-    -DMMDEPLOY_TARGET_BACKENDS="ort,trt" \
+    -DMMDEPLOY_TARGET_BACKENDS="ort;trt" \
     -DMMDEPLOY_CODEBASES=all \
     -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl \
     -DTENSORRT_DIR=/usr/src/tensorrt \

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -111,7 +111,7 @@ Install openssl first:
 ```shell
 sudo apt-get install -y libssl-dev
 ```
-Then install it from source, MMDeploy using mmcv version is `1.4.0`:
+Then install it from source, MMDeploy is using mmcv version is `1.4.0`:
 ```shell
 git clone https://github.com/open-mmlab/mmcv.git
 cd mmcv

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -133,18 +133,8 @@ sudo apt-get install libspdlog-dev
 ```
 
 ### Install onnxruntime
-
-1. Install python package
 ```shell
 pip install onnxruntime==1.8.1
-```
-2. Download the linux prebuilt binary package from [here](https://github.com/microsoft/onnxruntime/releases/tag/v1.8.1). Extract it and export environment variables as below:
-```shell
-wget https://github.com/microsoft/onnxruntime/releases/download/v1.8.1/onnxruntime-linux-x64-1.8.1.tgz
-tar -zxvf onnxruntime-linux-x64-1.8.1.tgz
-cd onnxruntime-linux-x64-1.8.1
-export ONNXRUNTIME_DIR=$(pwd)
-export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH
 ```
 
 ### Install pplcv
@@ -179,7 +169,7 @@ cmake .. \
     -DMMDEPLOY_BUILD_SDK=ON \
     -DMMDEPLOY_BUILD_SDK_PYTHON_API=ON \
     -DMMDEPLOY_TARGET_DEVICES="cuda;cpu" \
-    -DMMDEPLOY_TARGET_BACKENDS="ort;trt" \
+    -DMMDEPLOY_TARGET_BACKENDS="trt" \
     -DMMDEPLOY_CODEBASES=all \
     -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl \
     -DTENSORRT_DIR=/usr/src/tensorrt \

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -95,7 +95,7 @@ We can't directly use `pip install torchvision` to install torchvision for Jetso
 ```shell
 sudo apt-get install -y libjpeg-dev libpython3-dev libavcodec-dev libavformat-dev libswscale-dev
 ```
-Then just clone and compile the project, MMDeploy using `torchvision=0.9.0`:
+Then just clone and compile the project, MMDeploy is using `torchvision=0.9.0`:
 ```shell
 git clone https://github.com/pytorch/vision.git
 cd vision

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -267,3 +267,4 @@ Take the object detection for example:
 
   1. Set `MAX N` mode and perform `sudo nvpmodel -m 0 && sudo jetson_clocks`.
   2. Reduce the number of `pre_top_k` in deploy config file like [mmdet pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) does, e.g., `1000`.
+  3. Convert the model again and try SDK demo again.

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -215,8 +215,8 @@ running the object detection example:
 
 ### FAQs
 
-- **F-1**: For Jetson TX2 and Jetson Nano, `#assertion/root/workspace/mmdeploy/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp,98` or `pre_top_k need to be reduced for devices with arch 7.2`
+- **F-1**: **For Jetson TX2 and Jetson Nano**, `#assertion/root/workspace/mmdeploy/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp,98` or `pre_top_k need to be reduced for devices with arch 7.2`
 
-  **Q**: There tow step you need to do:
+  **Q**: There 2 steps you need to do:
   1. Set `MAX N` mode and process `sudo nvpmodel -m 0 && sudo jetson_clocks`.
   2. Reducing the number of `pre_top_k` like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. For Jetson Nano and TX2 I use `1000` to make it work.

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -43,6 +43,16 @@ source ~/.bashrc
 nvcc -V
 ```
 
+### pip env
+When we using `pip install` to install some package, it will throws error: `Illegal instruction (core dumped)`
+Follow the below step will solve the problem:
+```shell
+echo '# set env for TensorRT' >> ~/.bashrc
+echo 'export OPENBLAS_CORETYPE=ARMV8' >> ~/.bashrc
+source ~/.bashrc
+source activate mmdeploy
+```
+
 ### Conda
 
 We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below are the example for installation. You can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
@@ -229,3 +239,12 @@ running the object detection example:
   **Q**: There 2 steps you need to do:
   1. Set `MAX N` mode and process `sudo nvpmodel -m 0 && sudo jetson_clocks`.
   2. Reducing the number of `pre_top_k` in deploy config file like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. I reduce it to `1000` and it work.
+
+- **F-2**: `pip install` throws error: `Illegal instruction (core dumped)`
+  **Q**: Follow the below step will solve the problem:
+  ```shell
+  echo '# set env for TensorRT' >> ~/.bashrc
+  echo 'export OPENBLAS_CORETYPE=ARMV8' >> ~/.bashrc
+  source ~/.bashrc
+  source activate mmdeploy
+  ```

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -71,7 +71,6 @@ The `python3.6` is the version we need to use in the conda env later.
 We can create the virtual env `mmdeploy` using the command below. Ensure the python version in the command is the same as the above.
 ```shell
 conda create -y -n mmdeploy python=3.6
-conda activate mmdeploy
 ```
 
 ### Make TensorRT available in your Conda env
@@ -83,13 +82,20 @@ sudo find / -name tensorrt
 ```
 Then copy the tensorrt to our destination like:
 ```shell
-cp -r /usr/lib/python3.6/dist-packages/tensorrt* /your/path/to/archiconda3/envs/mmdeploy/lib/python3.6/site-packages/
+cp -r /usr/lib/python3.6/dist-packages/tensorrt* ~/conda/envs/mmdeploy/lib/python3.6/site-packages/
 ```
 Meanwhile, tensorrt libs like `libnvinfer.so` can be found in `LD_LIBRARY_PATH`, which is done by Jetpack as well.
 
 Final command of this step: export `TENSORRT_DIR` to the system env for MMDeploy installation:
 ```shell
-export TENSORRT_DIR=/usr/include/aarch64-linux-gnu
+echo '# set env for TensorRT' >> ~/.bashrc
+echo 'export TENSORRT_DIR=/usr/include/aarch64-linux-gnu' >> ~/.bashrc
+source ~/.bashrc
+```
+Then we can activate mmdeploy env for test it.
+```shell
+source activate mmdeploy
+python -c "import tensorrt; print(tensorrt.__version__)" # Will print the vresion of TensorRT
 ```
 
 ### Install PyTorch

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -42,11 +42,11 @@ source ~/.bashrc
 conda --version
 ```
 
-After we installed the Archiconda successfully, we need to check the tensorrt python package pre-installed by Jetpack by command below.
+After we install the Archiconda successfully, we need to check the tensorrt python package pre-installed by Jetpack by command below.
 ```shell
 sudo find / -name tensorrt
 ```
-Then you can see something like those in the terminal, take Jetson Nano as example:
+Then you can see something like those in the terminal. Take Jetson Nano as example:
 ```shell
 ...
 /usr/lib/python3.6/dist-packages/tensorrt
@@ -99,7 +99,7 @@ Then just clone and compile the project, MMDeploy is using `torchvision=0.9.0`:
 ```shell
 git clone https://github.com/pytorch/vision.git
 cd vision
-git checkout v0.9.0
+git checkout tags/v0.9.0 -b v0.9.0
 pip install -e .
 ```
 
@@ -150,7 +150,7 @@ pip install onnx
 ```
 
 ### Install pplcv
-PPL.CV is a high-performance image processing library of OpenPPL. Now, MMDeploy supports `v0.6.2` and has to use git clone to download it.
+PPL.CV is a high-performance image processing library of OpenPPL. We need to use git clone to download it.
 ```shell
 git clone https://github.com/openppl-public/ppl.cv.git
 cd ppl.cv
@@ -169,6 +169,7 @@ Using git to clone MMDeploy source code.
 ```shell
 git clone -b master https://github.com/open-mmlab/mmdeploy.git MMDeploy
 cd MMDeploy
+export MMDEPLOY_DIR=$(pwd)
 git submodule update --init --recursive
 ```
 
@@ -176,7 +177,6 @@ Build MMDeploy from source:
 ```shell
 mkdir -p build && cd build
 cmake .. \
-    -DCMAKE_CXX_COMPILER=g++-7 \
     -DMMDEPLOY_BUILD_SDK=ON \
     -DMMDEPLOY_BUILD_SDK_PYTHON_API=ON \
     -DMMDEPLOY_TARGET_DEVICES="cuda;cpu" \
@@ -192,7 +192,7 @@ make -j$(nproc) && make install
 ### Install MMDeploy Python API
 
 ```shell
-cd /path/to/mmdeploy
+cd ${MMDEPLOY_DIR}
 pip install -e .
 ```
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -171,13 +171,6 @@ Using git to clone MMDeploy source code.
 git clone -b master https://github.com/open-mmlab/mmdeploy.git MMDeploy
 cd MMDeploy
 git submodule update --init --recursive
-````
-
-We need the path of TensorRT and cuDNN for MMDeploy installation.
-- for Jetson Nano:
-```shell
-export TENSORRT_DIR=/usr/src/tensorrt
-export CUDNN_DIR=/etc/alternatives
 ```
 
 Build MMDeploy from source:
@@ -191,8 +184,8 @@ cmake .. \
     -DMMDEPLOY_TARGET_BACKENDS="trt" \
     -DMMDEPLOY_CODEBASES=all \
     -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl \
-    -DTENSORRT_DIR=${TENSORRT_DIR} \
-    -DCUDNN_DIR=${CUDNN_DIR}
+    -DTENSORRT_DIR=/usr/include/aarch64-linux-gnu \
+    -DCUDNN_DIR=/usr/include/aarch64-linux-gnu
 
 make -j$(nproc) && make install
 ```

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -253,14 +253,14 @@ Take the object detection for example:
     echo 'export OPENBLAS_CORETYPE=ARMV8' >> ~/.bashrc
     source ~/.bashrc
     ```
-  
+
   If steps below don't work, check if you are using any mirror, if you did, try this:
   ```shell
     rm .condarc
     conda clean -i
     conda create -n xxx python=${PYTHON_VERSION}
     ```
-  
+
 ### Runtime
 
 - `#assertion/root/workspace/mmdeploy/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp,98` or `pre_top_k need to be reduced for devices with arch 7.2`

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -47,10 +47,9 @@ nvcc -V
 When we using `pip install` to install some package, it will throws error: `Illegal instruction (core dumped)`
 Follow the below step will solve the problem:
 ```shell
-echo '# set env for TensorRT' >> ~/.bashrc
+echo '# set env for pip' >> ~/.bashrc
 echo 'export OPENBLAS_CORETYPE=ARMV8' >> ~/.bashrc
-source ~/.bashrc
-source activate mmdeploy
+sudo reboot
 ```
 
 ### Conda
@@ -243,8 +242,8 @@ running the object detection example:
 - **F-2**: `pip install` throws error: `Illegal instruction (core dumped)`
   **Q**: Follow the below step will solve the problem:
   ```shell
-  echo '# set env for TensorRT' >> ~/.bashrc
+  echo '# set env for pip' >> ~/.bashrc
   echo 'export OPENBLAS_CORETYPE=ARMV8' >> ~/.bashrc
-  source ~/.bashrc
-  source activate mmdeploy
+  sudo reboot
+  
   ```

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -34,7 +34,7 @@ Then we can use `nvcc -V` the get the version of cuda we use.
 
 ### Conda
 
-We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below are the example for installation, you can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
+We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below are the example for installation. You can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
 ```shell
 wget https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh
 bash Archiconda3-0.2.3-Linux-aarch64.sh
@@ -56,7 +56,7 @@ The `python3.6` is the version we need to use in the conda env later.
 
 We can create the virtual env `mmdeploy` using the command below. The version of python we got from the previous step.
 ```shell
-conda create -n mmdeploy python=x.x
+conda create -n mmdeploy python=3.6
 conda activate mmdeploy
 ```
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -46,7 +46,6 @@ source ~/.bashrc
 
 We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below are the example for installation. You can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
 ```shell
-cd /opt and 
 wget https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh
 bash Archiconda3-0.2.3-Linux-aarch64.sh
 source ~/.bashrc

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -42,9 +42,21 @@ source ~/.bashrc
 conda --version
 ```
 
-After we installed the Archiconda successfully, we can create the virtual env `mmdeploy` using the command below.
+After we installed the Archiconda successfully, we need to check the tensorrt python package pre-installed by Jetpack by command below.
 ```shell
-conda create -n mmdeploy python=3.6 # must be python 3.6
+sudo find / -name tensorrt
+```
+Then you can see something like those in the terminal, take Jetson Nano as example:
+```shell
+...
+/usr/lib/python3.6/dist-packages/tensorrt
+...
+```
+The `python3.6` is the version we need to use in the conda env later.
+
+We can create the virtual env `mmdeploy` using the command below. The version of python we got from the previous step.
+```shell
+conda create -n mmdeploy python=x.x
 conda activate mmdeploy
 ```
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -155,7 +155,6 @@ PPL.CV is a high-performance image processing library of OpenPPL. Now, MMDeploy 
 git clone https://github.com/openppl-public/ppl.cv.git
 cd ppl.cv
 export PPLCV_DIR=$(pwd)
-git checkout tags/v0.6.2 -b v0.6.2
 ./build.sh cuda
 ```
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -40,6 +40,7 @@ echo '# set env for CUDA' >> ~/.bashrc
 echo 'export PATH=$PATH:/usr/local/cuda/bin' >> ~/.bashrc
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' >> ~/.bashrc
 source ~/.bashrc
+nvcc -V
 ```
 
 ### Conda
@@ -47,7 +48,10 @@ source ~/.bashrc
 We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below are the example for installation. You can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
 ```shell
 wget https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh
-bash Archiconda3-0.2.3-Linux-aarch64.sh
+bash Archiconda3-0.2.3-Linux-aarch64.sh -b -p ~/conda
+rm Archiconda3-0.2.3-Linux-aarch64.sh
+echo '# set env for conda' >> ~/.bashrc
+echo 'export PATH=$PATH:~/conda/bin' >> ~/.bashrc
 source ~/.bashrc
 conda --version
 ```
@@ -66,7 +70,7 @@ The `python3.6` is the version we need to use in the conda env later.
 
 We can create the virtual env `mmdeploy` using the command below. Ensure the python version in the command is the same as the above.
 ```shell
-conda create -n mmdeploy python=3.6
+conda create -y -n mmdeploy python=3.6
 conda activate mmdeploy
 ```
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -75,6 +75,11 @@ cp -r /usr/lib/python3.6/dist-packages/tensorrt* /your/path/to/archiconda3/envs/
 ```
 Meanwhile, tensorrt libs like `libnvinfer.so` can be found in `LD_LIBRARY_PATH`, which is done by Jetpack as well.
 
+Final command of this step: export `TENSORRT_DIR` to the system env for MMDeploy installation:
+```shell
+export TENSORRT_DIR=/usr/include/aarch64-linux-gnu
+```
+
 ### Install PyTorch
 
 Before we use `pip install`, we have to install `libopenblas-base`, `libopenmpi-dev` first:
@@ -153,11 +158,6 @@ export PPLCV_DIR=$(pwd)
 ```shell
 sudo apt-get install pkg-config libhdf5-100 libhdf5-dev
 pip install versioned-hdf5
-```
-
-### Export TensorRT source dir
-```shell
-export TENSORRT_DIR=/usr/include/aarch64-linux-gnu
 ```
 
 ### Install MMDeploy

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -34,7 +34,7 @@ Then we can use `nvcc -V` the get the version of cuda we use.
 
 ### Conda
 
-We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson.
+We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below is an example for installation, you can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
 ```shell
 wget https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh
 bash Archiconda3-0.2.3-Linux-aarch64.sh

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -218,4 +218,4 @@ running the object detection example:
 
   **Q**: There 2 steps you need to do:
   1. Set `MAX N` mode and process `sudo nvpmodel -m 0 && sudo jetson_clocks`.
-  2. Reducing the number of `pre_top_k` like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. For Jetson Nano and TX2, I use `1000` to make it work.
+  2. Reducing the number of `pre_top_k` in deploy config file like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. I reduse it to `1000` and it work.

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -7,6 +7,8 @@ This tutorial introduces how to install mmdeploy on Nvidia Jetson systems. It ma
 
 For Jetson Nano, we use Jetson Nano 2GB and install [JetPack SDK](https://developer.nvidia.com/embedded/jetpack) through SD card image method.
 
+**Note**: The JetPack we use is `4.6`, and the default python version of it is `3.6`
+
 ### Install JetPack SDK
 
 There are mainly two ways to install the JetPack:
@@ -54,7 +56,7 @@ Then you can see something like those in the terminal. Take Jetson Nano as examp
 ```
 The `python3.6` is the version we need to use in the conda env later.
 
-We can create the virtual env `mmdeploy` using the command below. The version of python we got from the previous step.
+We can create the virtual env `mmdeploy` using the command below. Ensure the python version in the command is the same as the above.
 ```shell
 conda create -n mmdeploy python=3.6
 conda activate mmdeploy

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -83,7 +83,7 @@ We can't directly use `pip install torchvision` to install torchvision for Jetso
 ```shell
 sudo apt-get install -y libjpeg-dev libpython3-dev libavcodec-dev libavformat-dev libswscale-dev
 ```
-Then just clone and compile the project:
+Then just clone and compile the project, MMDeploy using `torchvision=0.9.0`:
 ```shell
 git clone https://github.com/pytorch/vision.git
 cd vision

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -188,7 +188,7 @@ cmake .. \
 make -j$(nproc) && make install
 ```
 
-### Install MMDeploy Python API 
+### Install MMDeploy Python API
 
 ```shell
 cd /path/to/mmdeploy

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -214,7 +214,7 @@ running the object detection example:
 
 ### FAQs
 
-- **F-1**: **For Jetson TX2 and Jetson Nano**, `#assertion/root/workspace/mmdeploy/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp,98` or `pre_top_k need to be reduced for devices with arch 7.2`
+- **F-1**: For **Jetson TX2** and **Jetson Nano**, may get the error: `#assertion/root/workspace/mmdeploy/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp,98` or `pre_top_k need to be reduced for devices with arch 7.2`.
 
   **Q**: There 2 steps you need to do:
   1. Set `MAX N` mode and process `sudo nvpmodel -m 0 && sudo jetson_clocks`.

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -144,9 +144,9 @@ cmake --version
 sudo apt-get install libspdlog-dev
 ```
 
-### Install onnxruntime
+### Install onnx
 ```shell
-pip install onnxruntime==1.8.1
+pip install onnx
 ```
 
 ### Install pplcv

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -36,7 +36,7 @@ conda --version
 After the installation, create a conda environment and activate it.
 ```shell
 # get the version of python installed by default
-export PYTHON_VERSION=`python --version | cut -d' ' -f 2 | cut -d'.' -f1,2`
+export PYTHON_VERSION=`python3 --version | cut -d' ' -f 2 | cut -d'.' -f1,2`
 conda create -n mmdeploy python=${PYTHON_VERSION}
 conda activate mmdeploy
 ```

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -150,7 +150,7 @@ git checkout tags/v0.6.2 -b v0.6.2
 ### Install h5py
 ```shell
 sudo apt-get install pkg-config libhdf5-100 libhdf5-dev
-pip install versioned-hdf5 --no-cache-dir
+pip install versioned-hdf5
 ```
 
 ### Install MMDeploy

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -197,9 +197,26 @@ cd /path/to/mmdeploy
 pip install -e .
 ```
 
+### Build MMDeploy SDK Example
+
+```shell
+cd ${MMDEPLOY_DIR}/build/install/example
+mkdir -p build && cd build
+cmake .. \
+  -DMMDeploy_DIR=${MMDEPLOY_DIR}/build/install/lib/cmake/MMDeploy \
+  -DTENSORRT_DIR=/usr/include/aarch64-linux-gnu
+make -j$(nproc)
+```
+
+running the object detection example:
+```shell
+./object_detection cuda ${work_dir} ${path/to/an/image}
+```
+
 ### FAQs
 
-- For Jetson TX2 and Jetson Nano, `#assertion/root/workspace/mmdeploy/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp,98` or `pre_top_k need to be reduced for devices with arch 7.2`
+- **F-1**: For Jetson TX2 and Jetson Nano, `#assertion/root/workspace/mmdeploy/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp,98` or `pre_top_k need to be reduced for devices with arch 7.2`
 
-    Set MAX N mode and `sudo nvpmodel -m 0 && sudo jetson_clocks`.
-    Reducing the number of [pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem.
+  **Q**: There tow step you need to do:
+  1. Set `MAX N` mode and process `sudo nvpmodel -m 0 && sudo jetson_clocks`.
+  2. Reducing the number of `pre_top_k` like [mmedt pre_top_k](https://github.com/open-mmlab/mmdeploy/blob/34879e638cc2db511e798a376b9a4b9932660fe1/configs/mmdet/_base_/base_static.py#L13) to reduce the number of proposals may resolve the problem. For Jetson Nano and TX2 I use `1000` to make it work.

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -42,9 +42,9 @@ source ~/.bashrc
 conda --version
 ```
 
-After we installed the Archiconda successfully, we can create the virtual env `mmdeploy` using the command below. 
+After we installed the Archiconda successfully, we can create the virtual env `mmdeploy` using the command below.
 ```shell
-conda create -n mmdeploy python=3.6  # must be python 3.6
+conda create -n mmdeploy python=3.6 # must be python 3.6
 conda activate mmdeploy
 ```
 
@@ -75,7 +75,7 @@ After that, download the PyTorch wheel for Jetson **specifically**. Click [here]
 
 After the download finished, using cmd to install it.
 ```shell
-pip3 install /your/path/dwonload/xxx.whl
+pip3 install /your/path/dwonload/torch-1.8.0-cp36-cp36m-linux_aarch64.whl
 ```
 
 ### Install torchvision
@@ -99,7 +99,7 @@ Install openssl first:
 ```shell
 sudo apt-get install -y libssl-dev
 ```
-Then install it from source, MMDeploy using mmcv version is `1.4.0`
+Then install it from source, MMDeploy using mmcv version is `1.4.0`:
 ```shell
 git clone https://github.com/open-mmlab/mmcv.git
 cd mmcv
@@ -138,8 +138,7 @@ sudo apt-get install libspdlog-dev
 ```shell
 pip install onnxruntime==1.8.1
 ```
-
-2. Download the linux prebuilt binary package from [here](https://github.com/microsoft/onnxruntime/releases/tag/v1.8.1).  Extract it and export environment variables as below:
+2. Download the linux prebuilt binary package from [here](https://github.com/microsoft/onnxruntime/releases/tag/v1.8.1). Extract it and export environment variables as below:
 ```shell
 wget https://github.com/microsoft/onnxruntime/releases/download/v1.8.1/onnxruntime-linux-x64-1.8.1.tgz
 tar -zxvf onnxruntime-linux-x64-1.8.1.tgz

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -34,7 +34,7 @@ Then we can use `nvcc -V` the get the version of cuda we use.
 
 ### Conda
 
-We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below is an example for installation, you can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
+We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below are the example for installation, you can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
 ```shell
 wget https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh
 bash Archiconda3-0.2.3-Linux-aarch64.sh
@@ -150,7 +150,7 @@ pip install onnx
 ```
 
 ### Install pplcv
-A high-performance image processing library of openPPL. Now, MMDeploy supports `v0.6.2` and has to use git clone to download it.
+PPL.CV is a high-performance image processing library of OpenPPL. Now, MMDeploy supports `v0.6.2` and has to use git clone to download it.
 ```shell
 git clone https://github.com/openppl-public/ppl.cv.git
 cd ppl.cv
@@ -173,6 +173,13 @@ cd MMDeploy
 git submodule update --init --recursive
 ````
 
+We need the path of TensorRT and cuDNN path for MMDeploy installation.
+- for Jetson Nano:
+```shell
+export TENSORRT_DIR=/usr/src/tensorrt
+export CUDNN_DIR=/etc/alternatives
+```
+
 Build MMDeploy from source:
 ```shell
 mkdir -p build && cd build
@@ -184,8 +191,8 @@ cmake .. \
     -DMMDEPLOY_TARGET_BACKENDS="trt" \
     -DMMDEPLOY_CODEBASES=all \
     -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl \
-    -DTENSORRT_DIR=/usr/src/tensorrt \
-    -DCUDNN_DIR=/etc/alternatives
+    -DTENSORRT_DIR=${TENSORRT_DIR} \
+    -DCUDNN_DIR=${CUDNN_DIR}
 
 make -j$(nproc) && make install
 ```

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -1,6 +1,6 @@
 # Build for Jetson
 
-In this chapter, we introduce how to install mmdeploy on NVIDIA Jetson platforms, especially on three main Jetson series boards:
+In this chapter, we introduce how to install mmdeploy on NVIDIA Jetson platforms, which we have verifed on the following models:
 - Jetson Nano
 - Jetson TX2
 - Jetson AGX Xavier

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -7,7 +7,7 @@ This tutorial introduces how to install mmdeploy on Nvidia Jetson systems. It ma
 
 For Jetson Nano, we use Jetson Nano 2GB and install [JetPack SDK](https://developer.nvidia.com/embedded/jetpack) through SD card image method.
 
-**Note**: The JetPack we use is `4.6`, and the default python version of it is `3.6`
+**Note**: The JetPack we use is `4.6.1`, and the default python version of it is `3.6`
 
 ### Install JetPack SDK
 
@@ -36,7 +36,7 @@ Then we can use `nvcc -V` the get the version of cuda we use.
 
 If you want to save CUDA env variables to bashrc, you could run 
 ```bash
-echo '# set env for CUDA and cuDNN' >> ~/.bashrc
+echo '# set env for CUDA' >> ~/.bashrc
 echo 'export PATH=$PATH:/usr/local/cuda/bin' >> ~/.bashrc
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' >> ~/.bashrc
 source ~/.bashrc
@@ -46,6 +46,7 @@ source ~/.bashrc
 
 We have to install [Archiconda](https://github.com/Archiconda/build-tools/releases) instead as the Anaconda does not provide the wheel built for jetson. The commands below are the example for installation. You can choose another version of Archiconda by accessing [Archiconda releases page](https://github.com/Archiconda/build-tools/releases).
 ```shell
+cd /opt and 
 wget https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh
 bash Archiconda3-0.2.3-Linux-aarch64.sh
 source ~/.bashrc

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -7,7 +7,7 @@ This tutorial introduces how to install mmdeploy on Nvidia Jetson systems. It ma
 
 For Jetson Nano, we use Jetson Nano 2GB and install [JetPack SDK](https://developer.nvidia.com/embedded/jetpack) through SD card image method.
 
-**Note**: The JetPack we use is `4.6.1`, and the default python version of it is `3.6`
+**Note**: The JetPack we use is `4.6.1`, and the default python version of it is `3.6`.
 
 ### Install JetPack SDK
 
@@ -34,7 +34,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
 ```
 Then we can use `nvcc -V` the get the version of cuda we use.
 
-If you want to save CUDA env variables to bashrc, you could run 
+If you want to save CUDA env variables to bashrc, you could run:
 ```bash
 echo '# set env for CUDA' >> ~/.bashrc
 echo 'export PATH=$PATH:/usr/local/cuda/bin' >> ~/.bashrc

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -254,7 +254,7 @@ Take the object detection for example:
     source ~/.bashrc
     ```
 
-  If steps below don't work, check if you are using any mirror, if you did, try this:
+  If steps above don't work, check if you are using any mirror, if you did, try this:
   ```shell
     rm .condarc
     conda clean -i


### PR DESCRIPTION
## Motivation

Improve mmdeploy build on Jetson doc: `docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md`

## Modification

I follow the doc to build mmdeploy on Jetson nano (4G version, Jetpack 4.6.1), and I add some solution or details when I can't get it from the doc.

## Still need to do
- [x] Cmake version of JetPack
- [x] Cmake update guide detail
- [x] Conda install path to `~/archiconda` and show the installation detail

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
