### PR TITLE
[Fix] Fix MMPose>=0.26 model export

### DIFF
--- a/mmdeploy/codebase/mmpose/deploy/pose_detection.py
+++ b/mmdeploy/codebase/mmpose/deploy/pose_detection.py
@@ -135,7 +135,6 @@ class PoseDetection(BaseTask):
         Returns:
             tuple: (data, img), meta information for the input image and input.
         """
-        from mmpose.apis.inference import _box2cs
         from mmpose.datasets.dataset_info import DatasetInfo
         from mmpose.datasets.pipelines import Compose
 
@@ -161,16 +160,10 @@ class PoseDetection(BaseTask):
         else:
             image_size = np.array(cfg.data_cfg['image_size'])
         for bbox in bboxes:
-            center, scale = _box2cs(cfg, bbox)
-
             # prepare data
             data = {
                 'img':
                 imgs,
-                'center':
-                center,
-                'scale':
-                scale,
                 'bbox_score':
                 bbox[4] if len(bbox) == 5 else 1,
                 'bbox_id':
@@ -189,6 +182,15 @@ class PoseDetection(BaseTask):
                     'flip_pairs': flip_pairs
                 }
             }
+
+            try:
+                from mmpose.apis.inference import _box2cs
+                center, scale = _box2cs(cfg, bbox)
+                data['center'] = center
+                data['scale'] = scale
+            except Exception:
+                # mmpose >= 0.26 does not have _box2cs
+                data['bbox'] = bbox
 
             data = test_pipeline(data)
             batch_data.append(data)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

MMPose>=0.26 model export failed because `_box2cs` has been removed from interface.py.

## Modification

Add `bbox` input to data.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
