### PR TITLE
support test with multi batch

### DIFF
--- a/configs/mmpose/pose-detection_tensorrt_dynamic-256x192.py
+++ b/configs/mmpose/pose-detection_tensorrt_dynamic-256x192.py
@@ -1,0 +1,23 @@
+_base_ = ['./pose-detection_static.py', '../_base_/backends/tensorrt.py']
+
+onnx_config = dict(
+    input_shape=[192, 256],
+    dynamic_axes={
+        'input': {
+            0: 'batch',
+        },
+        'output': {
+            0: 'batch'
+        }
+    })
+
+backend_config = dict(
+    common_config=dict(max_workspace_size=1 << 30),
+    model_inputs=[
+        dict(
+            input_shapes=dict(
+                input=dict(
+                    min_shape=[1, 3, 256, 192],
+                    opt_shape=[2, 3, 256, 192],
+                    max_shape=[4, 3, 256, 192])))
+    ])

--- a/docs/en/02-how-to-run/how_to_evaluate_a_model.md
+++ b/docs/en/02-how-to-run/how_to_evaluate_a_model.md
@@ -24,6 +24,7 @@ ${MODEL_CFG} \
 [--cfg-options ${CFG_OPTIONS}] \
 [--metric-options ${METRIC_OPTIONS}]
 [--log2file work_dirs/output.txt]
+[--batch-size ${BATCH_SIZE}]
 ```
 
 ## Description of all arguments
@@ -42,6 +43,7 @@ ${MODEL_CFG} \
 - `--metric-options`: Custom options for evaluation. The key-value pair in xxx=yyy
   format will be kwargs for dataset.evaluate() function.
 - `--log2file`: log evaluation results (and speed) to file.
+- `--batch-size`: the batch size for inference, which would override `samples_per_gpu` in data config. Default is `1`.
 
 \* Other arguments in `tools/test.py` are used for speed test. They have no concern with evaluation.
 

--- a/mmdeploy/codebase/mmdet/deploy/mmdetection.py
+++ b/mmdeploy/codebase/mmdet/deploy/mmdetection.py
@@ -59,22 +59,12 @@ class MMDetection(MMCodebase):
         from mmdet.datasets import build_dataset as build_dataset_mmdet
         from mmdet.datasets import replace_ImageToTensor
         assert dataset_type in dataset_cfg.data
+
         data_cfg = dataset_cfg.data[dataset_type]
-        # in case the dataset is concatenated
-        if isinstance(data_cfg, dict):
-            data_cfg.test_mode = True
-            samples_per_gpu = data_cfg.get('samples_per_gpu', 1)
-            if samples_per_gpu > 1:
-                # Replace 'ImageToTensor' to 'DefaultFormatBundle'
-                data_cfg.pipeline = replace_ImageToTensor(data_cfg.pipeline)
-        elif isinstance(data_cfg, list):
-            for ds_cfg in data_cfg:
-                ds_cfg.test_mode = True
-            samples_per_gpu = max(
-                [ds_cfg.get('samples_per_gpu', 1) for ds_cfg in data_cfg])
-            if samples_per_gpu > 1:
-                for ds_cfg in data_cfg:
-                    ds_cfg.pipeline = replace_ImageToTensor(ds_cfg.pipeline)
+        samples_per_gpu = dataset_cfg.data.get('samples_per_gpu', 1)
+        if samples_per_gpu > 1:
+            # Replace 'ImageToTensor' to 'DefaultFormatBundle'
+            data_cfg.pipeline = replace_ImageToTensor(data_cfg.pipeline)
         dataset = build_dataset_mmdet(data_cfg)
 
         return dataset

--- a/tools/test.py
+++ b/tools/test.py
@@ -73,6 +73,12 @@ def parse_args():
         help='the interval between each log, require setting '
         'speed-test first',
         default=100)
+    parser.add_argument(
+        '--batch-size',
+        type=int,
+        default=1,
+        help='the batch size for test, would override `samples_per_gpu`'
+        'in  data config.')
 
     args = parser.parse_args()
     return args
@@ -97,9 +103,11 @@ def main():
     # prepare the dataset loader
     dataset_type = 'test'
     dataset = task_processor.build_dataset(model_cfg, dataset_type)
+    # override samples_per_gpu that used for training
+    model_cfg.data['samples_per_gpu'] = args.batch_size
     data_loader = task_processor.build_dataloader(
         dataset,
-        samples_per_gpu=1,
+        samples_per_gpu=model_cfg.data.samples_per_gpu,
         workers_per_gpu=model_cfg.data.workers_per_gpu)
 
     # load the model of the backend


### PR DESCRIPTION

## Motivation
Add `--batch-size` argument to support run `tools/test.py` with multi batch inference.

## Modification

1. Add `--batch-size` argument to support run `tools/test.py` with multi batch inference.
2. Fix mmdet batch inference in #795

## BC-breaking (Optional)
None
## Use cases (Optional)

```
python tools/test.py \
configs/mmcls/classification_tensorrt_dynamic-224x224-224x224.py \
../mmclassification/configs/resnet/resnet18_8xb32_in1k.py \ 
--model ./work-dirs/mmcls/resnet/trt/end2end.engine \
--device cuda \
--batch-size 64 
```

## Checklist
