### PR TITLE
[Fix][P0] Fix for torch1.12

### DIFF
--- a/mmdeploy/apis/onnx/optimizer.py
+++ b/mmdeploy/apis/onnx/optimizer.py
@@ -19,3 +19,14 @@ def model_to_graph__custom_optimizer(ctx, *args, **kwargs):
                                                       torch_out)
 
     return graph, params_dict, torch_out
+
+
+@FUNCTION_REWRITER.register_rewriter(
+    'torch._C._jit_pass_onnx_deduplicate_initializers', backend='tensorrt')
+def jit_pass_onnx_deduplicate_initializers__disable(ctx, graph, param_dict,
+                                                    arg2):
+    """This pass will disable TensorRT topk export.
+
+    disable for TensorRT.
+    """
+    return param_dict

--- a/mmdeploy/core/rewriters/rewriter_utils.py
+++ b/mmdeploy/core/rewriters/rewriter_utils.py
@@ -2,6 +2,7 @@
 import inspect
 import warnings
 from abc import ABCMeta, abstractmethod
+from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import mmdeploy
@@ -352,6 +353,11 @@ class ContextCaller:
         self.func = func
         self.origin_func = origin_func
         self.cfg = cfg
+        if origin_func is not None:
+            wraps(origin_func)(self)
+        else:
+            self.__annotations__ = getattr(func, '__annotations__', {})
+
         for k, v in kwargs.items():
             setattr(self, k, v)
 

--- a/mmdeploy/core/rewriters/rewriter_utils.py
+++ b/mmdeploy/core/rewriters/rewriter_utils.py
@@ -353,6 +353,8 @@ class ContextCaller:
         self.func = func
         self.origin_func = origin_func
         self.cfg = cfg
+        # PyTorch will do annotation check on symbolic function
+        # Update the annotation so ContextCaller can pass the check.
         if origin_func is not None:
             wraps(origin_func)(self)
         else:


### PR DESCRIPTION
1. PyTorch will inspect the rewritten symbolic function(which has been replaced with a ContextCaller)

https://github.com/pytorch/pytorch/blob/67ece03c8cd632cce9523cd96efde6f2d1cc8121/torch/onnx/utils.py#L1333

2. PyTorch add a new pass `_jit_pass_onnx_deduplicate_initializers`, which will turn `k` in `topk` from `initializer` to `Identity`. Which broken the TensorRT export.

https://github.com/pytorch/pytorch/blob/67ece03c8cd632cce9523cd96efde6f2d1cc8121/torch/onnx/utils.py#L1101
