### PR TITLE
fix mmdeploy builder on windows

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,3 @@
-pyyaml
 asynctest
 coverage
 flake8
@@ -7,5 +6,6 @@ isort==4.3.21
 openpyxl==3.0.9
 pandas
 pytest
+pyyaml
 xlrd==1.2.0
 yapf

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,4 @@
+pyyaml
 asynctest
 coverage
 flake8

--- a/tools/package_tools/mmdeploy_builder.py
+++ b/tools/package_tools/mmdeploy_builder.py
@@ -163,8 +163,8 @@ def build_mmdeploy(cfg, mmdeploy_dir, dist_dir=None):
         build_cmd = 'cmake --build . --config Release -- /m'
         _call_command(build_cmd, build_dir)
         install_cmd = 'cmake --install . --config Release'
-        _remove_if_exist(build_dir, 'lib', 'Release')
         _call_command(install_cmd, build_dir)
+        _remove_if_exist(osp.join(build_dir, 'lib', 'Release'))
     else:
         # build cmd
         build_cmd = 'cmake --build . -- -j$(nproc) && cmake --install .'


### PR DESCRIPTION
The last PR forget to use `osp.join` and `_remove_if_exist` should call after `_call_command`

Fix https://github.com/open-mmlab/mmdeploy/pull/960