### PR TITLE
remove Release dir in mmdeploy package

### DIFF
--- a/tools/package_tools/mmdeploy_builder.py
+++ b/tools/package_tools/mmdeploy_builder.py
@@ -163,6 +163,7 @@ def build_mmdeploy(cfg, mmdeploy_dir, dist_dir=None):
         build_cmd = 'cmake --build . --config Release -- /m'
         _call_command(build_cmd, build_dir)
         install_cmd = 'cmake --install . --config Release'
+        _remove_if_exist(build_dir, 'lib', 'Release')
         _call_command(install_cmd, build_dir)
     else:
         # build cmd


### PR DESCRIPTION
## Motivation

On windows, there is a Release folder in mmdeploy-xxx.whl. This pr remove this folder.
