### PR TITLE
[Fix] set default topk for dump info

### DIFF
--- a/mmdeploy/codebase/mmcls/deploy/classification.py
+++ b/mmdeploy/codebase/mmcls/deploy/classification.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Union
 import mmcv
 import numpy as np
 import torch
+from importlib_metadata import warnings
 from torch.utils.data import Dataset
 
 from mmdeploy.codebase.base import BaseTask
@@ -18,7 +19,10 @@ def process_model_config(model_cfg: mmcv.Config,
                          input_shape: Optional[Sequence[int]] = None):
     """Process the model config.
 
-    Args:
+    Args:postprocess = self.model_cfg.model.head
+        assert 'topk' in postprocess, 'model config lack topk'
+        postprocess.topk = max(postprocess.topk)
+        return postprocess
         model_cfg (mmcv.Config): The model config.
         imgs (str | np.ndarray): Input image(s), accepted data type are `str`,
             `np.ndarray`.
@@ -281,8 +285,13 @@ class Classification(BaseTask):
             dict: Composed of the postprocess information.
         """
         postprocess = self.model_cfg.model.head
-        assert 'topk' in postprocess, 'model config lack topk'
-        postprocess.topk = max(postprocess.topk)
+        if 'topk' not in postprocess:
+            topk = (1, )
+            warnings.warn('no topk in postprocess config, using default \
+                 topk value.')
+        else:
+            topk = postprocess.topk
+        postprocess.topk = max(topk)
         return postprocess
 
     def get_model_name(self) -> str:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Dump info failed when testing the performance of new support mmcls models.

## Modification

When topk is not in default postprocess configs: setting as default value instead of assertion error.

## BC-breaking (Optional)

None.

## Use cases (Optional)

None.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
