### PR TITLE
[Document] ' -> "

### DIFF
--- a/docs/en/01-how-to-build/linux-x86_64.md
+++ b/docs/en/01-how-to-build/linux-x86_64.md
@@ -249,7 +249,7 @@ If you want to make the above environment variables permanent, you could add the
 ```bash
 echo '# set env for onnxruntime' >> ~/.bashrc
 echo "export ONNXRUNTIME_DIR=${ONNXRUNTIME_DIR}" >> ~/.bashrc
-echo 'export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
+echo "export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH" >> ~/.bashrc
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
If there is a variable in the string, single quotes will ignored it, while double quotes will bring the variable into the string after parsing

如果字符串中有变量，单引号会忽略，而双引号会把变量解析以后带入字符串



## Motivation

Change the document.

## Modification

If one excute:
```shell
echo 'export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH' >> ~/.bashrc
```
In the last line of `~/.bashrc`, that will be `export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH`.

$ONNXRUNTIME_DIR and $LD_LIBRARY_PATH will not be parsed.
