### PR TITLE
Fix get-started rendering issues in readthedocs

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -55,6 +55,7 @@ extensions = [
     'sphinx_markdown_tables',
     'myst_parser',
     'sphinx_copybutton',
+    'sphinxcontrib.mermaid'
 ]  # yapf: disable
 
 autodoc_mock_imports = ['tensorrt']

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -244,7 +244,7 @@ cv2.imwrite('output_detection.png', img)
 You can find more examples from [here](https://github.com/open-mmlab/mmdeploy/tree/master/demo/python).
 
 ```{note}
-If you build MMDeploy from the source, please add ${MMDEPLOY_DIR}/build/lib to the environment variable PYTHONPATH.
+If you build MMDeploy from source, please add ${MMDEPLOY_DIR}/build/lib to the environment variable PYTHONPATH.
 Otherwise, you will run into an error like ’ModuleNotFoundError: No module named 'mmdeploy_python'
 ```
 
@@ -252,7 +252,7 @@ Otherwise, you will run into an error like ’ModuleNotFoundError: No module nam
 
 Using SDK C API should follow next pattern,
 
-```mermaid
+```{mermaid}
 graph LR
   A[create inference handle] --> B(read image)
   B --> C(apply handle)

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -304,7 +304,7 @@ int main() {
                   cv::Point{(int)box.right, (int)box.bottom}, cv::Scalar{0, 255, 0});
   }
 
-  cv::imwrite('output_detection.png', img);
+  cv::imwrite("output_detection.png", img);
 
   // destroy result buffer
   mmdeploy_detector_release_result(bboxes, res_count, 1);

--- a/docs/zh_cn/02-how-to-run/quantize_model.md
+++ b/docs/zh_cn/02-how-to-run/quantize_model.md
@@ -14,7 +14,7 @@
 
 以 ncnn backend 为例，完整的工作流如下：
 
-```mermaid
+```{mermaid}
 flowchart TD;
      torch模型-->非标准onnx;
      非标准onnx-->ncnn-fp32;

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -56,6 +56,7 @@ extensions = [
     'sphinx_markdown_tables',
     'myst_parser',
     'sphinx_copybutton',
+    'sphinxcontrib.mermaid'
 ]  # yapf: disable
 
 autodoc_mock_imports = ['tensorrt']

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -303,7 +303,7 @@ int main() {
                   cv::Point{(int)box.right, (int)box.bottom}, cv::Scalar{0, 255, 0});
   }
 
-  cv::imwrite('output_detection.png', img);
+  cv::imwrite("output_detection.png", img);
 
   // 销毁结果
   mmdeploy_detector_release_result(bboxes, res_count, 1);

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -251,7 +251,7 @@ cv2.imwrite('output_detection.png', img)
 
 使用 C API 进行模型推理的流程符合下面的模式：
 
-```mermaid
+```{mermaid}
 graph LR
   A[创建推理句柄] --> B(读取图像)
   B --> C(应用句柄进行推理)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,3 +7,4 @@ recommonmark
 sphinx==4.0.2
 sphinx-copybutton
 sphinx_markdown_tables
+sphinxcontrib-mermaid

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -2,4 +2,5 @@ h5py
 mmcv
 onnx>=1.8.0
 opencv-python==4.5.4.60
+sphinxcontrib-mermaid
 torch


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. C++ code block is not highlighted in readthedocs
2. mermaid graph in markdown is not rendered correctly in readthedocs

## Modification

1. `get_started.md`, `conf.py` both in en / cn folder
2. quantize_model.md
3. add `sphinxcontrib-mermaid` in docs.txt as well as readthedocs.txt

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
5. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
6. The documentation has been modified accordingly, like docstring or example tutorials.
