### PR TITLE
Update: Optimize document

### DIFF
--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -9,8 +9,8 @@ In this chapter, we introduce how to install MMDeploy on NVIDIA Jetson platforms
 
 Hardware recommendation:
 
-- [Seeed reComputer built with Jetson Nano module](https://www.seeedstudio.com/Jetson-10-1-A0-p-5336.html) 
-- [Seeed reComputer built with Jetson Xavier NX module](https://www.seeedstudio.com/Jetson-20-1-H1-p-5328.html) 
+- [Seeed reComputer built with Jetson Nano module](https://www.seeedstudio.com/Jetson-10-1-A0-p-5336.html)
+- [Seeed reComputer built with Jetson Xavier NX module](https://www.seeedstudio.com/Jetson-20-1-H1-p-5328.html)
 
 ## Prerequisites
 
@@ -294,7 +294,7 @@ pip install -r requirements/build.txt
 pip install -v -e .  # or "python setup.py develop"
 ```
 
-2. Follow [this document](https://github.com/open-mmlab/mmdeploy/blob/master/docs/en/tutorials/how_to_convert_model.md) on how to convert model files. 
+2. Follow [this document](https://github.com/open-mmlab/mmdeploy/blob/master/docs/en/tutorials/how_to_convert_model.md) on how to convert model files.
 
 For this example, we have used [retinanet_r18_fpn_1x_coco.py](https://github.com/open-mmlab/mmdetection/blob/master/configs/retinanet/retinanet_r18_fpn_1x_coco.py) as the model config, and [this file](https://download.openmmlab.com/mmdetection/v2.0/retinanet/retinanet_r18_fpn_1x_coco/retinanet_r18_fpn_1x_coco_20220407_171055-614fd399.pth) as the corresponding checkpoint file. Also for deploy config, we have used [detection_tensorrt_dynamic-320x320-1344x1344.py](https://github.com/open-mmlab/mmdeploy/blob/master/configs/mmdet/detection/detection_tensorrt_dynamic-320x320-1344x1344.py)
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -1,15 +1,22 @@
 # Build for Jetson
 
 In this chapter, we introduce how to install MMDeploy on NVIDIA Jetson platforms, which we have verified on the following modules:
+
 - Jetson Nano
+- Jetson Xavier NX
 - Jetson TX2
 - Jetson AGX Xavier
 
+Hardware recommendation:
+
+- [Seeed reComputer built with Jetson Nano module](https://www.seeedstudio.com/Jetson-10-1-A0-p-5336.html) 
+- [Seeed reComputer built with Jetson Xavier NX module](https://www.seeedstudio.com/Jetson-20-1-H1-p-5328.html) 
+
 ## Prerequisites
 
-To equip a Jetson device, the JetPack SDK is a must.
-Besides, the Model Converter of MMDeploy requires an environment with PyTorch for converting PyTorch models to ONNX models.
-Regarding the toolchain, CMake and GCC has to be upgraded to no less than 3.14 and 7.0 respectively.
+- To equip a Jetson device, JetPack SDK is a must.
+- The Model Converter of MMDeploy requires an environment with PyTorch for converting PyTorch models to ONNX models.
+- Regarding the toolchain, CMake and GCC has to be upgraded to no less than 3.14 and 7.0 respectively.
 
 ### JetPack SDK
 
@@ -20,9 +27,11 @@ There are two major installation methods including,
 1. SD Card Image Method
 2. NVIDIA SDK Manager Method
 
-You can find a very detailed installation guide from NVIDIA [official website](https://developer.nvidia.com/jetpack-sdk-50dp).
+You can find a very detailed installation guide from NVIDIA [official website](https://developer.nvidia.com/jetpack-sdk-461).
 
-Here we choose [JetPack 4.6.1](https://developer.nvidia.com/jetpack-sdk-461) as our best practice on setup Jetson platforms. MMDeploy has been tested on JetPack 4.6 rev3 and above and TensorRT 8.0.1.6 and above. Earlier JetPack versions has incompatibilities with TensorRT 7.x
+**Note:** Please select the option to install "Jetson SDK Components" when using NVIDIA SDK Manager as this includes CUDA and TensorRT which are needed for this guide.
+
+Here we have chosen [JetPack 4.6.1](https://developer.nvidia.com/jetpack-sdk-461) as our best practice on setting up Jetson platforms. MMDeploy has been tested on JetPack 4.6 (rev.3) and above and TensorRT 8.0.1.6 and above. Earlier JetPack versions has incompatibilities with TensorRT 7.x
 
 ### Conda
 
@@ -53,14 +62,14 @@ conda activate mmdeploy
 ```
 
 ```{note}
-JetPack SDK 4+ provides python 3.6. We strongly recommend using the default python. Trying to upgrade it probably will ruin the JetPack environment.
+JetPack SDK 4+ provides Python 3.6. We strongly recommend using the default Python. Trying to upgrade it will probably ruin the JetPack environment.
 
-If a higher-version python is necessary, you can install JetPack 5+, in which the python version is 3.8.
+If a higher-version of Python is necessary, you can install JetPack 5+, in which the Python version is 3.8.
 ```
+
 ### PyTorch
 
-Download the PyTorch wheel for Jetson from [here](https://forums.developer.nvidia.com/t/pytorch-for-jetson-version-1-10-now-available/72048) and save it to the local directory `/opt`.
-And build torchvision from source as there is no prebuilt torchvision for Jetson platforms.
+Download the PyTorch wheel for Jetson from [here](https://forums.developer.nvidia.com/t/pytorch-for-jetson-version-1-11-now-available/72048) and save it to the `/home/username` directory. Build torchvision from source as there is no prebuilt torchvision for Jetson platforms.
 
 Take `torch 1.10.0` and  `torchvision 0.11.1` for example. You can install them as below:
 
@@ -68,15 +77,16 @@ Take `torch 1.10.0` and  `torchvision 0.11.1` for example. You can install them 
 # pytorch
 wget https://nvidia.box.com/shared/static/fjtbno0vpo676a25cgvuqc1wty0fkkg6.whl -O torch-1.10.0-cp36-cp36m-linux_aarch64.whl
 pip3 install torch-1.10.0-cp36-cp36m-linux_aarch64.whl
+
 # torchvision
-sudo apt-get install libjpeg-dev zlib1g-dev libpython3-dev libavcodec-dev libavformat-dev libswscale-dev -y
-sudo rm -r torchvision
-git clone https://github.com/pytorch/vision torchvision
+sudo apt-get install libjpeg-dev zlib1g-dev libpython3-dev libavcodec-dev libavformat-dev libswscale-dev libopenblas-base libopenmpi-dev -y
+git clone --branch v0.11.1 https://github.com/pytorch/vision torchvision
 cd torchvision
-git checkout tags/v0.11.1 -b v0.11.1
 export BUILD_VERSION=0.11.1
 pip install -e .
 ```
+
+**Note:** It takes about 30 minutes to install torchvision on a Jetson Nano. So, please be patient until the installation is complete.
 
 If you install other versions of PyTorch and torchvision, make sure the versions are compatible. Refer to the compatibility chart listed [here](https://pypi.org/project/torchvision/).
 
@@ -86,8 +96,7 @@ We use the latest cmake v3.23.1 released in April 2022.
 
 ```shell
 # purge existing
-sudo apt-get purge cmake
-sudo snap remove cmake
+sudo apt-get purge cmake -y
 
 # install prebuilt binary
 export CMAKE_VER=3.23.1
@@ -101,14 +110,13 @@ cmake --version
 ## Install Dependencies
 
 The Model Converter of MMDeploy on Jetson platforms depends on [MMCV](https://github.com/open-mmlab/mmcv) and the inference engine [TensorRT](https://developer.nvidia.com/tensorrt).
-While MMDeploy C/C++ Inference SDK relies on [spdlog](https://github.com/gabime/spdlog), OpenCV and [ppl.cv](https://github.com/openppl-public/ppl.cv) and so on， as well as TensorRT.
+While MMDeploy C/C++ Inference SDK relies on [spdlog](https://github.com/gabime/spdlog), OpenCV and [ppl.cv](https://github.com/openppl-public/ppl.cv) and so on, as well as TensorRT.
 Thus, in the following sections, we will describe how to prepare TensorRT.
 And then, we will present the way to install dependencies of Model Converter and C/C++ Inference SDK respectively.
 
 ### Prepare TensorRT
 
-TensorRT is already packed into JetPack SDK. However, in order to import it successfully in the conda environment,
-we need to copy the tensorrt package to the conda environment created before.
+TensorRT is already packed into JetPack SDK. But In order to import it successfully in conda environment, we need to copy the tensorrt package to the conda environment created before.
 
 ```shell
 cp -r /usr/lib/python${PYTHON_VERSION}/dist-packages/tensorrt* ~/archiconda3/envs/mmdeploy/lib/python${PYTHON_VERSION}/site-packages/
@@ -119,7 +127,9 @@ python -c "import tensorrt; print(tensorrt.__version__)" # Will print the versio
 # set environment variable for building mmdeploy later on
 export TENSORRT_DIR=/usr/include/aarch64-linux-gnu
 
-# append cuda path and libraries to PATH and LD_LIBRARY_PATH, which is also used for building mmdeploy later on
+# append cuda path and libraries to PATH and LD_LIBRARY_PATH, which is also used for building mmdeploy later on.
+# this is not needed if you use NVIDIA SDK Manager with "Jetson SDK Components" for installing JetPack.
+# this is only needed if you install JetPack using SD Card Image Method.
 export PATH=$PATH:/usr/local/cuda/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
 ```
@@ -130,6 +140,8 @@ You can also make the above environment variables permanent by adding them to `~
 echo -e '\n# set environment variable for TensorRT' >> ~/.bashrc
 echo 'export TENSORRT_DIR=/usr/include/aarch64-linux-gnu' >> ~/.bashrc
 
+# this is not needed if you use NVIDIA SDK Manager with "Jetson SDK Components" for installing JetPack.
+# this is only needed if you install JetPack using SD Card Image Method.
 echo -e '\n# set environment variable for CUDA' >> ~/.bashrc
 echo 'export PATH=$PATH:/usr/local/cuda/bin' >> ~/.bashrc
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64' >> ~/.bashrc
@@ -140,57 +152,60 @@ conda activate mmdeploy
 
 ### Install Dependencies for Model Converter
 
-- Install [MMCV](https://github.com/open-mmlab/mmcv)
+#### Install MMCV
 
-  MMCV hasn't provided prebuilt package for Jetson platforms, so we have to build it from source.
+[MMCV](https://github.com/open-mmlab/mmcv) has not provided prebuilt package for Jetson platforms, so we have to build it from source.
 
-  ```shell
-  sudo apt-get install -y libssl-dev
-  git clone https://github.com/open-mmlab/mmcv.git
-  cd mmcv
-  git checkout v1.4.0
-  MMCV_WITH_OPS=1 pip install -e .
-  ```
+```shell
+sudo apt-get install -y libssl-dev
+git clone --branch v1.4.0 https://github.com/open-mmlab/mmcv.git
+cd mmcv
+MMCV_WITH_OPS=1 pip install -e .
+```
 
-- Install ONNX
+**Note:** It takes about 1 hour 40 minutes to install MMCV on a Jetson Nano. So, please be patient until the installation is complete.
 
-  ```shell
-  pip install onnx
-  ```
+#### Install ONNX
 
-- Install h5py
+```shell
+pip install onnx
+```
 
-  Model Converter employs HDF5 to save the calibration data for TensorRT INT8 quantization.
+#### Install h5py
 
-  ```shell
-  sudo apt-get install -y pkg-config libhdf5-100 libhdf5-dev
-  pip install versioned-hdf5
-  ```
+Model Converter employs HDF5 to save the calibration data for TensorRT INT8 quantization.
 
-### Install Dependencies for SDK
+```shell
+sudo apt-get install -y pkg-config libhdf5-100 libhdf5-dev
+pip install versioned-hdf5
+```
 
-You can skip this section if you don't need MMDeploy C/C++ Inference SDK.
+**Note:** It takes about 6 minutes to install versioned-hdf5 on a Jetson Nano. So, please be patient until the installation is complete.
 
-- Install [spdlog](https://github.com/gabime/spdlog)
+### Install Dependencies for C/C++ Inference SDK
 
-  "`spdlog` is a very fast, header-only/compiled, C++ logging library"
+#### Install spdlog
 
-  ```shell
-  sudo apt-get install -y libspdlog-dev
-  ```
+[spdlog](https://github.com/gabime/spdlog) is a very fast, header-only/compiled, C++ logging library
 
-- Install [ppl.cv](https://github.com/openppl-public/ppl.cv)
+```shell
+sudo apt-get install -y libspdlog-dev
+```
 
-  "`ppl.cv` is a high-performance image processing library of [OpenPPL](https://openppl.ai/home)"
+#### Install ppl.cv
 
-  ```shell
-  git clone https://github.com/openppl-public/ppl.cv.git
-  cd ppl.cv
-  export PPLCV_DIR=$(pwd)
-  echo -e '\n# set environment variable for ppl.cv' >> ~/.bashrc
-  echo "export PPLCV_DIR=$(pwd)" >> ~/.bashrc
-  ./build.sh cuda
-  ```
+[ppl.cv](https://github.com/openppl-public/ppl.cv) is a high-performance image processing library of [openPPL](https://openppl.ai/home)
+
+```shell
+git clone https://github.com/openppl-public/ppl.cv.git
+cd ppl.cv
+export PPLCV_DIR=$(pwd)
+echo -e '\n# set environment variable for ppl.cv' >> ~/.bashrc
+echo "export PPLCV_DIR=$(pwd)" >> ~/.bashrc
+./build.sh cuda
+```
+
+**Note:** It takes about 15 minutes to install ppl.cv on a Jetson Nano. So, please be patient until the installation is complete.
 
 ## Install MMDeploy
 
@@ -202,8 +217,7 @@ export MMDEPLOY_DIR=$(pwd)
 
 ### Install Model Converter
 
-Since some operators adopted by OpenMMLab codebases are not supported by TenorRT,
-we build the custom TensorRT plugins to make it up, such as `roi_align`, `scatternd`, etc.
+Since some operators adopted by OpenMMLab codebases are not supported by TensorRT, we build the custom TensorRT plugins to make it up, such as `roi_align`, `scatternd`, etc.
 You can find a full list of custom plugins from [here](../ops/tensorrt.md).
 
 ```shell
@@ -220,39 +234,77 @@ pip install -v -e .
 # thus any local modifications made to the code will take effect without re-installation.
 ```
 
-### Install C/C++ Inference SDK
+**Note:** It takes about 5 minutes to install model converter on a Jetson Nano. So, please be patient until the installation is complete.
 
-You can skip this section if you don't need MMDeploy C/C++ Inference SDK.
+### Install C/C++ Inference SDK
 
 1. Build SDK Libraries
 
-    ```shell
-    mkdir -p build && cd build
-    cmake .. \
-        -DMMDEPLOY_BUILD_SDK=ON \
-        -DMMDEPLOY_BUILD_SDK_PYTHON_API=ON \
-        -DMMDEPLOY_TARGET_DEVICES="cuda;cpu" \
-        -DMMDEPLOY_TARGET_BACKENDS="trt" \
-        -DMMDEPLOY_CODEBASES=all \
-        -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl
-    make -j$(nproc) && make install
-    ```
+```shell
+mkdir -p build && cd build
+cmake .. \
+    -DMMDEPLOY_BUILD_SDK=ON \
+    -DMMDEPLOY_BUILD_SDK_PYTHON_API=ON \
+    -DMMDEPLOY_TARGET_DEVICES="cuda;cpu" \
+    -DMMDEPLOY_TARGET_BACKENDS="trt" \
+    -DMMDEPLOY_CODEBASES=all \
+    -Dpplcv_DIR=${PPLCV_DIR}/cuda-build/install/lib/cmake/ppl
+make -j$(nproc) && make install
+```
+
+**Note:** It takes about 9 minutes to build SDK libraries on a Jetson Nano. So, please be patient until the installation is complete.
 
 2. Build SDK demos
 
-    ```shell
-    cd ${MMDEPLOY_DIR}/build/install/example
-    mkdir -p build && cd build
-    cmake .. -DMMDeploy_DIR=${MMDEPLOY_DIR}/build/install/lib/cmake/MMDeploy
-    make -j$(nproc)
-    ```
+```shell
+cd ${MMDEPLOY_DIR}/build/install/example
+mkdir -p build && cd build
+cmake .. -DMMDeploy_DIR=${MMDEPLOY_DIR}/buildinstall/lib/cmake/MMDeploy
+make -j$(nproc)
+```
 
-3. Run a demo
+### Run a Demo
 
-    Take the object detection for example:
-    ```shell
-    ./object_detection cuda ${directory/to/the/converted/models} ${path/to/an/image}
-    ```
+#### Object Detection demo
+
+Before running this demo, you need to convert model files to be able to use with this SDK.
+
+1. Install [MMDetection](https://github.com/open-mmlab/mmdetection) which is needed for model conversion
+
+MMDetection is an open source object detection toolbox based on PyTorch
+
+```shell
+git clone https://github.com/open-mmlab/mmdetection.git
+cd mmdetection
+pip install -r requirements/build.txt
+pip install -v -e .  # or "python setup.py develop"
+```
+
+2. Follow [this document](https://github.com/open-mmlab/mmdeploy/blob/master/docs/en/tutorials/how_to_convert_model.md) on how to convert model files. 
+
+For this example, we have used [retinanet_r18_fpn_1x_coco.py](https://github.com/open-mmlab/mmdetection/blob/master/configs/retinanet/retinanet_r18_fpn_1x_coco.py) as the model config, and [this file](https://download.openmmlab.com/mmdetection/v2.0/retinanet/retinanet_r18_fpn_1x_coco/retinanet_r18_fpn_1x_coco_20220407_171055-614fd399.pth) as the corresponding checkpoint file. Also for deploy config, we have used [detection_tensorrt_dynamic-320x320-1344x1344.py](https://github.com/open-mmlab/mmdeploy/blob/master/configs/mmdet/detection/detection_tensorrt_dynamic-320x320-1344x1344.py)
+
+```shell
+python ./tools/deploy.py \
+    configs/mmdet/detection/detection_tensorrt_dynamic-320x320-1344x1344.py \
+    $PATH_TO_MMDET/configs/retinanet/retinanet_r18_fpn_1x_coco.py \
+    retinanet_r18_fpn_1x_coco_20220407_171055-614fd399.pth \
+    $PATH_TO_MMDET/demo/demo.jpg \
+    --work-dir work_dir \
+    --show \
+    --device cuda:0 \
+    --dump-info
+```
+
+3. Finally run inference on an image
+
+```shell
+./object_detection cuda ${directory/to/the/converted/models} ${path/to/an/image}
+```
+
+<div align=center><img width=1000 src="https://files.seeedstudio.com/wiki/open-mmlab/output_detection.png"/></div>
+
+The above inference is done on a [Seeed reComputer built with Jetson Nano module](https://www.seeedstudio.com/Jetson-10-1-A0-p-5336.html)
 
 ## Troubleshooting
 
@@ -260,13 +312,8 @@ You can skip this section if you don't need MMDeploy C/C++ Inference SDK.
 
 - `pip install` throws an error like `Illegal instruction (core dumped)`
 
-  ```shell
-  echo '# set env for pip' >> ~/.bashrc
-  echo 'export OPENBLAS_CORETYPE=ARMV8' >> ~/.bashrc
-  source ~/.bashrc
-  ```
+  Check if you are using any mirror, if you did, try this:
 
-  If the steps above don't work, check if you are using any mirror. If so, try this:
   ```shell
   rm .condarc
   conda clean -i

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -29,7 +29,9 @@ There are two major installation methods including,
 
 You can find a very detailed installation guide from NVIDIA [official website](https://developer.nvidia.com/jetpack-sdk-461).
 
-**Note:** Please select the option to install "Jetson SDK Components" when using NVIDIA SDK Manager as this includes CUDA and TensorRT which are needed for this guide.
+```{note}
+Please select the option to install "Jetson SDK Components" when using NVIDIA SDK Manager as this includes CUDA and TensorRT which are needed for this guide.
+```
 
 Here we have chosen [JetPack 4.6.1](https://developer.nvidia.com/jetpack-sdk-461) as our best practice on setting up Jetson platforms. MMDeploy has been tested on JetPack 4.6 (rev.3) and above and TensorRT 8.0.1.6 and above. Earlier JetPack versions has incompatibilities with TensorRT 7.x
 
@@ -86,7 +88,9 @@ export BUILD_VERSION=0.11.1
 pip install -e .
 ```
 
-**Note:** It takes about 30 minutes to install torchvision on a Jetson Nano. So, please be patient until the installation is complete.
+```{note}
+It takes about 30 minutes to install torchvision on a Jetson Nano. So, please be patient until the installation is complete.
+```
 
 If you install other versions of PyTorch and torchvision, make sure the versions are compatible. Refer to the compatibility chart listed [here](https://pypi.org/project/torchvision/).
 
@@ -163,7 +167,9 @@ cd mmcv
 MMCV_WITH_OPS=1 pip install -e .
 ```
 
-**Note:** It takes about 1 hour 40 minutes to install MMCV on a Jetson Nano. So, please be patient until the installation is complete.
+```{note}
+It takes about 1 hour 40 minutes to install MMCV on a Jetson Nano. So, please be patient until the installation is complete.
+```
 
 #### Install ONNX
 
@@ -180,7 +186,9 @@ sudo apt-get install -y pkg-config libhdf5-100 libhdf5-dev
 pip install versioned-hdf5
 ```
 
-**Note:** It takes about 6 minutes to install versioned-hdf5 on a Jetson Nano. So, please be patient until the installation is complete.
+```{note}
+It takes about 6 minutes to install versioned-hdf5 on a Jetson Nano. So, please be patient until the installation is complete.
+```
 
 ### Install Dependencies for C/C++ Inference SDK
 
@@ -205,7 +213,9 @@ echo "export PPLCV_DIR=$(pwd)" >> ~/.bashrc
 ./build.sh cuda
 ```
 
-**Note:** It takes about 15 minutes to install ppl.cv on a Jetson Nano. So, please be patient until the installation is complete.
+```{note}
+It takes about 15 minutes to install ppl.cv on a Jetson Nano. So, please be patient until the installation is complete.
+```
 
 ## Install MMDeploy
 
@@ -234,7 +244,9 @@ pip install -v -e .
 # thus any local modifications made to the code will take effect without re-installation.
 ```
 
-**Note:** It takes about 5 minutes to install model converter on a Jetson Nano. So, please be patient until the installation is complete.
+```{note}
+It takes about 5 minutes to install model converter on a Jetson Nano. So, please be patient until the installation is complete.
+```
 
 ### Install C/C++ Inference SDK
 
@@ -252,7 +264,9 @@ cmake .. \
 make -j$(nproc) && make install
 ```
 
-**Note:** It takes about 9 minutes to build SDK libraries on a Jetson Nano. So, please be patient until the installation is complete.
+```{note}
+It takes about 9 minutes to build SDK libraries on a Jetson Nano. So, please be patient until the installation is complete.
+```
 
 2. Build SDK demos
 

--- a/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
+++ b/docs/en/tutorials/how_to_install_mmdeploy_on_jetsons.md
@@ -312,11 +312,13 @@ python ./tools/deploy.py \
 
 3. Finally run inference on an image
 
+<div align=center><img width=650 src="https://files.seeedstudio.com/wiki/open-mmlab/source_image.jpg"/></div>
+
 ```shell
 ./object_detection cuda ${directory/to/the/converted/models} ${path/to/an/image}
 ```
 
-<div align=center><img width=1000 src="https://files.seeedstudio.com/wiki/open-mmlab/output_detection.png"/></div>
+<div align=center><img width=650 src="https://files.seeedstudio.com/wiki/open-mmlab/output_detection.png"/></div>
 
 The above inference is done on a [Seeed reComputer built with Jetson Nano module](https://www.seeedstudio.com/Jetson-10-1-A0-p-5336.html)
 


### PR DESCRIPTION
- Minor fixes in styling and grammar
- Add support for Jetson Xavier NX (Tested and worked)
- Add hardware recommendation
- Change JetPack installation guide URL from jp5.0 to jp4.6.1
- Add a note to select "Jetson SDK Components" when using NVIDIA SDK Manager
- Change PyTorch wheel save location
- Add more dependencies needed for torchvision installation. Otherwise installation error
- Simplify torchvision git cloning branch
- Add installation times for torchvision, MMCV, versioned-hdf5, ppl.cv, model converter, SDK libraries
- Delete "snap" from cmake removal as "apt-get purge" is enough
- Add a note on which scenarios you need to append cu da path and libraries to PATH and LD_LIBRARY_PATH
- Simplify MMCV git cloning branch
- Delete "skip if you don't need MMDeploy C/C++ Inference SDK", because that is the only available inference SDK at the moment
- Add more details to object detection demo using C/C++ Inference SDK such as installing MMDetection and converting a model
- Add image of inference result
- Delete "set env for pip" in troubleshooting because this is already mentioned under "installing Archiconda"

Signed-off-by: Lakshantha Dissanayake <lakshanthad@seeed.cc>