### PR TITLE
[2.0] Refactor dump info

### DIFF
--- a/mmdeploy/codebase/base/task.py
+++ b/mmdeploy/codebase/base/task.py
@@ -322,7 +322,7 @@ class BaseTask(metaclass=ABCMeta):
         return input_data['inputs']
 
     @abstractmethod
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -331,7 +331,7 @@ class BaseTask(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
@@ -340,7 +340,7 @@ class BaseTask(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:

--- a/mmdeploy/codebase/mmcls/deploy/classification.py
+++ b/mmdeploy/codebase/mmcls/deploy/classification.py
@@ -241,7 +241,7 @@ class Classification(BaseTask):
         """
         raise NotImplementedError('Not supported yet.')
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -252,7 +252,7 @@ class Classification(BaseTask):
         preprocess = cfg.test_pipeline
         return preprocess
 
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
@@ -269,7 +269,7 @@ class Classification(BaseTask):
         postprocess.topk = max(topk)
         return postprocess
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:

--- a/mmdeploy/codebase/mmdet/deploy/object_detection.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection.py
@@ -206,7 +206,7 @@ class ObjectDetection(BaseTask):
             f'Unknown partition_type {partition_type}'
         return MMDET_PARTITION_CFG[partition_type]
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -217,7 +217,7 @@ class ObjectDetection(BaseTask):
         preprocess = model_cfg.test_pipeline
         return preprocess
 
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
@@ -233,7 +233,7 @@ class ObjectDetection(BaseTask):
                     'mask_thr_binary']
         return postprocess
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:

--- a/mmdeploy/codebase/mmdet3d/deploy/voxel_detection.py
+++ b/mmdeploy/codebase/mmdet3d/deploy/voxel_detection.py
@@ -199,7 +199,7 @@ class VoxelDetection(BaseTask):
             eval_kwargs.update(dict(metric=metrics, **kwargs))
             dataset.evaluate(outputs, **eval_kwargs)
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:
@@ -230,7 +230,7 @@ class VoxelDetection(BaseTask):
         """
         raise NotImplementedError
 
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
@@ -238,7 +238,7 @@ class VoxelDetection(BaseTask):
         """
         raise NotImplementedError
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:

--- a/mmdeploy/codebase/mmedit/deploy/super_resolution.py
+++ b/mmdeploy/codebase/mmedit/deploy/super_resolution.py
@@ -286,7 +286,7 @@ class SuperResolution(BaseTask):
         for stat in stats:
             logger.info('Eval-{}: {}'.format(stat, stats[stat]))
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -300,7 +300,7 @@ class SuperResolution(BaseTask):
                 item['std'] = [255, 255, 255]
         return preprocess
 
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
@@ -308,7 +308,7 @@ class SuperResolution(BaseTask):
         """
         return dict()
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:

--- a/mmdeploy/codebase/mmocr/deploy/text_recognition.py
+++ b/mmdeploy/codebase/mmocr/deploy/text_recognition.py
@@ -218,7 +218,7 @@ class TextRecognition(BaseTask):
         """
         raise NotImplementedError('Not supported yet.')
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -226,21 +226,62 @@ class TextRecognition(BaseTask):
         """
         input_shape = get_input_shape(self.deploy_cfg)
         model_cfg = process_model_config(self.model_cfg, [''], input_shape)
-        preprocess = model_cfg.test_dataloader.dataset.pipeline
-        return preprocess
+        pipeline = model_cfg.test_dataloader.dataset.pipeline
+        meta_keys = [
+            'filename', 'ori_filename', 'ori_shape', 'img_shape', 'pad_shape',
+            'scale_factor', 'flip', 'flip_direction', 'img_norm_cfg',
+            'valid_ratio'
+        ]
+        transforms = [
+            item for item in pipeline if 'Random' not in item['type']
+            and 'Annotation' not in item['type']
+        ]
+        for i, transform in enumerate(transforms):
+            if transform['type'] == 'PackTextRecogInputs':
+                meta_keys += transform[
+                    'meta_keys'] if 'meta_keys' in transform else []
+                transform['meta_keys'] = list(set(meta_keys))
+                transform['keys'] = ['img']
+                transforms[i]['type'] = 'Collect'
+            if transform['type'] == 'Resize':
+                transforms[i]['size'] = transforms[i]['scale']
 
-    def get_postprocess(self) -> Dict:
+        data_preprocessor = model_cfg.model.data_preprocessor
+        transforms.insert(-1, dict(type='DefaultFormatBundle'))
+        transforms.insert(
+            -2,
+            dict(
+                type='Pad',
+                size_divisor=data_preprocessor.get('pad_size_divisor', 1)))
+        transforms.insert(
+            -3,
+            dict(
+                type='Normalize',
+                to_rgb=data_preprocessor.get('bgr_to_rgb', False),
+                mean=data_preprocessor.get('mean', [0, 0, 0]),
+                std=data_preprocessor.get('std', [1, 1, 1])))
+        return transforms
+
+    def get_postprocess(self,
+                        work_dir: Optional[str] = None,
+                        **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
-            dict: Composed of the postprocess information.
+            Dict: Composed of the postprocess information.
         """
         postprocess = self.model_cfg.model.decoder.postprocessor
         if postprocess.type == 'CTCPostProcessor':
             postprocess.type = 'CTCConvertor'
+        import shutil
+        shutil.copy(self.model_cfg.dictionary.dict_file,
+                    f'{work_dir}/dict_file.txt')
+        with_padding = self.model_cfg.dictionary.get('with_padding', False)
+        params = dict(dict_file='dict_file.txt', with_padding=with_padding)
+        postprocess['params'] = params
         return postprocess
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:

--- a/mmdeploy/codebase/mmpose/deploy/pose_detection.py
+++ b/mmdeploy/codebase/mmpose/deploy/pose_detection.py
@@ -305,7 +305,7 @@ class PoseDetection(BaseTask):
         for k, v in sorted(results.items()):
             logger.info(f'{k}: {v:.4f}')
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:
@@ -324,7 +324,7 @@ class PoseDetection(BaseTask):
         """
         raise NotImplementedError('Not supported yet.')
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -335,7 +335,7 @@ class PoseDetection(BaseTask):
         preprocess = model_cfg.data.test.pipeline
         return preprocess
 
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK."""
         postprocess = {'type': 'UNKNOWN'}
         if self.model_cfg.model.type == 'TopDown':

--- a/mmdeploy/codebase/mmrotate/deploy/rotated_detection.py
+++ b/mmdeploy/codebase/mmrotate/deploy/rotated_detection.py
@@ -335,7 +335,7 @@ class RotatedDetection(BaseTask):
             eval_kwargs.update(dict(metric=metrics, **kwargs))
             logger.info(dataset.evaluate(outputs, **eval_kwargs))
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -349,7 +349,7 @@ class RotatedDetection(BaseTask):
         preprocess = model_cfg.data.test.pipeline
         return preprocess
 
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
@@ -358,7 +358,7 @@ class RotatedDetection(BaseTask):
         postprocess = self.model_cfg.model.test_cfg
         return postprocess
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:

--- a/mmdeploy/codebase/mmseg/deploy/segmentation.py
+++ b/mmdeploy/codebase/mmseg/deploy/segmentation.py
@@ -241,7 +241,7 @@ class Segmentation(BaseTask):
     def get_partition_cfg(partition_type: str) -> Dict:
         raise NotImplementedError('Not supported yet.')
 
-    def get_preprocess(self) -> Dict:
+    def get_preprocess(self, *args, **kwargs) -> Dict:
         """Get the preprocess information for SDK.
 
         Return:
@@ -272,7 +272,7 @@ class Segmentation(BaseTask):
                 ]))
         return preprocess
 
