### PR TITLE
set test_mode for mmdet

### DIFF
--- a/mmdeploy/codebase/base/task.py
+++ b/mmdeploy/codebase/base/task.py
@@ -68,7 +68,7 @@ class BaseTask(metaclass=ABCMeta):
     def build_dataset(self,
                       dataset_cfg: Union[str, mmcv.Config],
                       dataset_type: str = 'val',
-                      is_sort_dataset: bool = True,
+                      is_sort_dataset: bool = False,
                       **kwargs) -> Dataset:
         """Build dataset for different codebase.
 
@@ -80,6 +80,7 @@ class BaseTask(metaclass=ABCMeta):
             is_sort_dataset (bool): When 'True', the dataset will be sorted
                 by image shape in ascending order if 'dataset_cfg'
                 contains information about height and width.
+                Default is `False`.
 
         Returns:
             Dataset: The built dataset.

--- a/mmdeploy/codebase/mmdet/deploy/mmdetection.py
+++ b/mmdeploy/codebase/mmdet/deploy/mmdetection.py
@@ -62,9 +62,19 @@ class MMDetection(MMCodebase):
 
         data_cfg = dataset_cfg.data[dataset_type]
         samples_per_gpu = dataset_cfg.data.get('samples_per_gpu', 1)
-        if samples_per_gpu > 1:
-            # Replace 'ImageToTensor' to 'DefaultFormatBundle'
-            data_cfg.pipeline = replace_ImageToTensor(data_cfg.pipeline)
+        if isinstance(data_cfg, dict):
+            data_cfg.test_mode = True
+            if samples_per_gpu > 1:
+                # Replace 'ImageToTensor' to 'DefaultFormatBundle'
+                data_cfg.pipeline = replace_ImageToTensor(data_cfg.pipeline)
+        elif isinstance(data_cfg, list):
+            for ds_cfg in data_cfg:
+                ds_cfg.test_mode = True
+                if samples_per_gpu > 1:
+                    ds_cfg.pipeline = replace_ImageToTensor(ds_cfg.pipeline)
+        else:
+            raise TypeError(f'Unsupported type {type(data_cfg)}')
+
         dataset = build_dataset_mmdet(data_cfg)
 
         return dataset

--- a/tools/test.py
+++ b/tools/test.py
@@ -107,9 +107,7 @@ def main():
 
     # prepare the dataset loader
     dataset_type = 'test'
-
-    dataset = task_processor.build_dataset(
-        model_cfg, dataset_type, is_sort_dataset=False)
+    dataset = task_processor.build_dataset(model_cfg, dataset_type)
     # override samples_per_gpu that used for training
     model_cfg.data['samples_per_gpu'] = args.batch_size
     data_loader = task_processor.build_dataloader(

--- a/tools/test.py
+++ b/tools/test.py
@@ -107,7 +107,9 @@ def main():
 
     # prepare the dataset loader
     dataset_type = 'test'
-    dataset = task_processor.build_dataset(model_cfg, dataset_type)
+
+    dataset = task_processor.build_dataset(
+        model_cfg, dataset_type, is_sort_dataset=False)
     # override samples_per_gpu that used for training
     model_cfg.data['samples_per_gpu'] = args.batch_size
     data_loader = task_processor.build_dataloader(


### PR DESCRIPTION

## Motivation

1. fix https://github.com/open-mmlab/mmdeploy/issues/905
2. Some small images are filtered out for coco dataset when `cfg.data.test.test_mode` is `False` which is not aligned with mmdet setting.

## Modification


1. Set default of `is_sort_dataset` to  `False` to fix https://github.com/open-mmlab/mmdeploy/issues/905
3. set `cfg.data.test.test_mode = True` to align with mmdet [tools](https://github.com/open-mmlab/mmdetection/blob/3b72b12fe9b14de906d1363982b9fba05e7d47c1/tools/test.py#L192) and won't filter small image of the dataset according to [here](https://github.com/open-mmlab/mmdetection/blob/3b72b12fe9b14de906d1363982b9fba05e7d47c1/mmdet/datasets/custom.py#L48).
4. 
## BC-breaking (Optional)
None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist
