### PR TITLE
[FIX] fix dump info of mmpose if input_shape is not given in deploy_cfg

### DIFF
--- a/mmdeploy/codebase/mmpose/deploy/pose_detection.py
+++ b/mmdeploy/codebase/mmpose/deploy/pose_detection.py
@@ -38,6 +38,8 @@ def process_model_config(
     sdk_pipeline = []
     color_type = 'color'
     channel_order = 'rgb'
+    if input_shape is None:
+        input_shape = np.array(cfg.data_cfg['image_size'])
 
     idx = 0
     while idx < len(test_pipeline):


### PR DESCRIPTION
## Motivation

When export mmpose model with --dump-info, if deploy_cfg doesn't contains input_shape, we should consider data_cfg['image_size'] in model config.


