### PR TITLE
[feat] add basic webcam demo (#659)

### DIFF
--- a/demo/python/webcam_demo.py
+++ b/demo/python/webcam_demo.py
@@ -1,0 +1,62 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import logging
+from argparse import ArgumentParser
+
+import webcam_demo
+
+# from webcam_demo.misc import is_image, is_video
+
+
+def parse_args():
+    parser = ArgumentParser('')
+
+    parser.add_argument('model_path')
+
+    parser.add_argument('--device', type=str, default='cuda')
+
+    parser.add_argument('--camera', type=str, default='0')
+
+    parser.add_argument('--debug', action='store_true')
+
+    parser.add_argument('--fps', type=str, default='30')
+
+    parser.add_argument('--skip', type=str, default='2')
+
+    parser.add_argument('--output', type=str, default='')
+
+    return parser.parse_args()
+
+
+def main():
+
+    args = parse_args()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    file = ''
+
+    try:
+        camera_id = int(args.camera)
+    except ValueError:
+        camera_id = -1
+        file = args.camera.lower()
+
+    if camera_id != -1:
+        demo = webcam_demo.WebcamDemo(camera_id, args.model_path,
+                                      args.device, 0.5, int(args.fps),
+                                      int(args.skip), args.output)
+    elif webcam_demo.misc.is_image(file):
+        demo = webcam_demo.ImageDemo(file, args.model_path, args.device,
+                                     args.output)
+    elif webcam_demo.misc.is_video(file):
+        demo = webcam_demo.VideoDemo(file, args.model_path, args.device,
+                                     args.output)
+    else:
+        raise NotImplementedError('File type not supported')
+
+    demo.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/python/webcam_demo/__init__.py
+++ b/demo/python/webcam_demo/__init__.py
@@ -1,0 +1,242 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import logging
+import threading
+from abc import abstractclassmethod
+
+import cv2
+import mmdeploy_python
+import numpy as np
+
+from . import misc
+
+# import misc
+
+
+class AbstractWebcamDemo:
+
+    def __init__(self, model_path: str, device: str = 'cuda'):
+        self.detector = mmdeploy_python.PoseDetector(model_path, device, 0)
+        self.bbox = []
+
+        self.cached_points = []
+
+        self.visible = True
+        self.help_visible = True
+
+        self.cap = None
+        self.writer = None
+
+    def init_bbox(self, box):
+        self.bbox = box
+
+    # @abstractclassmethod
+    def handle(self, frame):
+        self.add_points(frame)
+        self.add_help_message(frame)
+
+    def get_points(self, frame):
+        assert self.detector is not None
+        assert self.bbox != []
+
+        res = self.detector([frame], [[self.bbox]])[0]
+
+        _, point_cnt, _ = res.shape
+        self.cached_points = res[:, :, :2].reshape(point_cnt, 2).astype(int)
+
+    # @abstractclassmethod
+    def add_points(self, frame):
+        if self.visible:
+            for [x, y] in self.cached_points:
+                cv2.circle(frame, (int(x), int(y)), 1, (0, 0, 255), 2)
+
+    def add_help_message(self, frame):
+        return
+        cv2.putText(frame, self.help_message,
+                    cv2.getWindowImageRect('demo')[:2],
+                    cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 255, 255), 5,
+                    cv2.LINE_AA, False)
+
+    def receive_key(self, key: int):
+        if key == ord('q'):
+            return True
+        else:
+            if key == ord('v'):
+                self.visible = not self.visible
+            elif key == ord('h'):
+                self.help_visible = not self.help_visible
+
+            return False
+
+    @abstractclassmethod
+    def run(self):
+        pass
+
+
+class ImageDemo(AbstractWebcamDemo):
+
+    def __init__(self,
+                 image_file: str,
+                 model_path: str,
+                 device: str = 'cuda',
+                 output_file: str = ''):
+        super().__init__(model_path, device)
+
+        self.input_file = image_file
+        self.output_file = output_file
+
+    def handle(self, frame):
+        self.get_points(frame)
+        super().handle(frame)
+
+    def run(self):
+        img = cv2.imread(self.input_file)
+
+        self.init_bbox([0, 0, *img.shape[:2]])
+        self.handle(img)
+
+        logging.info('Image as input')
+        logging.info('Press any key to continue...')
+
+        cv2.imshow('demo', img)
+        cv2.imwrite('output.png', img)
+
+        cv2.waitKey(0)
+
+        cv2.destroyAllWindows()
+
+
+class VideoDemo(AbstractWebcamDemo):
+
+    def __init__(self,
+                 video_file: str,
+                 model_path: str,
+                 device: str = 'cuda',
+                 output_file: str = '',
+                 code: str = ''):
+        super().__init__(model_path, device)
+
+        self.input_file = video_file
+        self.output_file = output_file
+        self.code = code
+
+    def run(self):
+        self.cap = cv2.VideoCapture(self.input_file)
+
+        frames = []
+        while True:
+            ret, frame = self.cap.read()
+            if not ret:
+                break
+
+            frames.append(frame)
+
+        self.cap.release()
+
+        if not frames:
+            logging.warning('No frame detected')
+            # sys.exit(0)
+        else:
+            row, col, _ = frames[0].shape
+
+            if self.output_file != '':
+                self.writer = cv2.VideoWriter(
+                    self.output_file, cv2.VideoWriter_fourcc(*self.code), 30,
+                    (row, col))
+
+            for frame in frames:
+                self.handle(frame)
+
+                cv2.imshow('demo', frame)
+                if self.writer is not None:
+                    self.writer.write(frame)
+
+                if self.receive_key(cv2.waitKey(10)):
+                    break
+
+            if self.writer is not None:
+                self.writer.release()
+
+        logging.info('Procedure finished, press any key to continue...')
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+
+
+class WebcamDemo(AbstractWebcamDemo):
+
+    def __init__(self,
+                 camera_id: int,
+                 model_path: str,
+                 device: str = 'cuda',
+                 max_delay: float = 0.5,
+                 max_fps=30,
+                 skip: int = 2,
+                 output_file: str = ''):
+        super().__init__(model_path, device)
+
+        self.camera_id = camera_id
+
+        self.max_delay = max(0.0, max_delay)
+        self.max_fps = max(5, max_fps)
+        self.skip_count = max(skip, 1)
+
+        assert output_file == '', 'Webcam output has not been supported'
+
+        self.cnt = 0
+
+    def work(self, frame, q):
+        if self.cnt % self.skip_count == 0 or self.cached_points == []:
+            self.get_points(frame)
+
+        self.handle(frame)
+        q.append(frame)
+
+        self.cnt += 1
+
+    def run(self):
+        self.cap = cv2.VideoCapture(self.camera_id)
+
+        # writer = cv2.VideoWriter('output.avi',
+        #   cv2.VideoWriter_fourcc(*'XVID'), 30, (1920, 1080))
+        q = []
+
+        flag = False
+        last = None
+
+        cv2.namedWindow('demo', cv2.WINDOW_NORMAL)
+
+        while True:
+            with misc.limit_max_fps(self.max_fps):
+                if not flag:
+                    ret, frame = self.cap.read()
+
+                    if not ret:
+                        flag = True
+                    else:
+                        if not self.bbox:
+                            self.init_bbox([0, 0, *frame.shape[:2]])
+
+                        th = threading.Thread(
+                            target=self.work, args=(frame, q))
+                        th.setDaemon(True)
+                        th.start()
+                        # th.join()
+
+                if len(q) > 0:
+                    last = q[0]
+                    q.pop(0)
+                elif flag:
+                    break
+
+                if last is not None:
+                    assert (type(last) == np.ndarray)
+
+                    cv2.imshow('demo', last)
+                    # writer.write(last)
+
+                if self.receive_key(cv2.waitKey(10)):
+                    break
+
+        if self.cap is not None:
+            self.cap.release()
+        # writer.release()
+        cv2.destroyAllWindows()

