### PR TITLE
fix wrong exit code in pipeline_manager

### DIFF
--- a/mmdeploy/apis/core/pipeline_manager.py
+++ b/mmdeploy/apis/core/pipeline_manager.py
@@ -79,7 +79,7 @@ class PipelineCaller:
         if call_id not in self._mp_dict:
             get_root_logger().error(
                 f'`{self._func_name}` with Call id: {call_id} failed. exit.')
-            exit(-1)
+            exit(1)
         ret = self._mp_dict[call_id]
         self._mp_dict.pop(call_id)
         return ret

--- a/mmdeploy/apis/core/pipeline_manager.py
+++ b/mmdeploy/apis/core/pipeline_manager.py
@@ -79,7 +79,7 @@ class PipelineCaller:
         if call_id not in self._mp_dict:
             get_root_logger().error(
                 f'`{self._func_name}` with Call id: {call_id} failed. exit.')
-            exit()
+            exit(-1)
         ret = self._mp_dict[call_id]
         self._mp_dict.pop(call_id)
         return ret

--- a/mmdeploy/backend/pplnn/utils.py
+++ b/mmdeploy/backend/pplnn/utils.py
@@ -37,14 +37,14 @@ def register_engines(device_id: int,
         x86_engine = pplnn.X86EngineFactory.Create(x86_options)
         if not x86_engine:
             logger.error('Failed to create x86 engine')
-            sys.exit(-1)
+            sys.exit(1)
 
         if disable_avx512:
             status = x86_engine.Configure(pplnn.X86_CONF_DISABLE_AVX512)
             if status != pplcommon.RC_SUCCESS:
                 logger.error('x86 engine Configure() failed: ' +
                              pplcommon.GetRetCodeStr(status))
-                sys.exit(-1)
+                sys.exit(1)
 
         engines.append(pplnn.Engine(x86_engine))
 
@@ -55,7 +55,7 @@ def register_engines(device_id: int,
         cuda_engine = pplnn.CudaEngineFactory.Create(cuda_options)
         if not cuda_engine:
             logger.error('Failed to create cuda engine.')
-            sys.exit(-1)
+            sys.exit(1)
 
         if quick_select:
             status = cuda_engine.Configure(
@@ -63,7 +63,7 @@ def register_engines(device_id: int,
             if status != pplcommon.RC_SUCCESS:
                 logger.error('cuda engine Configure() failed: ' +
                              pplcommon.GetRetCodeStr(status))
-                sys.exit(-1)
+                sys.exit(1)
 
         if input_shapes is not None:
             status = cuda_engine.Configure(pplnn.CUDA_CONF_SET_INPUT_DIMS,
@@ -72,7 +72,7 @@ def register_engines(device_id: int,
                 logger.error(
                     'cuda engine Configure(CUDA_CONF_SET_INPUT_DIMS) failed: '
                     + pplcommon.GetRetCodeStr(status))
-                sys.exit(-1)
+                sys.exit(1)
 
         if export_algo_file is not None:
             status = cuda_engine.Configure(pplnn.CUDA_CONF_EXPORT_ALGORITHMS,
@@ -81,7 +81,7 @@ def register_engines(device_id: int,
                 logger.error(
                     'cuda engine Configure(CUDA_CONF_EXPORT_ALGORITHMS) '
                     'failed: ' + pplcommon.GetRetCodeStr(status))
-                sys.exit(-1)
+                sys.exit(1)
 
         if import_algo_file is not None:
             status = cuda_engine.Configure(pplnn.CUDA_CONF_IMPORT_ALGORITHMS,
@@ -90,7 +90,7 @@ def register_engines(device_id: int,
                 logger.error(
                     'cuda engine Configure(CUDA_CONF_IMPORT_ALGORITHMS) '
                     'failed: ' + pplcommon.GetRetCodeStr(status))
-                sys.exit(-1)
+                sys.exit(1)
 
         engines.append(pplnn.Engine(cuda_engine))
 


### PR DESCRIPTION

## Motivation

fix wrong exit code in pipeline_manager. Tools like regression_test.py need a nonzero exit code if the program exits wrongly.

## Modification

Set exit code to -1 in pipeline_manager

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
