### PR TITLE
fix passing wrong backend type for patch_model

### DIFF
--- a/mmdeploy/apis/calibration.py
+++ b/mmdeploy/apis/calibration.py
@@ -62,7 +62,7 @@ def create_calib_input_data(calib_file: str,
         dataset = task_processor.build_dataset(dataset_cfg, dataset_type)
 
         # patch model
-        backend = get_backend(deploy_cfg)
+        backend = get_backend(deploy_cfg).value
         ir = IR.get(get_ir_config(deploy_cfg)['type'])
         patched_model = patch_model(
             model, cfg=deploy_cfg, backend=backend, ir=ir)

--- a/mmdeploy/core/rewriters/rewriter_manager.py
+++ b/mmdeploy/core/rewriters/rewriter_manager.py
@@ -48,7 +48,11 @@ def patch_model(model: nn.Module,
 
     Examples:
         >>> from mmdeploy.core import patch_model
-        >>> patched_model = patch_model(model, cfg=deploy_cfg, backend=backend)
+        >>> from mmdeploy.utils import Backend, IR
+        >>> deploy_cfg = {}
+        >>> backend = Backend.DEFAULT.value
+        >>> ir = IR.ONNX
+        >>> patched_model = patch_model(model, deploy_cfg, backend, ir)
     """
     return MODULE_REWRITER.patch_model(model, cfg, backend, ir, recursive,
                                        **kwargs)


### PR DESCRIPTION


## Motivation

Fix passing wrong type for argument `backend` in `mmdeploy/apis/calibration.py`.
Related issue:https://github.com/open-mmlab/mmdeploy/issues/709

## Modification

Convert to `backend` to `str`  type/ 

## BC-breaking (Optional)

Nonw

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