--- a/demo/python/webcam_demo/misc.py
+++ b/demo/python/webcam_demo/misc.py
@@ -1,0 +1,36 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import time
+from contextlib import contextmanager
+
+
+def is_image(s: str):
+    a = ['jpg', 'png', 'jfif', 'webp', 'jpeg']
+
+    for t in a:
+        if s.endswith('.' + t):
+            return True
+
+    return False
+
+
+def is_video(s: str):
+    a = ['mp4', 'flv']
+
+    for t in a:
+        if s.endswith('.' + t):
+            return True
+
+    return False
+
+
+@contextmanager
+def limit_max_fps(fps: float):
+    t_start = time.time()
+    try:
+        yield
+    finally:
+        t_end = time.time()
+        if fps is not None:
+            t_sleep = 1.0 / fps - t_end + t_start
+            if t_sleep > 0:
+                time.sleep(t_sleep)


### PR DESCRIPTION
## Motivation

In order to get started more quickly, a webcam demo which is easy-to-use is needed. Also solving issue #659.

## Modification

Added `demo/python/webcam_demo.py`, `demo/python/webcam_demo/__init__.py` and `demo/python/webcam_demo/misc.py`.

## BC-breaking (Optional)

There is no BC-breaking.

## Use cases (Optional)

The webcam demo can be used to show how to take use of the APIs of MMDeploy. This is a basic version, and more features may be added soon.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.
