### PR TITLE
fix mmdet ONNXRuntime cuda test bug

### DIFF
--- a/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
@@ -208,6 +208,7 @@ class End2EndModel(BaseBackendModel):
         rescale = kwargs.get('rescale', True)
         for i in range(batch_size):
             dets, labels = batch_dets[i], batch_labels[i]
+            dets = dets.to(device=torch.device(self.device))
             if rescale:
                 scale_factor = img_metas[i]['scale_factor']
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix mmdet ONNXRuntime cuda test bug.
Some error happended when I test the yolox speed.
```
python tools/test.py \
    configs/mmdet/detection/detection_onnxruntime_dynamic.py \
    ../mmdetection/configs/yolox/yolox_s_8x8_300e_coco.py \
    --model work_dir/det/yolox-s-ort-dynamic/end2end.onnx \
    --speed-test \
    --log2file work_dir/det/yolox-s-ort-dynamic/logs-cuda.txt \
    --device cuda:0
```
error
```
Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

## Modification

Under the line https://github.com/open-mmlab/mmdeploy/blob/master/mmdeploy/codebase/mmdet/deploy/object_detection_model.py#L210 add this code could solve the question.
```python
dets = dets.to(device=torch.device(self.device))
```


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
