### PR TITLE
Fix doc error of building C examples

### DIFF
--- a/docs/en/02-how-to-run/prebuilt_package_windows.md
+++ b/docs/en/02-how-to-run/prebuilt_package_windows.md
@@ -317,7 +317,7 @@ The following describes how to use the SDK's C API for inference
    // Path should be modified according to the actual location
    mkdir build
    cd build
-   cmake .. -A x64 -T v142 `
+   cmake ..\cpp -A x64 -T v142 `
      -DOpenCV_DIR=C:\Deps\opencv\build\x64\vc15\lib `
      -DMMDeploy_DIR=C:\workspace\mmdeploy-0.7.0-windows-amd64-onnxruntime1.8.1\sdk\lib\cmake\MMDeploy `
      -DONNXRUNTIME_DIR=C:\Deps\onnxruntime\onnxruntime-win-gpu-x64-1.8.1
@@ -353,7 +353,7 @@ The following describes how to use the SDK's C API for inference
    // Path should be modified according to the actual location
    mkdir build
    cd build
-   cmake .. -A x64 -T v142 `
+   cmake ..\cpp -A x64 -T v142 `
      -DOpenCV_DIR=C:\Deps\opencv\build\x64\vc15\lib `
      -DMMDeploy_DIR=C:\workspace\mmdeploy-0.7.0-windows-amd64-cuda11.1-tensorrt8 2.3.0\sdk\lib\cmake\MMDeploy `
      -DTENSORRT_DIR=C:\Deps\tensorrt\TensorRT-8.2.3.0 `

--- a/docs/zh_cn/02-how-to-run/prebuilt_package_windows.md
+++ b/docs/zh_cn/02-how-to-run/prebuilt_package_windows.md
@@ -333,7 +333,7 @@ python .\mmdeploy\demo\python\image_classification.py cpu .\work_dir\onnx\resnet
    // 部分路径根据实际位置进行修改
    mkdir build
    cd build
-   cmake .. -A x64 -T v142 `
+   cmake ..\cpp -A x64 -T v142 `
      -DOpenCV_DIR=C:\Deps\opencv\build\x64\vc15\lib `
      -DMMDeploy_DIR=C:\workspace\mmdeploy-0.7.0-windows-amd64-onnxruntime1.8.1\sdk\lib\cmake\MMDeploy `
      -DONNXRUNTIME_DIR=C:\Deps\onnxruntime\onnxruntime-win-gpu-x64-1.8.1
@@ -369,7 +369,7 @@ python .\mmdeploy\demo\python\image_classification.py cpu .\work_dir\onnx\resnet
    // 部分路径根据所在硬盘的位置进行修改
    mkdir build
    cd build
-   cmake .. -A x64 -T v142 `
+   cmake ..\cpp -A x64 -T v142 `
      -DOpenCV_DIR=C:\Deps\opencv\build\x64\vc15\lib `
      -DMMDeploy_DIR=C:\workspace\mmdeploy-0.7.0-windows-amd64-cuda11.1-tensorrt8 2.3.0\sdk\lib\cmake\MMDeploy `
      -DTENSORRT_DIR=C:\Deps\tensorrt\TensorRT-8.2.3.0 `


### PR DESCRIPTION
Fix doc error of building C examples.

## Motivation

To fix wrong path description in docs which incurs the failure of building C examples.

## Modification

Modify the doc description of [`02-how-to-run/prebuilt_package_windows.md`](https://github.com/open-mmlab/mmdeploy/blob/master/docs/zh_cn/02-how-to-run/prebuilt_package_windows.md) and its [english version](https://github.com/open-mmlab/mmdeploy/blob/master/docs/en/02-how-to-run/prebuilt_package_windows.md).

Modify `cmake ..` into `cmake ..\cpp` for the directory `..` hasn't `CMakeLists.txt` which can cause a failure of compilation.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