-    def get_postprocess(self) -> Dict:
+    def get_postprocess(self, *args, **kwargs) -> Dict:
         """Get the postprocess information for SDK.
 
         Return:
@@ -281,7 +281,7 @@ class Segmentation(BaseTask):
         postprocess = self.model_cfg.model.decode_head
         return postprocess
 
-    def get_model_name(self) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         """Get the model name.
 
         Return:

--- a/mmdeploy/utils/__init__.py
+++ b/mmdeploy/utils/__init__.py
@@ -22,7 +22,7 @@ if importlib.util.find_spec('mmcv') is not None:
                                get_dynamic_axes, get_input_shape,
                                get_ir_config, get_model_inputs,
                                get_onnx_config, get_partition_config,
-                               get_task_type, is_dynamic_batch,
+                               get_precision, get_task_type, is_dynamic_batch,
                                is_dynamic_shape, load_config)
 
     # yapf: enable
@@ -33,5 +33,5 @@ if importlib.util.find_spec('mmcv') is not None:
         'get_codebase_config', 'get_common_config', 'get_dynamic_axes',
         'get_input_shape', 'get_ir_config', 'get_model_inputs',
         'get_onnx_config', 'get_partition_config', 'get_task_type',
-        'is_dynamic_batch', 'is_dynamic_shape', 'load_config'
+        'is_dynamic_batch', 'is_dynamic_shape', 'load_config', 'get_precision'
     ]

--- a/mmdeploy/utils/config_utils.py
+++ b/mmdeploy/utils/config_utils.py
@@ -380,3 +380,26 @@ def get_dynamic_axes(
                 raise KeyError('No names were found to define dynamic axes.')
         dynamic_axes = dict(zip(axes_names, dynamic_axes))
     return dynamic_axes
+
+
+def get_precision(deploy_cfg: Union[str, mmengine.Config]) -> str:
+    """Get precision of config.
+
+    Args:
+        deploy_cfg (str | mmengine.Config): The path or content of config.
+
+    Returns:
+        str: The precision of target backend.
+    """
+    precision = 'FP32'
+    deploy_cfg = load_config(deploy_cfg)[0]
+    backend = get_backend(deploy_cfg=deploy_cfg)
+    if backend == Backend.TENSORRT:
+        common_cfg = get_common_config(deploy_cfg)
+        if common_cfg.get('fp16_mode', False):
+            precision = 'FP16'
+        if common_cfg.get('int8_mode', False):
+            precision = 'INT8'
+    if backend == Backend.NCNN and 'precision' in deploy_cfg['backend_config']:
+        precision = deploy_cfg['backend_config']['precision']
+    return precision


### PR DESCRIPTION
Based on PR `SDK ocr 2.0` #1006. 
Mainly changed:
1. move get_preprocess into task_processor
2. move get_postprocess into task_processor
3. refactor func `get_models`