### PR TITLE
Fix markdown table rendering failure in readthedocs

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,6 @@
 docutils==0.16.0
 m2r==0.2.1
+markdown<3.4.0
 mistune==0.8.4
 myst-parser
 -e git+https://github.com/open-mmlab/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

https://readthedocs.org/projects/mmcv/builds/17455215/

Failed to build docs due to breaking changes of markdown3.4. More details at https://github.com/ryanfox/sphinx-markdown-tables/issues/36.


## Modification

Set `markdown<3.4.0`. Refer to https://github.com/open-mmlab/mmcv/pull/2121/files

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
