### PR TITLE
fix missing cudart cublas missing when build MMDeployExtern on linux

### DIFF
--- a/csrc/apis/c/CMakeLists.txt
+++ b/csrc/apis/c/CMakeLists.txt
@@ -48,6 +48,9 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/common.h
         DESTINATION include/c)
 
 if (MMDEPLOY_BUILD_SDK_CSHARP_API)
+    if ("cuda" IN_LIST MMDEPLOY_TARGET_DEVICES)
+        include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake NO_POLICY_SCOPE)
+    endif()
     # build MMDeployExtern.dll just for csharp nuget package.
     # no Installation for c/c++ package.
     file(GLOB SRCS "*.c" "*.cpp")


### PR DESCRIPTION
## Motivation

Address the missing -lcudart -lcublas issue when build MMDeployExtern with BUILD_SHARED_LIBS=OFF and cuda device.
