### PR TITLE
fix: compatable with mmpose v0.26

### DIFF
--- a/mmdeploy/codebase/mmpose/deploy/pose_detection.py
+++ b/mmdeploy/codebase/mmpose/deploy/pose_detection.py
@@ -135,7 +135,6 @@ class PoseDetection(BaseTask):
         Returns:
             tuple: (data, img), meta information for the input image and input.
         """
-        from mmpose.apis.inference import _box2cs
         from mmpose.datasets.dataset_info import DatasetInfo
         from mmpose.datasets.pipelines import Compose
 
@@ -160,17 +159,12 @@ class PoseDetection(BaseTask):
             image_size = input_shape
         else:
             image_size = np.array(cfg.data_cfg['image_size'])
-        for bbox in bboxes:
-            center, scale = _box2cs(cfg, bbox)
 
+        for bbox in bboxes:
             # prepare data
             data = {
                 'img':
                 imgs,
-                'center':
-                center,
-                'scale':
-                scale,
                 'bbox_score':
                 bbox[4] if len(bbox) == 5 else 1,
                 'bbox_id':
@@ -189,6 +183,17 @@ class PoseDetection(BaseTask):
                     'flip_pairs': flip_pairs
                 }
             }
+
+            # for compatibility of mmpose
+            try:
+                # for mmpose<=v0.25.1
+                from mmpose.apis.inference import _box2cs
+                center, scale = _box2cs(cfg, bbox)
+                data['center'] = center
+                data['scale'] = scale
+            except ImportError:
+                # for mmpose>=v0.26.0
+                data['bbox'] = bbox
 
             data = test_pipeline(data)
             batch_data.append(data)

--- a/tests/test_codebase/test_mmpose/data/model.py
+++ b/tests/test_codebase/test_mmpose/data/model.py
@@ -1,5 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 # model settings
+import mmpose
+from packaging import version
+
 channel_cfg = dict(
     num_output_channels=17,
     dataset_joints=17,
@@ -47,6 +50,7 @@ data_cfg = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile'),
+    # dict(type='TopDownGetBboxCenterScale'),
     dict(type='TopDownAffine'),
     dict(type='ToTensor'),
     dict(
@@ -61,6 +65,9 @@ test_pipeline = [
             'flip_pairs'
         ]),
 ]
+# compatible with mmpose >=v0.26.0
+if version.parse(mmpose.__version__) >= version.parse('0.26.0'):
+    test_pipeline.insert(1, dict(type='TopDownGetBboxCenterScale'))
 
 dataset_info = dict(
     dataset_name='coco',

--- a/tests/test_codebase/test_mmpose/test_pose_detection.py
+++ b/tests/test_codebase/test_mmpose/test_pose_detection.py
@@ -46,7 +46,6 @@ num_output_channels = model_cfg['data_cfg']['num_output_channels']
 
 
 def test_create_input():
-    model_cfg = load_config(model_cfg_path)[0]
     deploy_cfg = mmcv.Config(
         dict(
             backend_config=dict(type=Backend.ONNXRUNTIME.value),


### PR DESCRIPTION


## Motivation

Fix mmpose error of v0.26.0

## Modification

- [x] fix `ImportError: cannot import name '_box2cs' from 'mmpose.apis.inference'`on mmpose==0.26.0
- [x] update unit test

## BC-breaking (Optional)

None

## Use cases (Optional)

4. The documentation has been modified accordingly, like docstring or example tutorials.
