### PR TITLE
[Fix] reduce log verbosity & improve error reporting

### DIFF
--- a/csrc/mmdeploy/apis/c/mmdeploy/executor.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/executor.cpp
@@ -15,7 +15,8 @@ mmdeploy_scheduler_t CreateScheduler(const char* type, const Value& config = Val
   try {
     auto creator = Registry<SchedulerType>::Get().GetCreator(type);
     if (!creator) {
-      MMDEPLOY_ERROR("creator for {} not found.", type);
+      MMDEPLOY_ERROR("Creator for {} not found. Available schedulers: {}", type,
+                     Registry<SchedulerType>::Get().List());
       return nullptr;
     }
     return Cast(new SchedulerType(creator->Create(config)));

--- a/csrc/mmdeploy/apis/c/mmdeploy/executor.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/executor.cpp
@@ -20,7 +20,7 @@ mmdeploy_scheduler_t CreateScheduler(const char* type, const Value& config = Val
     }
     return Cast(new SchedulerType(creator->Create(config)));
   } catch (const std::exception& e) {
-    MMDEPLOY_ERROR("failed to create {}, error: {}", type, e.what());
+    MMDEPLOY_ERROR("failed to create Scheduler: {} ({}), config: {}", type, e.what(), config);
     return nullptr;
   }
 }

