### PR TITLE
[Fix] adapt mmocr different versions

### DIFF
--- a/mmdeploy/codebase/mmocr/deploy/text_recognition_model.py
+++ b/mmdeploy/codebase/mmocr/deploy/text_recognition_model.py
@@ -143,14 +143,26 @@ class End2EndModel(BaseBackendModel):
         Returns:
             np.ndarray: Drawn image, only if not `show` or `out_file`.
         """
-        return BaseRecognizer.show_result(
-            self,
-            img,
-            result,
-            score_thr=score_thr,
-            show=show,
-            win_name=win_name,
-            out_file=out_file)
+        import mmocr
+        if mmocr.__version__ >= '0.5.0':
+            # Method show_result is a static method when mmocr >= '0.5.0'
+            return BaseRecognizer.show_result(
+                img,
+                result,
+                score_thr=score_thr,
+                show=show,
+                win_name=win_name,
+                out_file=out_file)
+        else:
+            return BaseRecognizer.show_result(
+                self,
+                img,
+                result,
+                score_thr=score_thr,
+                show=show,
+                win_name=win_name,
+                out_file=out_file)
+
 
 
 @__BACKEND_MODEL.register_module('sdk')

--- a/mmdeploy/codebase/mmocr/deploy/text_recognition_model.py
+++ b/mmdeploy/codebase/mmocr/deploy/text_recognition_model.py
@@ -144,7 +144,9 @@ class End2EndModel(BaseBackendModel):
             np.ndarray: Drawn image, only if not `show` or `out_file`.
         """
         import mmocr
-        if mmocr.__version__ >= '0.5.0':
+        from packaging import version
+
+        if version.parse(mmocr.__version__) >= version.parse('0.5.0'):
             # Method show_result is a static method when mmocr >= '0.5.0'
             return BaseRecognizer.show_result(
                 img,

--- a/mmdeploy/codebase/mmocr/deploy/text_recognition_model.py
+++ b/mmdeploy/codebase/mmocr/deploy/text_recognition_model.py
@@ -164,7 +164,6 @@ class End2EndModel(BaseBackendModel):
                 out_file=out_file)
 
 
-
 @__BACKEND_MODEL.register_module('sdk')
 class SDKEnd2EndModel(End2EndModel):
     """SDK inference class, converts SDK output to mmocr format."""


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Text Recognition model visualize failed when mmocr >= 0.5.0 because mmocr 0.5.0 changed the `show_result` api to a static method.

## Modification

Add conditional statement for mmocr versions to adapt different `show_result` apis.

## BC-breaking (Optional)

None.

## Use cases (Optional)

None.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
