### PR TITLE
pass img_metas while exporting to onnx

### DIFF
--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -61,6 +61,7 @@ def torch2onnx(img: Any,
 
     torch_model = task_processor.init_pytorch_model(model_checkpoint)
     data, model_inputs = task_processor.create_input(img, input_shape)
+    input_metas = dict(img_metas=data['img_metas'])
     if not isinstance(model_inputs, torch.Tensor) and len(model_inputs) == 1:
         model_inputs = model_inputs[0]
 
@@ -87,6 +88,7 @@ def torch2onnx(img: Any,
         export(
             torch_model,
             model_inputs,
+            input_metas=input_metas,
             output_path_prefix=output_prefix,
             backend=backend,
             input_names=input_names,

--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -61,7 +61,7 @@ def torch2onnx(img: Any,
 
     torch_model = task_processor.init_pytorch_model(model_checkpoint)
     data, model_inputs = task_processor.create_input(img, input_shape)
-    input_metas = dict(img_metas=data['img_metas'])
+    input_metas = dict(img_metas=data.get('img_metas', None))
     if not isinstance(model_inputs, torch.Tensor) and len(model_inputs) == 1:
         model_inputs = model_inputs[0]
 

--- a/mmdeploy/codebase/mmcls/models/classifiers/base.py
+++ b/mmdeploy/codebase/mmcls/models/classifiers/base.py
@@ -6,7 +6,7 @@ from mmdeploy.core import FUNCTION_REWRITER
     'mmcls.models.classifiers.ImageClassifier.forward', backend='default')
 @FUNCTION_REWRITER.register_rewriter(
     'mmcls.models.classifiers.BaseClassifier.forward', backend='default')
-def base_classifier__forward(ctx, self, img, *args, **kwargs):
+def base_classifier__forward(ctx, self, img, return_loss=False, **kwargs):
     """Rewrite `forward` of BaseClassifier for default backend.
 
     Rewrite this function to call simple_test function,
@@ -23,5 +23,5 @@ def base_classifier__forward(ctx, self, img, *args, **kwargs):
         result(Tensor): The result of classifier.The tensor
             shape (batch_size,num_classes).
     """
-    result = self.simple_test(img, {})
+    result = self.simple_test(img, **kwargs)
     return result

--- a/mmdeploy/codebase/mmseg/models/segmentors/base.py
+++ b/mmdeploy/codebase/mmseg/models/segmentors/base.py
@@ -23,12 +23,12 @@ def base_segmentor__forward(ctx, self, img, img_metas=None, **kwargs):
         torch.Tensor: Output segmentation map pf shape [N, 1, H, W].
     """
     if img_metas is None:
-        img_metas = {}
-    while isinstance(img_metas, list):
+        img_metas = [{}]
+    else:
+        assert len(img_metas) == 1, 'do not support aug_test'
         img_metas = img_metas[0]
-
     if isinstance(img, list):
-        img = torch.cat(img, 0)
+        img = img[0]
     assert isinstance(img, torch.Tensor)
 
     deploy_cfg = ctx.cfg
@@ -37,5 +37,5 @@ def base_segmentor__forward(ctx, self, img, img_metas=None, **kwargs):
     img_shape = img.shape[2:]
     if not is_dynamic_flag:
         img_shape = [int(val) for val in img_shape]
-    img_metas['img_shape'] = img_shape
+    img_metas[0]['img_shape'] = img_shape
     return self.simple_test(img, img_metas, **kwargs)

--- a/tests/test_codebase/test_mmcls/test_mmcls_models.py
+++ b/tests/test_codebase/test_mmcls/test_mmcls_models.py
@@ -73,7 +73,7 @@ def test_baseclassifier_forward():
         def forward_train(self, imgs):
             return 'train'
 
-        def simple_test(self, img, tmp, **kwargs):
+        def simple_test(self, img, tmp=None, **kwargs):
             return 'simple_test'
 
     model = DummyClassifier().eval()

--- a/tools/onnx2ncnn.py
+++ b/tools/onnx2ncnn.py
@@ -28,12 +28,8 @@ def main():
     output_prefix = args.output_prefix
 
     logger.info(f'onnx2ncnn: \n\tonnx_path: {onnx_path} ')
-    try:
-        from_onnx(onnx_path, output_prefix)
-        logger.info('onnx2ncnn success.')
-    except Exception as e:
-        logger.error(e)
-        logger.error('onnx2ncnn failed.')
+    from_onnx(onnx_path, output_prefix)
+    logger.info('onnx2ncnn success.')
 
 
 if __name__ == '__main__':

--- a/tools/onnx2pplnn.py
+++ b/tools/onnx2pplnn.py
@@ -49,11 +49,11 @@ def main():
     if isinstance(input_shapes[0], int):
         input_shapes = [input_shapes]
 
-    logger.info(f'onnx2ppl: \n\tonnx_path: {onnx_path} '
+    logger.info(f'onnx2pplnn: \n\tonnx_path: {onnx_path} '
                 f'\n\toutput_prefix: {output_prefix}'
                 f'\n\topt_shapes: {input_shapes}')
     from_onnx(onnx_path, output_prefix, device, input_shapes)
-    logger.info('onnx2tpplnn success.')
+    logger.info('onnx2pplnn success.')
 
 
 if __name__ == '__main__':

--- a/tools/onnx2pplnn.py
+++ b/tools/onnx2pplnn.py
@@ -52,12 +52,8 @@ def main():
     logger.info(f'onnx2ppl: \n\tonnx_path: {onnx_path} '
                 f'\n\toutput_prefix: {output_prefix}'
                 f'\n\topt_shapes: {input_shapes}')
-    try:
-        from_onnx(onnx_path, output_prefix, device, input_shapes)
-        logger.info('onnx2tpplnn success.')
-    except Exception as e:
-        logger.error(e)
-        logger.error('onnx2tpplnn failed.')
+    from_onnx(onnx_path, output_prefix, device, input_shapes)
+    logger.info('onnx2tpplnn success.')
 
 
 if __name__ == '__main__':

--- a/tools/onnx2tensorrt.py
+++ b/tools/onnx2tensorrt.py
@@ -55,22 +55,18 @@ def main():
 
     logger.info(f'onnx2tensorrt: \n\tonnx_path: {onnx_path} '
                 f'\n\tdeploy_cfg: {deploy_cfg_path}')
-    try:
-        from_onnx(
-            onnx_path,
-            output_prefix,
-            input_shapes=final_params['input_shapes'],
-            log_level=get_trt_log_level(),
-            fp16_mode=final_params.get('fp16_mode', False),
-            int8_mode=final_params.get('int8_mode', False),
-            int8_param=int8_param,
-            max_workspace_size=final_params.get('max_workspace_size', 0),
-            device_id=device_id)
+    from_onnx(
+        onnx_path,
+        output_prefix,
+        input_shapes=final_params['input_shapes'],
+        log_level=get_trt_log_level(),
+        fp16_mode=final_params.get('fp16_mode', False),
+        int8_mode=final_params.get('int8_mode', False),
+        int8_param=int8_param,
+        max_workspace_size=final_params.get('max_workspace_size', 0),
+        device_id=device_id)
 
-        logger.info('onnx2tensorrt success.')
-    except Exception as e:
-        logger.error(e)
-        logger.error('onnx2tensorrt failed.')
+    logger.info('onnx2tensorrt success.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

## Motivation

- [x] pass `img_metas` while exporting to onnx. This is useful where needs to parse data from `img_metas`.
- [x] remove `try-catch` in tools for clear error message.

## BC-breaking (Optional)

None
