### PR TITLE
[Fix] Close onnx optimizer for ncnn

### DIFF
--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -6,8 +6,8 @@ import mmcv
 import torch
 
 from mmdeploy.apis.core.pipeline_manager import no_mp
-from mmdeploy.utils import (get_backend, get_dynamic_axes, get_input_shape,
-                            get_onnx_config, load_config)
+from mmdeploy.utils import (Backend, get_backend, get_dynamic_axes,
+                            get_input_shape, get_onnx_config, load_config)
 from .core import PIPELINE_MANAGER
 from .onnx import export
 
@@ -88,6 +88,11 @@ def torch2onnx(img: Any,
     keep_initializers_as_inputs = onnx_cfg.get('keep_initializers_as_inputs',
                                                True)
     optimize = onnx_cfg.get('optimize', False)
+    if backend == Backend.NCNN.value:
+        '''NCNN backend needs a precise blob counts, while using onnx
+        optimizer will merge duplicate initilizers without reference count.
+        '''
+        optimize = False
     with no_mp():
         export(
             torch_model,

--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -89,9 +89,9 @@ def torch2onnx(img: Any,
                                                True)
     optimize = onnx_cfg.get('optimize', False)
     if backend == Backend.NCNN.value:
-        '''NCNN backend needs a precise blob counts, while using onnx
+        """NCNN backend needs a precise blob counts, while using onnx
         optimizer will merge duplicate initilizers without reference count.
-        '''
+        """
         optimize = False
     with no_mp():
         export(

--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -89,9 +89,8 @@ def torch2onnx(img: Any,
                                                True)
     optimize = onnx_cfg.get('optimize', False)
     if backend == Backend.NCNN.value:
-        """NCNN backend needs a precise blob counts, while using onnx
-        optimizer will merge duplicate initilizers without reference count.
-        """
+        """NCNN backend needs a precise blob counts, while using onnx optimizer
+        will merge duplicate initilizers without reference count."""
         optimize = False
     with no_mp():
         export(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

ONNX Optimizer(#690) will merge duplicate Initializers and Constant Nodes, but the merged initializers still exists in onnx graph nodes. 
So the count of ncnn blobs has wrong.
`blob_count = blob_names.size - zero_reference_weight_node_count + splitncnn_blob_count`
The merged initializers will minus merged initializers duplicately.

## Modification

Force close ncnn optimizer for ncnn.

## BC-breaking (Optional)

None.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
