### PR TITLE
[Bug] fix setitem with scalar or single element tensor

### DIFF
--- a/mmdeploy/pytorch/functions/tensor_setitem.py
+++ b/mmdeploy/pytorch/functions/tensor_setitem.py
@@ -4,7 +4,7 @@ from typing import Sequence
 import torch
 from packaging.version import parse
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, SYMBOLIC_REWRITER
 
 
 @FUNCTION_REWRITER.register_rewriter(func_name='torch.Tensor.__setitem__')
@@ -71,3 +71,10 @@ def tensor__setitem__default(ctx, self, key, value):
     # self assign
     # Note that set item does not return any value
     self[...] = out
+
+
+if parse(torch.__version__) >= parse('1.12.0'):
+
+    @SYMBOLIC_REWRITER.register_symbolic('copy', is_pytorch=True)
+    def copy__default(ctx, g, x, y, non_blocking):
+        return x


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

slice put would be failed when the value is scalar or single element tensor.

## Modification

create a tensor when element is scalar

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
