### PR TITLE
[Fix] fix det with static shape

### DIFF
--- a/mmdeploy/codebase/mmdet/deploy/object_detection.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection.py
@@ -44,7 +44,7 @@ def process_model_config(model_cfg: mmcv.Config,
             trans_type = trans['type']
             if trans_type == 'Resize':
                 trans['keep_ratio'] = False
-            elif trans_type == 'Pad':
+            elif trans_type == 'Pad' and 'size_divisor' in trans:
                 trans['size_divisor'] = 1
 
     cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)

--- a/mmdeploy/codebase/mmdet/deploy/object_detection.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection.py
@@ -42,10 +42,14 @@ def process_model_config(model_cfg: mmcv.Config,
         transforms = cfg.data.test.pipeline[1]['transforms']
         for trans in transforms:
             trans_type = trans['type']
-            if trans_type == 'Resize':
+            if trans_type == 'Resize' and len(
+                    input_shape) != 1 and input_shape[0] != input_shape[1]:
                 trans['keep_ratio'] = False
-            elif trans_type == 'Pad' and 'size_divisor' in trans:
-                trans['size_divisor'] = 1
+            elif trans_type == 'Pad':
+                if 'size_divisor' in trans:
+                    trans['size_divisor'] = 1
+                else:
+                    trans['size'] = tuple(input_shape)
 
     cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)
     return cfg

--- a/mmdeploy/codebase/mmrotate/deploy/rotated_detection.py
+++ b/mmdeploy/codebase/mmrotate/deploy/rotated_detection.py
@@ -64,7 +64,7 @@ def process_model_config(model_cfg: mmcv.Config,
         transforms = cfg.data.test.pipeline[1]['transforms']
         for trans in transforms:
             trans_type = trans['type']
-            if trans_type == 'Pad':
+            if trans_type == 'Pad' and 'size_divisor' in trans:
                 trans['size_divisor'] = 1
 
     cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

static shape config failed when pad mode is size instead of size_divisor

## Modification

`configs/efficientnet/retinanet_effb3_fpn_crop896_8x4_1x_coco.py`

```python
onnx_config = dict(
    type='onnx',
    export_params=True,
    keep_initializers_as_inputs=False,
    opset_version=11,
    save_file='end2end.onnx',
    input_names=['input'],
    output_names=['dets', 'labels'],
    input_shape=(896, 896),
    # dynamic_axes=dict(
    #     input=dict({
    #         0: 'batch',
    #         2: 'height',
    #         3: 'width'
    #     }),
    #     dets=dict({
    #         0: 'batch',
    #         1: 'num_dets'
    #     }),
    #     labels=dict({
    #         0: 'batch',
    #         1: 'num_dets'
    #     })),
    optimize=True)
codebase_config = dict(
    type='mmdet',
    task='ObjectDetection',
    model_type='end2end',
    post_processing=dict(
        score_threshold=0.05,
        confidence_threshold=0.005,
        iou_threshold=0.5,
        max_output_boxes_per_class=200,
        pre_top_k=5000,
        keep_top_k=100,
        background_label_id=-1))
backend_config = dict(
    type='tensorrt',
    common_config=dict(fp16_mode=False, max_workspace_size=1073741824),
    model_inputs=[
        dict(
            input_shapes=dict(
                input=dict(
                    min_shape=[1, 3, 896, 896],
                    opt_shape=[1, 3, 896, 896],
                    max_shape=[1, 3, 896, 896])))
    ])

```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
