### PR TITLE
fix mmseg twice resize

### DIFF
--- a/mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py
+++ b/mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py
@@ -1,9 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch.nn.functional as F
-from mmseg.ops import resize
 
 from mmdeploy.core import FUNCTION_REWRITER
-from mmdeploy.utils import is_dynamic_shape
 
 
 @FUNCTION_REWRITER.register_rewriter(
@@ -25,16 +23,7 @@ def encoder_decoder__simple_test(ctx, self, img, img_meta, **kwargs):
         torch.Tensor: Output segmentation map pf shape [N, 1, H, W].
     """
     seg_logit = self.encode_decode(img, img_meta)
-    seg_logit = resize(
-        input=seg_logit,
-        size=img_meta['img_shape'],
-        mode='bilinear',
-        align_corners=self.align_corners)
     seg_logit = F.softmax(seg_logit, dim=1)
-    seg_pred = seg_logit.argmax(dim=1)
-    # our inference backend only support 4D output
-    shape = seg_pred.shape
-    if not is_dynamic_shape(ctx.cfg):
-        shape = [int(_) for _ in shape]
-    seg_pred = seg_pred.view(shape[0], 1, shape[1], shape[2])
+    # keep 4D output required by backends such as TensorRT
+    seg_pred = seg_logit.argmax(dim=1, keepdim=True)
     return seg_pred

--- a/mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py
+++ b/mmdeploy/codebase/mmseg/models/segmentors/encoder_decoder.py
@@ -24,6 +24,5 @@ def encoder_decoder__simple_test(ctx, self, img, img_meta, **kwargs):
     """
     seg_logit = self.encode_decode(img, img_meta)
     seg_logit = F.softmax(seg_logit, dim=1)
-    # keep 4D output required by backends such as TensorRT
     seg_pred = seg_logit.argmax(dim=1, keepdim=True)
     return seg_pred

--- a/tests/test_codebase/test_mmseg/test_mmseg_models.py
+++ b/tests/test_codebase/test_mmseg/test_mmseg_models.py
@@ -93,7 +93,8 @@ def _demo_mm_inputs(input_shape=(1, 3, 8, 16), num_classes=10):
     return mm_inputs
 
 
-@pytest.mark.parametrize('backend', [Backend.ONNXRUNTIME, Backend.OPENVINO])
+@pytest.mark.parametrize('backend',
+                         [Backend.ONNXRUNTIME, Backend.OPENVINO, Backend.NCNN])
 def test_encoderdecoder_simple_test(backend):
     check_backend(backend)
     segmentor = get_model()
@@ -109,7 +110,8 @@ def test_encoderdecoder_simple_test(backend):
         num_classes = segmentor.decode_head[-1].num_classes
     else:
         num_classes = segmentor.decode_head.num_classes
-    mm_inputs = _demo_mm_inputs(num_classes=num_classes)
+    mm_inputs = _demo_mm_inputs(
+        input_shape=(1, 3, 32, 32), num_classes=num_classes)
     imgs = mm_inputs.pop('imgs')
     img_metas = mm_inputs.pop('img_metas')
     model_inputs = {'img': imgs, 'img_meta': img_metas}


### PR DESCRIPTION

## Motivation

Unnecessary resize in mmseg encode-decoder head: https://github.com/open-mmlab/mmsegmentation/issues/1529

## Modification

- [x] Remove second unused resize.
- [x] Make sure output of 4d tensor in a nice way.
- [x] Update unit test.

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.


