### PR TITLE
fix cuda ci of building lanms-neo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         run: |
           python -V
           python -m pip install mmcv-full==${{matrix.mmcv}} -f https://download.openmmlab.com/mmcv/dist/cu102/${{matrix.torch_version}}/index.html
-          python -m pip install -r requirements.txt
+          CFLAGS=`python -c 'import sysconfig;print("-I"+sysconfig.get_paths()["include"])'` python -m pip install -r requirements.txt
           pip install -U pycuda
           python -m pip install -U numpy
       - name: Build and install
@@ -167,7 +167,7 @@ jobs:
         run: |
           python -V
           python -m pip install mmcv-full==${{matrix.mmcv}} -f https://download.openmmlab.com/mmcv/dist/cu111/${{matrix.torch_version}}/index.html
-          python -m pip install -r requirements.txt
+          CFLAGS=`python -c 'import sysconfig;print("-I"+sysconfig.get_paths()["include"])'` python -m pip install -r requirements.txt
           pip install -U pycuda
           python -m pip install -U numpy
       - name: Build and install

--- a/.github/workflows/quantize.yml
+++ b/.github/workflows/quantize.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           python -V
           python -m pip install mmcv-full==${{matrix.mmcv}} -f https://download.openmmlab.com/mmcv/dist/cu111/${{matrix.torch_version}}/index.html
-          python -m pip install -r requirements.txt
+          CFLAGS=`python -c 'import sysconfig;print("-I"+sysconfig.get_paths()["include"])'` python -m pip install -r requirements.txt
           python -m pip install -U numpy
 
       - name: Install mmcls


### PR DESCRIPTION

## Motivation

Fix cuda ci with building `lanms-neo` which is the dependency if `mmocr`.
This problem is also mentioned in the [issue](https://github.com/actions/setup-python/issues/489) of setup-python repo.


## Modification

Add cflags explicitly in cuda ci:
```
CFLAGS=`python -c 'import sysconfig;print("-I"+sysconfig.get_paths()["include"])'` python -m pip install -r requirements.txt
```


## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
