### PR TITLE
[Fix][Feature] support build single sdk library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ if (MMDEPLOY_BUILD_SDK)
     endif ()
 
     if (MMDEPLOY_BUILD_EXAMPLES)
+        include(${CMAKE_SOURCE_DIR}/cmake/opencv.cmake)
         add_subdirectory(demo/csrc)
     endif ()
 

--- a/demo/csrc/CMakeLists.txt
+++ b/demo/csrc/CMakeLists.txt
@@ -17,6 +17,7 @@ function(add_example task name)
     endif ()
     if (MMDEPLOY_BUILD_SDK_MONOLITHIC)
       target_link_libraries(${name} PRIVATE mmdeploy ${OpenCV_LIBS})
+      install(TARGETS ${name} RUNTIME DESTINATION bin)
     else ()
       # Load MMDeploy modules
       mmdeploy_load_static(${name} MMDeployStaticModules)


### PR DESCRIPTION
## Motivation

fix opencv not found and when -DMMDEPLOY_BUILD_SDK_MONOLITHIC=ON
fix examples installation  when -DMMDEPLOY_BUILD_SDK_MONOLITHIC=ON