--- a/csrc/mmdeploy/apis/c/mmdeploy/handle.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/handle.h
@@ -22,7 +22,8 @@ class AsyncHandle {
     config["context"].update({{"device", device_}, {"stream", stream_}});
     auto creator = Registry<graph::Node>::Get().GetCreator("Pipeline");
     if (!creator) {
-      MMDEPLOY_ERROR("Failed to find Pipeline creator");
+      MMDEPLOY_ERROR("Failed to find Pipeline creator. Available nodes: {}",
+                     Registry<graph::Node>::Get().List());
       throw_exception(eEntryNotFound);
     }
     pipeline_ = creator->Create(config);

--- a/csrc/mmdeploy/apis/c/mmdeploy/handle.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/handle.h
@@ -22,12 +22,12 @@ class AsyncHandle {
     config["context"].update({{"device", device_}, {"stream", stream_}});
     auto creator = Registry<graph::Node>::Get().GetCreator("Pipeline");
     if (!creator) {
-      MMDEPLOY_ERROR("failed to find Pipeline creator");
+      MMDEPLOY_ERROR("Failed to find Pipeline creator");
       throw_exception(eEntryNotFound);
     }
     pipeline_ = creator->Create(config);
     if (!pipeline_) {
-      MMDEPLOY_ERROR("create pipeline failed");
+      MMDEPLOY_ERROR("Failed to create pipeline, config: {}", config);
       throw_exception(eFail);
     }
   }

--- a/csrc/mmdeploy/apis/java/native/mmdeploy_Classifier.cpp
+++ b/csrc/mmdeploy/apis/java/native/mmdeploy_Classifier.cpp
@@ -22,7 +22,7 @@ jlong Java_mmdeploy_Classifier_create(JNIEnv *env, jobject, jstring modelPath, j
 }
 
 void Java_mmdeploy_Classifier_destroy(JNIEnv *, jobject, jlong handle) {
-  MMDEPLOY_INFO("Java_mmdeploy_Classifier_destroy");
+  MMDEPLOY_DEBUG("Java_mmdeploy_Classifier_destroy");
   mmdeploy_classifier_destroy((mmdeploy_classifier_t)handle);
 }
 

--- a/csrc/mmdeploy/apis/java/native/mmdeploy_Detector.cpp
+++ b/csrc/mmdeploy/apis/java/native/mmdeploy_Detector.cpp
@@ -21,7 +21,7 @@ jlong Java_mmdeploy_Detector_create(JNIEnv *env, jobject, jstring modelPath, jst
 }
 
 void Java_mmdeploy_Detector_destroy(JNIEnv *, jobject, jlong handle) {
-  MMDEPLOY_INFO("Java_mmdeploy_Detector_destroy");  // maybe use info?
+  MMDEPLOY_DEBUG("Java_mmdeploy_Detector_destroy");  // maybe use info?
   mmdeploy_detector_destroy((mmdeploy_detector_t)handle);
 }
 

--- a/csrc/mmdeploy/apis/java/native/mmdeploy_PoseDetector.cpp
+++ b/csrc/mmdeploy/apis/java/native/mmdeploy_PoseDetector.cpp
@@ -22,7 +22,7 @@ jlong Java_mmdeploy_PoseDetector_create(JNIEnv *env, jobject, jstring modelPath,
 }
 
 void Java_mmdeploy_PoseDetector_destroy(JNIEnv *, jobject, jlong handle) {
-  MMDEPLOY_INFO("Java_mmdeploy_PoseDetector_destroy");
+  MMDEPLOY_DEBUG("Java_mmdeploy_PoseDetector_destroy");
   mmdeploy_pose_detector_destroy((mmdeploy_pose_detector_t)handle);
 }
 

--- a/csrc/mmdeploy/apis/java/native/mmdeploy_Restorer.cpp
+++ b/csrc/mmdeploy/apis/java/native/mmdeploy_Restorer.cpp
@@ -21,7 +21,7 @@ jlong Java_mmdeploy_Restorer_create(JNIEnv *env, jobject, jstring modelPath, jst
 }
 
 void Java_mmdeploy_Restorer_destroy(JNIEnv *, jobject, jlong handle) {
-  MMDEPLOY_INFO("Java_mmdeploy_Restorer_destroy");
+  MMDEPLOY_DEBUG("Java_mmdeploy_Restorer_destroy");
   mmdeploy_restorer_destroy((mmdeploy_restorer_t)handle);
 }
 

--- a/csrc/mmdeploy/apis/java/native/mmdeploy_Segmentor.cpp
+++ b/csrc/mmdeploy/apis/java/native/mmdeploy_Segmentor.cpp
@@ -21,7 +21,7 @@ jlong Java_mmdeploy_Segmentor_create(JNIEnv *env, jobject, jstring modelPath, js
 }
 
 void Java_mmdeploy_Segmentor_destroy(JNIEnv *, jobject, jlong handle) {
-  MMDEPLOY_INFO("Java_mmdeploy_Segmentor_destroy");
+  MMDEPLOY_DEBUG("Java_mmdeploy_Segmentor_destroy");
   mmdeploy_segmentor_destroy((mmdeploy_segmentor_t)handle);
 }
 

--- a/csrc/mmdeploy/apis/java/native/mmdeploy_TextDetector.cpp
+++ b/csrc/mmdeploy/apis/java/native/mmdeploy_TextDetector.cpp
@@ -22,7 +22,7 @@ jlong Java_mmdeploy_TextDetector_create(JNIEnv *env, jobject, jstring modelPath,
 }
 
 void Java_mmdeploy_TextDetector_destroy(JNIEnv *, jobject, jlong handle) {
-  MMDEPLOY_INFO("Java_mmdeploy_TextDetector_destroy");
+  MMDEPLOY_DEBUG("Java_mmdeploy_TextDetector_destroy");
   mmdeploy_text_detector_destroy((mmdeploy_text_detector_t)handle);
 }
 

--- a/csrc/mmdeploy/apis/java/native/mmdeploy_TextRecognizer.cpp
+++ b/csrc/mmdeploy/apis/java/native/mmdeploy_TextRecognizer.cpp
@@ -22,7 +22,7 @@ jlong Java_mmdeploy_TextRecognizer_create(JNIEnv *env, jobject, jstring modelPat
 }
 
 void Java_mmdeploy_TextRecognizer_destroy(JNIEnv *, jobject, jlong handle) {
-  MMDEPLOY_INFO("Java_mmdeploy_TextRecognizer_destroy");  // maybe use info?
+  MMDEPLOY_DEBUG("Java_mmdeploy_TextRecognizer_destroy");  // maybe use info?
   mmdeploy_text_recognizer_destroy((mmdeploy_text_recognizer_t)handle);
 }
 

--- a/csrc/mmdeploy/codebase/common.h
+++ b/csrc/mmdeploy/codebase/common.h
@@ -45,7 +45,8 @@ class CodebaseCreator : public Creator<Module> {
     auto postprocess_type = cfg[key].get<std::string>();
     auto creator = Registry<Tag>::Get().GetCreator(postprocess_type);
     if (creator == nullptr) {
-      MMDEPLOY_ERROR("could not found entry '{}' in {}", postprocess_type, Tag::name);
+      MMDEPLOY_ERROR("Could not found entry '{}' in {}. Available components: {}", postprocess_type,
+                     Tag::name, Registry<Tag>::Get().List());
       throw_exception(eEntryNotFound);
     }
     return creator->Create(cfg);

--- a/csrc/mmdeploy/codebase/mmocr/dbnet.cpp
+++ b/csrc/mmdeploy/codebase/mmocr/dbnet.cpp
@@ -35,7 +35,9 @@ class DBHead : public MMOCR {
     auto platform = Platform(device_.platform_id()).GetPlatformName();
     auto creator = Registry<DbHeadImpl>::Get().GetCreator(platform);
     if (!creator) {
-      MMDEPLOY_ERROR("DBHead: implementation for platform \"{}\" not found", platform);
+      MMDEPLOY_ERROR(
+          "DBHead: implementation for platform \"{}\" not found. Available platforms: {}", platform,
+          Registry<DbHeadImpl>::Get().List());
       throw_exception(eEntryNotFound);
     }
     impl_ = creator->Create(nullptr);

--- a/csrc/mmdeploy/codebase/mmocr/panet.cpp
+++ b/csrc/mmdeploy/codebase/mmocr/panet.cpp
@@ -37,7 +37,9 @@ class PANHead : public MMOCR {
     auto platform = Platform(device_.platform_id()).GetPlatformName();
     auto creator = Registry<PaHeadImpl>::Get().GetCreator(platform);
     if (!creator) {
-      MMDEPLOY_ERROR("PANHead: implementation for platform \"{}\" not found", platform);
+      MMDEPLOY_ERROR(
+          "PANHead: implementation for platform \"{}\" not found. Available platforms: {}",
+          platform, Registry<PaHeadImpl>::Get().List());
       throw_exception(eEntryNotFound);
     }
     impl_ = creator->Create(nullptr);

--- a/csrc/mmdeploy/codebase/mmocr/psenet.cpp
+++ b/csrc/mmdeploy/codebase/mmocr/psenet.cpp
@@ -34,7 +34,9 @@ class PSEHead : public MMOCR {
     auto platform = Platform(device_.platform_id()).GetPlatformName();
     auto creator = Registry<PseHeadImpl>::Get().GetCreator(platform);
     if (!creator) {
-      MMDEPLOY_ERROR("PSEHead: implementation for platform \"{}\" not found", platform);
+      MMDEPLOY_ERROR(
+          "PSEHead: implementation for platform \"{}\" not found. Available platforms: {}",
+          platform, Registry<PseHeadImpl>::Get().List());
       throw_exception(eEntryNotFound);
     }
     impl_ = creator->Create(nullptr);

--- a/csrc/mmdeploy/core/model.cpp
+++ b/csrc/mmdeploy/core/model.cpp
@@ -35,13 +35,13 @@ Result<void> Model::Init(const std::string& model_path) {
     }
     OUTCOME_TRY(auto meta, impl->ReadMeta());
 
-    MMDEPLOY_INFO("{} successfully load sdk model {}", entry.name, model_path);
+    MMDEPLOY_INFO("{} successfully load model {}", entry.name, model_path);
     impl_ = std::move(impl);
     meta_ = std::move(meta);
     return success();
   }
 
-  MMDEPLOY_ERROR("no ModelImpl can read sdk_model {}", model_path);
+  MMDEPLOY_ERROR("no ModelImpl can read model {}", model_path);
   return Status(eNotSupported);
 }
 
@@ -56,7 +56,7 @@ Result<void> Model::Init(const void* buffer, size_t size) {
     }
     OUTCOME_TRY(auto meta, impl->ReadMeta());
 
-    MMDEPLOY_INFO("successfully load sdk model {}", entry.name);
+    MMDEPLOY_INFO("Successfully load model {}", entry.name);
     impl_ = std::move(impl);
     meta_ = std::move(meta);
     return success();

--- a/csrc/mmdeploy/core/registry.cpp
+++ b/csrc/mmdeploy/core/registry.cpp
@@ -8,7 +8,7 @@ Registry<void>::Registry() = default;
 
 Registry<void>::~Registry() = default;
 
-bool Registry<void>::AddCreator(Creator<void> &creator) {
+bool Registry<void>::AddCreator(Creator<void>& creator) {
   MMDEPLOY_DEBUG("Adding creator: {}", creator.GetName());
   auto key = creator.GetName();
   if (entries_.find(key) == entries_.end()) {
@@ -26,7 +26,7 @@ bool Registry<void>::AddCreator(Creator<void> &creator) {
   return true;
 }
 
-Creator<void> *Registry<void>::GetCreator(const std::string &type, int version) {
+Creator<void>* Registry<void>::GetCreator(const std::string& type, int version) {
   auto iter = entries_.find(type);
   if (iter == entries_.end()) {
     return nullptr;
@@ -41,6 +41,14 @@ Creator<void> *Registry<void>::GetCreator(const std::string &type, int version) 
     }
   }
   return nullptr;
+}
+
+std::vector<std::string> Registry<void>::List() {
+  std::vector<std::string> list;
+  for (const auto& [name, _] : entries_) {
+    list.push_back(name);
+  }
+  return list;
 }
 
 }  // namespace mmdeploy

--- a/csrc/mmdeploy/core/registry.h
+++ b/csrc/mmdeploy/core/registry.h
@@ -38,7 +38,7 @@ template <>
 class Creator<void> {
  public:
   virtual ~Creator() = default;
-  virtual const char *GetName() const = 0;
+  virtual const char* GetName() const = 0;
   virtual int GetVersion() const { return 0; }
 };
 
@@ -48,7 +48,7 @@ class Creator : public Creator<void> {
   using ReturnType = detail::get_return_type_t<EntryType>;
 
  public:
-  virtual ReturnType Create(const Value &args) = 0;
+  virtual ReturnType Create(const Value& args) = 0;
 };
 
 template <class EntryType>
@@ -61,25 +61,27 @@ class MMDEPLOY_API Registry<void> {
 
   ~Registry();
 
-  bool AddCreator(Creator<void> &creator);
+  bool AddCreator(Creator<void>& creator);
 
-  Creator<void> *GetCreator(const std::string &type, int version = 0);
+  Creator<void>* GetCreator(const std::string& type, int version = 0);
+
+  std::vector<std::string> List();
 
  private:
-  std::multimap<std::string, Creator<void> *> entries_;
+  std::multimap<std::string, Creator<void>*> entries_;
 };
 
 template <class EntryType>
 class Registry : public Registry<void> {
  public:
-  bool AddCreator(Creator<EntryType> &creator) { return Registry<void>::AddCreator(creator); }
+  bool AddCreator(Creator<EntryType>& creator) { return Registry<void>::AddCreator(creator); }
 
-  Creator<EntryType> *GetCreator(const std::string &type, int version = 0) {
+  Creator<EntryType>* GetCreator(const std::string& type, int version = 0) {
     auto creator = Registry<void>::GetCreator(type, version);
-    return static_cast<Creator<EntryType> *>(creator);
+    return static_cast<Creator<EntryType>*>(creator);
   }
 
-  static Registry &Get();
+  static Registry& Get();
 
  private:
   Registry() = default;
@@ -98,11 +100,11 @@ class Registerer {
 
 #define MMDEPLOY_DECLARE_REGISTRY(EntryType) \
   template <>                                \
-  Registry<EntryType> &Registry<EntryType>::Get();
+  Registry<EntryType>& Registry<EntryType>::Get();
 
 #define MMDEPLOY_DEFINE_REGISTRY(EntryType)                         \
   template <>                                                       \
-  MMDEPLOY_EXPORT Registry<EntryType> &Registry<EntryType>::Get() { \
+  MMDEPLOY_EXPORT Registry<EntryType>& Registry<EntryType>::Get() { \
     static Registry v;                                              \
     return v;                                                       \
   }
@@ -115,10 +117,10 @@ class Registerer {
    public:                                                             \
     module_name##Creator() = default;                                  \
     ~module_name##Creator() = default;                                 \
-    const char *GetName() const override { return #module_name; }      \
+    const char* GetName() const override { return #module_name; }      \
     int GetVersion() const override { return version; }                \
                                                                        \
-    std::unique_ptr<base_type> Create(const Value &value) override {   \
+    std::unique_ptr<base_type> Create(const Value& value) override {   \
       return std::make_unique<module_name>(value);                     \
     }                                                                  \
   };                                                                   \

--- a/csrc/mmdeploy/core/status_code.cpp
+++ b/csrc/mmdeploy/core/status_code.cpp
@@ -3,6 +3,7 @@
 #include "mmdeploy/core/status_code.h"
 
 #include "mmdeploy/core/logger.h"
+#include "mmdeploy/core/utils/source_location.h"
 
 namespace mmdeploy {
 
@@ -21,7 +22,11 @@ string_ref Status::message() const {
   std::string ret;
   try {
 #if MMDEPLOY_STATUS_USE_SOURCE_LOCATION
+#if MMDEPLOY_HAS_SOURCE_LOCATION
     ret = fmt::format("{} ({}) @ {}:{}", to_string(ec), (int32_t)ec, file, line);
+#else
+    ret = fmt::format("{} ({})", to_string(ec), (int32_t)ec);
+#endif
 #elif MMDEPLOY_STATUS_USE_STACKTRACE
     ret = fmt::format("{} ({}), stacktrace:\n{}", to_string(ec), (int32_t)ec, st.to_string());
 #else

--- a/csrc/mmdeploy/device/cuda/cuda_device.cpp
+++ b/csrc/mmdeploy/device/cuda/cuda_device.cpp
@@ -58,7 +58,7 @@ Allocator CreateDefaultAllocator() {
   AllocatorImplPtr allocator = std::make_shared<Mallocator>();
   allocator = std::make_shared<Tree>(allocator, -1, .5);
   allocator = std::make_shared<Locked>(allocator);
-  MMDEPLOY_INFO("Default CUDA allocator initialized");
+  MMDEPLOY_DEBUG("Default CUDA allocator initialized");
   return Access::create<Allocator>(allocator);
 }
 

--- a/csrc/mmdeploy/execution/bulk.h
+++ b/csrc/mmdeploy/execution/bulk.h
@@ -36,7 +36,7 @@ struct _Receiver<Receiver, Shape, Func>::type {
 
   template <class... As>
   friend void tag_invoke(set_value_t, type&& self, As&&... as) noexcept {
-    MMDEPLOY_WARN("fallback Bulk implementation");
+    MMDEPLOY_DEBUG("fallback Bulk implementation");
     for (Shape i = 0; i < self.shape_; ++i) {
       self.func_(i, as...);
     }

--- a/csrc/mmdeploy/execution/schedulers/dynamic_batch_scheduler.h
+++ b/csrc/mmdeploy/execution/schedulers/dynamic_batch_scheduler.h
@@ -77,7 +77,7 @@ struct Context : context_base_t {
         delay_(scheduler_.timeout_),
         timer_(scheduler_.timer_) {}
 
-  ~Context() { MMDEPLOY_INFO("~Context()"); }
+  ~Context() { MMDEPLOY_DEBUG("~Context()"); }
 
   using _operation_t = operation_t<Sender, Scheduler, Receiver, Func>;
 

--- a/csrc/mmdeploy/graph/common.h
+++ b/csrc/mmdeploy/graph/common.h
@@ -30,7 +30,8 @@ inline Result<RetType> CreateFromRegistry(const Value& config, const char* key =
   auto type = config[key].get<std::string>();
   auto creator = Registry<EntryType>::Get().GetCreator(type);
   if (!creator) {
-    MMDEPLOY_ERROR("Failed to find module creator: {}", type);
+    MMDEPLOY_ERROR("Failed to find creator: {}. Available: {}", type,
+                   Registry<EntryType>::Get().List());
     return Status(eEntryNotFound);
   }
   auto inst = creator->Create(config);

--- a/csrc/mmdeploy/graph/common.h
+++ b/csrc/mmdeploy/graph/common.h
@@ -26,16 +26,16 @@ inline std::true_type Check(T&&) {
 
 template <typename EntryType, typename RetType = typename Creator<EntryType>::ReturnType>
 inline Result<RetType> CreateFromRegistry(const Value& config, const char* key = "type") {
-  MMDEPLOY_INFO("config: {}", config);
+  MMDEPLOY_DEBUG("config: {}", config);
   auto type = config[key].get<std::string>();
   auto creator = Registry<EntryType>::Get().GetCreator(type);
   if (!creator) {
-    MMDEPLOY_ERROR("failed to find module creator: {}", type);
+    MMDEPLOY_ERROR("Failed to find module creator: {}", type);
     return Status(eEntryNotFound);
   }
   auto inst = creator->Create(config);
   if (!Check(inst)) {
-    MMDEPLOY_ERROR("failed to create module: {}", type);
+    MMDEPLOY_ERROR("Failed to create module: {}, config: {}", type, config);
     return Status(eFail);
   }
   return std::move(inst);

--- a/csrc/mmdeploy/graph/pipeline.cpp
+++ b/csrc/mmdeploy/graph/pipeline.cpp
@@ -125,7 +125,6 @@ Result<unique_ptr<Pipeline>> PipelineParser::Parse(const Value& config) {
 
     use_count_.resize(size + 1);
 
-    // MMDEPLOY_INFO("pipeline->inputs: {}", pipeline->inputs());
     OUTCOME_TRY(UpdateOutputCoords(static_cast<int>(size), pipeline->inputs()));
     for (auto task_config : task_configs) {
       auto index = static_cast<int>(nodes.size());
@@ -163,7 +162,6 @@ Result<unique_ptr<Pipeline>> PipelineParser::Parse(const Value& config) {
 }
 
 Result<vector<Pipeline::Coords>> PipelineParser::GetInputCoords(const vector<string>& names) {
-  // MMDEPLOY_INFO("GetInputCoords: {}", names);
   vector<Pipeline::Coords> ret;
   ret.reserve(names.size());
   for (int i = 0; i < names.size(); ++i) {
@@ -192,7 +190,6 @@ Result<void> PipelineParser::UpdateOutputCoords(int index, const vector<string>&
       MMDEPLOY_ERROR("duplicate output: ", output);
       return Status(eNotSupported);
     } else {
-      // MMDEPLOY_ERROR("insert: {}", output);
       output_name_to_coords_.insert({output, {index, i}});
     }
   }

--- a/csrc/mmdeploy/graph/pipeline.cpp
+++ b/csrc/mmdeploy/graph/pipeline.cpp
@@ -142,7 +142,7 @@ Result<unique_ptr<Pipeline>> PipelineParser::Parse(const Value& config) {
         OUTCOME_TRY(UpdateOutputCoords(index, node->outputs()));
         nodes.push_back(std::move(node));
       } else {
-        MMDEPLOY_ERROR("could not create {}: {}", name, type);
+        MMDEPLOY_ERROR("Could not create {}: {}", type, name);
         return Status(eFail);
       }
     }
@@ -199,9 +199,12 @@ Result<void> PipelineParser::UpdateOutputCoords(int index, const vector<string>&
 class PipelineCreator : public Creator<Node> {
  public:
   const char* GetName() const override { return "Pipeline"; }
-  int GetVersion() const override { return 0; }
   std::unique_ptr<Node> Create(const Value& value) override {
-    return PipelineParser{}.Parse(value).value();
+    try {
+      return PipelineParser{}.Parse(value).value();
+    } catch (...) {
+    }
+    return nullptr;
   }
 };
 

--- a/csrc/mmdeploy/graph/task.cpp
+++ b/csrc/mmdeploy/graph/task.cpp
@@ -72,9 +72,12 @@ Result<unique_ptr<Task>> TaskParser::Parse(const Value& config) {
 class TaskCreator : public Creator<Node> {
  public:
   const char* GetName() const override { return "Task"; }
-  int GetVersion() const override { return 0; }
   std::unique_ptr<Node> Create(const Value& value) override {
-    return TaskParser::Parse(value).value();
+    try {
+      return TaskParser::Parse(value).value();
+    } catch (...) {
+    }
+    return nullptr;
   }
 };
 

--- a/csrc/mmdeploy/model/zip_model_impl.cpp
+++ b/csrc/mmdeploy/model/zip_model_impl.cpp
@@ -34,10 +34,10 @@ class ZipModelImpl : public ModelImpl {
     int ret = 0;
     zip_ = zip_open(model_path.c_str(), 0, &ret);
     if (ret != 0) {
-      MMDEPLOY_INFO("open zip file {} failed, ret {}", model_path.c_str(), ret);
+      MMDEPLOY_INFO("Failed to open zip file {}, ret {}", model_path.c_str(), ret);
       return Status(eInvalidArgument);
     }
-    MMDEPLOY_INFO("open sdk model file {} successfully", model_path.c_str());
+    MMDEPLOY_INFO("Open model file {} successfully", model_path.c_str());
     return InitZip();
   }
 
@@ -103,7 +103,7 @@ class ZipModelImpl : public ModelImpl {
  private:
   Result<void> InitZip() {
     int files = zip_get_num_files(zip_);
-    MMDEPLOY_INFO("there are {} files in sdk model file", files);
+    MMDEPLOY_INFO("There are {} files in the model", files);
     if (files == 0) {
       return Status(eFail);
     }

--- a/csrc/mmdeploy/net/net_module.cpp
+++ b/csrc/mmdeploy/net/net_module.cpp
@@ -34,7 +34,8 @@ struct NetModule::Impl {
       stream_ = context.value("stream", Stream::GetDefault(device_));
       auto creator = Registry<Net>::Get().GetCreator(config.backend);
       if (!creator) {
-        MMDEPLOY_ERROR("Net backend not found: {}", config.backend);
+        MMDEPLOY_ERROR("Net backend not found: {}, available backends: {}", config.backend,
+                       Registry<Net>::Get().List());
         return Status(eEntryNotFound);
       }
       auto net_cfg = args;

--- a/csrc/mmdeploy/net/net_module.cpp
+++ b/csrc/mmdeploy/net/net_module.cpp
@@ -41,6 +41,7 @@ struct NetModule::Impl {
       net_cfg["context"].update({{"device", device_}, {"stream", stream_}});
       net_ = creator->Create(net_cfg);
       if (!net_) {
+        MMDEPLOY_ERROR("Failed to create Net backend: {}, config: {}", config.backend, net_cfg);
         return Status(eFail);
       }
       OUTCOME_TRY(InitializeInputTensors(args));

--- a/csrc/mmdeploy/net/ort/ort_net.cpp
+++ b/csrc/mmdeploy/net/ort/ort_net.cpp
@@ -77,7 +77,7 @@ Result<void> OrtNet::Init(const Value& args) {
     auto input_name = session_.GetInputName(i, allocator);
     auto type_info = session_.GetInputTypeInfo(i);
     auto shape = to_shape(type_info);
-    MMDEPLOY_INFO("input {}, shape = {}", i, shape);
+    MMDEPLOY_DEBUG("input {}, shape = {}", i, shape);
     filter_shape(shape);
     OUTCOME_TRY(auto data_type,
                 ConvertElementType(type_info.GetTensorTypeAndShapeInfo().GetElementType()));
@@ -91,7 +91,7 @@ Result<void> OrtNet::Init(const Value& args) {
     auto output_name = session_.GetOutputName(i, allocator);
     auto type_info = session_.GetOutputTypeInfo(i);
     auto shape = to_shape(type_info);
-    MMDEPLOY_INFO("output {}, shape = {}", i, shape);
+    MMDEPLOY_DEBUG("output {}, shape = {}", i, shape);
     filter_shape(shape);
     OUTCOME_TRY(auto data_type,
                 ConvertElementType(type_info.GetTensorTypeAndShapeInfo().GetElementType()));

--- a/csrc/mmdeploy/net/ppl/ppl_net.cpp
+++ b/csrc/mmdeploy/net/ppl/ppl_net.cpp
@@ -236,7 +236,7 @@ Result<void> PPLNet::Reshape(Span<TensorShape> input_shapes) {
   if (can_infer_output_shapes_) {
     OUTCOME_TRY(auto output_shapes,
                 InferOutputShapes(input_shapes, prev_in_shapes, prev_out_shapes));
-    //    MMDEPLOY_ERROR("inferred output shapes: {}", output_shapes);
+    MMDEPLOY_DEBUG("inferred output shapes: {}", output_shapes);
     for (int i = 0; i < outputs_external_.size(); ++i) {
       auto& output = outputs_external_[i];
       output.Reshape(output_shapes[i]);

--- a/csrc/mmdeploy/net/trt/trt_net.cpp
+++ b/csrc/mmdeploy/net/trt/trt_net.cpp
@@ -18,7 +18,7 @@ class TRTLogger : public nvinfer1::ILogger {
   void log(Severity severity, const char* msg) noexcept override {
     switch (severity) {
       case Severity::kINFO:
-        // MMDEPLOY_INFO("TRTNet: {}", msg);
+        MMDEPLOY_DEBUG("TRTNet: {}", msg);
         break;
       case Severity::kWARNING:
         MMDEPLOY_WARN("TRTNet: {}", msg);
@@ -169,7 +169,7 @@ Result<void> TRTNet::Reshape(Span<TensorShape> input_shapes) {
   }
   for (int i = 0; i < input_tensors_.size(); ++i) {
     auto dims = to_dims(input_shapes[i]);
-    //    MMDEPLOY_ERROR("input shape: {}", to_string(dims));
+    MMDEPLOY_DEBUG("input shape: {}", to_string(dims));
     TRT_TRY(context_->setBindingDimensions(input_ids_[i], dims));
     input_tensors_[i].Reshape(input_shapes[i]);
   }
@@ -179,7 +179,7 @@ Result<void> TRTNet::Reshape(Span<TensorShape> input_shapes) {
   }
   for (int i = 0; i < output_tensors_.size(); ++i) {
     auto dims = context_->getBindingDimensions(output_ids_[i]);
-    //    MMDEPLOY_ERROR("output shape: {}", to_string(dims));
+    MMDEPLOY_DEBUG("output shape: {}", to_string(dims));
     output_tensors_[i].Reshape(to_shape(dims));
   }
   return success();

--- a/csrc/mmdeploy/preprocess/transform/compose.cpp
+++ b/csrc/mmdeploy/preprocess/transform/compose.cpp
@@ -21,12 +21,12 @@ Compose::Compose(const Value& args, int version) : Transform(args) {
     auto creator = Registry<Transform>::Get().GetCreator(type, version);
     if (!creator) {
       MMDEPLOY_ERROR("unable to find creator: {}", type);
-      throw std::invalid_argument("unable to find creator");
+      throw_exception(eEntryNotFound);
     }
     auto transform = creator->Create(cfg);
     if (!transform) {
-      MMDEPLOY_ERROR("failed to create transform: {}", type);
-      throw std::invalid_argument("failed to create transform");
+      MMDEPLOY_ERROR("failed to create transform: {}, config: {}", type, cfg);
+      throw_exception(eFail);
     }
     transforms_.push_back(std::move(transform));
   }

--- a/csrc/mmdeploy/preprocess/transform/compose.cpp
+++ b/csrc/mmdeploy/preprocess/transform/compose.cpp
@@ -20,12 +20,13 @@ Compose::Compose(const Value& args, int version) : Transform(args) {
     MMDEPLOY_DEBUG("creating transform: {} with cfg: {}", type, mmdeploy::to_json(cfg).dump(2));
     auto creator = Registry<Transform>::Get().GetCreator(type, version);
     if (!creator) {
-      MMDEPLOY_ERROR("unable to find creator: {}", type);
+      MMDEPLOY_ERROR("Unable to find Transform creator: {}. Available transforms: {}", type,
+                     Registry<Transform>::Get().List());
       throw_exception(eEntryNotFound);
     }
     auto transform = creator->Create(cfg);
     if (!transform) {
-      MMDEPLOY_ERROR("failed to create transform: {}, config: {}", type, cfg);
+      MMDEPLOY_ERROR("Failed to create transform: {}, config: {}", type, cfg);
       throw_exception(eFail);
     }
     transforms_.push_back(std::move(transform));

--- a/csrc/mmdeploy/preprocess/transform/transform.h
+++ b/csrc/mmdeploy/preprocess/transform/transform.h
@@ -41,12 +41,12 @@ class MMDEPLOY_API Transform : public Module {
     std::unique_ptr<T> impl(nullptr);
     auto impl_creator = Registry<T>::Get().GetCreator(specified_platform_, version);
     if (nullptr == impl_creator) {
-      MMDEPLOY_WARN("cannot find {} implementation on specific platform {} ", transform_type,
+      MMDEPLOY_WARN("Cannot find {} implementation on platform {}", transform_type,
                     specified_platform_);
       for (auto& name : candidate_platforms_) {
         impl_creator = Registry<T>::Get().GetCreator(name);
         if (impl_creator) {
-          MMDEPLOY_INFO("fallback {} implementation to platform {}", transform_type, name);
+          MMDEPLOY_INFO("Fallback {} implementation to platform {}", transform_type, name);
           break;
         }
       }

--- a/csrc/mmdeploy/preprocess/transform_module.cpp
+++ b/csrc/mmdeploy/preprocess/transform_module.cpp
@@ -18,7 +18,8 @@ TransformModule::TransformModule(const Value& args) {
   const auto type = "Compose";
   auto creator = Registry<Transform>::Get().GetCreator(type, 1);
   if (!creator) {
-    MMDEPLOY_ERROR("Unable to find Transform creator: {}", type);
+    MMDEPLOY_ERROR("Unable to find Transform creator: {}. Available transforms: {}", type,
+                   Registry<Transform>::Get().List());
     throw_exception(eEntryNotFound);
   }
   auto cfg = args;

--- a/csrc/mmdeploy/preprocess/transform_module.cpp
+++ b/csrc/mmdeploy/preprocess/transform_module.cpp
@@ -18,7 +18,7 @@ TransformModule::TransformModule(const Value& args) {
   const auto type = "Compose";
   auto creator = Registry<Transform>::Get().GetCreator(type, 1);
   if (!creator) {
-    MMDEPLOY_ERROR("unable to find creator: {}", type);
+    MMDEPLOY_ERROR("Unable to find Transform creator: {}", type);
     throw_exception(eEntryNotFound);
   }
   auto cfg = args;


### PR DESCRIPTION
- clear useless logging of configs, only log configs when there are errors.
- when registry lookup fails critically, print a list of available entries. 