### PR TITLE
[Fix] ncnn [-Wreturn-type] and improve mutex `if`

### DIFF
--- a/csrc/backend_ops/ncnn/ops/constantofshape/constantofshape.cpp
+++ b/csrc/backend_ops/ncnn/ops/constantofshape/constantofshape.cpp
@@ -30,7 +30,7 @@ int ConstantOfShape::forward(const Mat& bottom_blob, Mat& top_blob, const Option
     top_blob.fill(val);
     return 0;
   }
-  if (dims == 2) {
+  else if (dims == 2) {
     int h = (int)(shape_ptr[0] + 0.5);
     int w = (int)(shape_ptr[1] + 0.5);
     size_t elemsize = sizeof(val);
@@ -39,7 +39,7 @@ int ConstantOfShape::forward(const Mat& bottom_blob, Mat& top_blob, const Option
     top_blob.fill(val);
     return 0;
   }
-  if (dims == 3) {
+  else if (dims == 3) {
     int channels = (int)(shape_ptr[0] + 0.5);
     int h = (int)(shape_ptr[1] + 0.5);
     int w = (int)(shape_ptr[2] + 0.5);
@@ -49,6 +49,7 @@ int ConstantOfShape::forward(const Mat& bottom_blob, Mat& top_blob, const Option
     top_blob.fill(val);
     return 0;
   }
+  return -1;
 }
 
 }  // namespace mmdeploy

--- a/csrc/backend_ops/ncnn/ops/constantofshape/constantofshape.cpp
+++ b/csrc/backend_ops/ncnn/ops/constantofshape/constantofshape.cpp
@@ -29,8 +29,7 @@ int ConstantOfShape::forward(const Mat& bottom_blob, Mat& top_blob, const Option
     if (top_blob.empty()) return -100;
     top_blob.fill(val);
     return 0;
-  }
-  else if (dims == 2) {
+  } else if (dims == 2) {
     int h = (int)(shape_ptr[0] + 0.5);
     int w = (int)(shape_ptr[1] + 0.5);
     size_t elemsize = sizeof(val);
@@ -38,8 +37,7 @@ int ConstantOfShape::forward(const Mat& bottom_blob, Mat& top_blob, const Option
     if (top_blob.empty()) return -100;
     top_blob.fill(val);
     return 0;
-  }
-  else if (dims == 3) {
+  } else if (dims == 3) {
     int channels = (int)(shape_ptr[0] + 0.5);
     int h = (int)(shape_ptr[1] + 0.5);
     int w = (int)(shape_ptr[2] + 0.5);

--- a/csrc/backend_ops/ncnn/ops/expand/expand.cpp
+++ b/csrc/backend_ops/ncnn/ops/expand/expand.cpp
@@ -46,8 +46,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
       return -100;
     }
     return 0;
-  }
-  else if (bottom_blob.dims == 1 && shape_blob.w == 2) {
+  } else if (bottom_blob.dims == 1 && shape_blob.w == 2) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     if (bottom_blob.w != shape_1 && bottom_blob.w != 1 && shape_1 != 1) {
@@ -78,8 +77,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
       return -100;
     }
     return 0;
-  }
-  else if (bottom_blob.dims == 1 && shape_blob.w == 3) {
+  } else if (bottom_blob.dims == 1 && shape_blob.w == 3) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     int shape_2 = (int)(shape_blob[2] + 0.5);
@@ -112,8 +110,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
       return -100;
     }
     return 0;
-  }
-  else if (bottom_blob.dims == 2 && shape_blob.w == 2) {
+  } else if (bottom_blob.dims == 2 && shape_blob.w == 2) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     if (bottom_blob.w != shape_1 && bottom_blob.w != 1 && shape_1 != 1) {
@@ -160,8 +157,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
       return -100;
     }
     return 0;
-  }
-  else if (bottom_blob.dims == 2 && shape_blob.w == 3) {
+  } else if (bottom_blob.dims == 2 && shape_blob.w == 3) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     int shape_2 = (int)(shape_blob[2] + 0.5);
@@ -219,8 +215,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
       return -100;
     }
     return 0;
-  }
-  else if (bottom_blob.dims == 3 && shape_blob.w == 3) {
+  } else if (bottom_blob.dims == 3 && shape_blob.w == 3) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     int shape_2 = (int)(shape_blob[2] + 0.5);

--- a/csrc/backend_ops/ncnn/ops/expand/expand.cpp
+++ b/csrc/backend_ops/ncnn/ops/expand/expand.cpp
@@ -47,7 +47,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
     }
     return 0;
   }
-  if (bottom_blob.dims == 1 && shape_blob.w == 2) {
+  else if (bottom_blob.dims == 1 && shape_blob.w == 2) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     if (bottom_blob.w != shape_1 && bottom_blob.w != 1 && shape_1 != 1) {
@@ -79,7 +79,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
     }
     return 0;
   }
-  if (bottom_blob.dims == 1 && shape_blob.w == 3) {
+  else if (bottom_blob.dims == 1 && shape_blob.w == 3) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     int shape_2 = (int)(shape_blob[2] + 0.5);
@@ -113,7 +113,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
     }
     return 0;
   }
-  if (bottom_blob.dims == 2 && shape_blob.w == 2) {
+  else if (bottom_blob.dims == 2 && shape_blob.w == 2) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     if (bottom_blob.w != shape_1 && bottom_blob.w != 1 && shape_1 != 1) {
@@ -161,7 +161,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
     }
     return 0;
   }
-  if (bottom_blob.dims == 2 && shape_blob.w == 3) {
+  else if (bottom_blob.dims == 2 && shape_blob.w == 3) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     int shape_2 = (int)(shape_blob[2] + 0.5);
@@ -220,7 +220,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
     }
     return 0;
   }
-  if (bottom_blob.dims == 3 && shape_blob.w == 3) {
+  else if (bottom_blob.dims == 3 && shape_blob.w == 3) {
     int shape_0 = (int)(shape_blob[0] + 0.5);
     int shape_1 = (int)(shape_blob[1] + 0.5);
     int shape_2 = (int)(shape_blob[2] + 0.5);
@@ -332,6 +332,7 @@ int Expand::forward(const std::vector<Mat>& bottom_blobs, std::vector<Mat>& top_
   }
   fprintf(stderr, "Layer: Expand, bottom_blob.dims: %d, shape_blob.w: %d\n", bottom_blob.dims,
           shape_blob.w);
+  return -1;
 }
 
 }  // namespace mmdeploy


### PR DESCRIPTION
I using `dev-v0.5.0` for base, If I merge to `master` it will be plenty file changed which is not my commit. So I PR to `v0.5.0`.

## Motivation

When I compile project, I met warning for ncnn : `control reaches end of non-void function [-Wreturn-type]`

## Modification

- Add `return -1` at the end of `Expand::forward` of `csrc/backend_ops/ncnn/ops/expand/expand.cpp`
- Add `return -1` at the end of  `ConstantOfShape::forward` of `csrc/backend_ops/ncnn/ops/constantofshape/constantofshape.cpp`

Also I make the mutex if to `if ... else if ...`
