### PR TITLE
Support compute capability 87 architectures such as Jetson AGX Orin

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -56,6 +56,9 @@ if (NOT CMAKE_CUDA_ARCHITECTURES)
             # cuda doesn't support `sm_86` until version 11.1
             set(_NVCC_FLAGS "${_NVCC_FLAGS} -gencode arch=compute_86,code=sm_86")
         endif ()
+        if (CUDA_VERSION_MINOR VERSION_GREATER_EQUAL "4")
+            set(_NVCC_FLAGS "${_NVCC_FLAGS} -gencode arch=compute_87,code=sm_87")
+        endif ()
     endif ()
 endif ()
 


### PR DESCRIPTION
## Motivation

For Jetson AGX Orin, we need `-DCMAKE_CUDA_ARCHITECTURES=87` in building the binary, or it will not convert models with NMS to TensorRT correctly (the assertion at [nmsInference](https://github.com/open-mmlab/mmdeploy/blob/v0.5.0/csrc/backend_ops/tensorrt/batched_nms/trt_batched_nms.cpp#L99) fails at inference time, and you can find it is because of the error `no kernel image is available for execution on the device` at [permuteData](https://github.com/open-mmlab/mmdeploy/blob/v0.5.0/csrc/backend_ops/tensorrt/common_impl/nms/batched_nms_kernel.cpp#L77)).

## Modification

Added `gencode` option and it now supports CC=87 as default.

## BC-breaking (Optional)

If your CUDA compiler is >= 11.4, additional binaries are built.

## Use cases (Optional)

MMDeploy for Jetson AGX Orin

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
