### PR TITLE
[Enhancement] Better index put ONNX export.

### DIFF
--- a/mmdeploy/pytorch/functions/__init__.py
+++ b/mmdeploy/pytorch/functions/__init__.py
@@ -9,6 +9,7 @@ from .linear import linear__ncnn
 from .normalize import normalize__ncnn
 from .repeat import tensor__repeat__tensorrt
 from .size import tensor__size__ncnn
+from .tensor_setitem import tensor__setitem__default
 from .topk import topk__dynamic, topk__tensorrt
 from .triu import triu
 
@@ -17,5 +18,5 @@ __all__ = [
     'interpolate__tensorrt', 'linear__ncnn', 'tensor__repeat__tensorrt',
     'tensor__size__ncnn', 'topk__dynamic', 'topk__tensorrt', 'chunk__ncnn',
     'triu', 'atan2__default', 'normalize__ncnn', 'expand__ncnn',
-    'chunk__torchscript'
+    'chunk__torchscript', 'tensor__setitem__default'
 ]

--- a/mmdeploy/pytorch/functions/tensor_setitem.py
+++ b/mmdeploy/pytorch/functions/tensor_setitem.py
@@ -1,0 +1,51 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Sequence
+
+import torch
+
+from mmdeploy.core import FUNCTION_REWRITER
+
+
+@FUNCTION_REWRITER.register_rewriter(func_name='torch.Tensor.__setitem__')
+def tensor__setitem__default(ctx, self, key, value):
+    """Rewrite `setitem` to ease the index put."""
+    if isinstance(key, slice):
+        key = (key, )
+
+    if not isinstance(key, Sequence):
+        return ctx.origin_func(self, key, value)
+
+    for k in key:
+        if not isinstance(k, slice) or k.step is not None:
+            return ctx.origin_func(self, key, value)
+
+    out = value
+    for i, k in enumerate(key):
+        if k == slice(None):
+            continue
+
+        cat_list = []
+
+        # slice self start
+        if k.start is not None:
+            self_slice_start = (slice(None), ) * i + (slice(
+                0, k.start), ) + key[i + 1:]
+            self_start = self[self_slice_start]
+            cat_list.append(self_start)
+
+        # add value
+        cat_list.append(out)
+
+        # slice self end
+        if k.stop is not None:
+            self_slice_end = (slice(None), ) * i + (slice(
+                k.stop, None), ) + key[i + 1:]
+            self_end = self[self_slice_end]
+            cat_list.append(self_end)
+
+        # concate
+        out = torch.cat(cat_list, dim=i)
+
+    # self assign
+    # Note that set item does not return any value
+    self[...] = out

--- a/tests/test_pytorch/test_pytorch_functions.py
+++ b/tests/test_pytorch/test_pytorch_functions.py
@@ -283,3 +283,32 @@ def test_normalize_ncnn(input, dim):
     param_path, bin_path = ncnn_apis.get_output_model_file(ir_file_path)
     assert osp.exists(param_path)
     assert osp.exists(bin_path)
+
+
+@backend_checker(Backend.ONNXRUNTIME)
+@pytest.mark.parametrize('x', [torch.rand(1, 3, 16, 16)])
+@pytest.mark.parametrize('y', [torch.rand(1, 3, 4, 4)])
+def test_tensor_setitem(x, y):
+    import onnx
+
+    from mmdeploy.utils.test import get_onnx_model
+
+    def setitem_slice(x, y):
+        H, W = y.shape[2:]
+        x[:, :, 2:H + 2, 2:W + 2] = y
+        return x
+
+    wrapped_func = WrapFunction(setitem_slice)
+    model_inputs = {'x': x, 'y': y}
+
+    deploy_cfg = mmcv.Config(
+        dict(
+            onnx_config=dict(input_shape=None),
+            backend_config=dict(type='onnxruntime'),
+            codebase_config=dict(type='mmdet', task='ObjectDetection')))
+    ir_file_path = get_onnx_model(wrapped_func, model_inputs, deploy_cfg)
+
+    onnx_model = onnx.load(ir_file_path)
+    nodes = onnx_model.graph.node
+    for node in nodes:
+        assert node.op_type != 'ScatterND'


### PR DESCRIPTION
```python
x[:,:,:H,:W] = y
```

origin:

![shIsm0hIMj](https://user-images.githubusercontent.com/1239736/177259180-11f6e5c7-2dc9-4c28-a193-82f412ce3677.png)

new:
![DbJQZVVsBH](https://user-images.githubusercontent.com/1239736/177259213-14978f9c-ff93-4248-8d00-601fb840a579.png)

benchmark:

origin:
```
-------------------  ------------  ------------  ------------  ------------  ------------  ------------  
               Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------  ------------  ------------  ------------  ------------  ------------  ------------  
    model_inference        95.66%       4.387ms        99.11%       4.545ms       4.545ms             1  
-------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 4.586ms
```

 new:
```
-------------------  ------------  ------------  ------------  ------------  ------------  ------------  
               Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------  ------------  ------------  ------------  ------------  ------------  ------------  
    model_inference        92.63%       2.440ms        99.70%       2.626ms       2.626ms             1  
-------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 2.634ms
```
