### PR TITLE
fix: bbox_nms not onnxizing if batch size > 1

### DIFF
--- a/mmdeploy/codebase/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdeploy/codebase/mmdet/core/post_processing/bbox_nms.py
@@ -202,7 +202,7 @@ def multiclass_nms__default(ctx,
     """
     deploy_cfg = ctx.cfg
     batch_size = boxes.size(0)
-    if not is_dynamic_batch(deploy_cfg) and batch_size != 1:
+    if not is_dynamic_batch(deploy_cfg) and batch_size == 1:
         return _multiclass_nms_single(
             boxes,
             scores,


### PR DESCRIPTION
A typo prevents nms from onnxizing correctly if batch size is static and greater than 1.
