### PR TITLE
[Fix] fix mmrotate TensorRT int8

### DIFF
--- a/mmdeploy/codebase/mmrotate/deploy/rotated_detection.py
+++ b/mmdeploy/codebase/mmrotate/deploy/rotated_detection.py
@@ -268,9 +268,10 @@ class RotatedDetection(BaseTask):
         Returns:
             torch.Tensor: An image in `Tensor`.
         """
-        if isinstance(input_data['img'], DataContainer):
-            return input_data['img'].data[0]
-        return input_data['img'][0]
+        img_data = input_data['img'][0]
+        if isinstance(img_data, DataContainer):
+            return img_data.data[0]
+        return img_data
 
     @staticmethod
     def evaluate_outputs(model_cfg,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

https://github.com/open-mmlab/mmdeploy/issues/1048

## Modification

- Fix `get_tensor_from_input`.
- Better head rewriter.

Note that **DO NOT** enable fp16 if you want to use int8 mode.

Test with config:

```python
onnx_config = dict(
    type='onnx',
    export_params=True,
    keep_initializers_as_inputs=False,
    opset_version=11,
    save_file='end2end.onnx',
    input_names=['input'],
    output_names=['dets', 'labels'],
    input_shape=None,
    optimize=True,
    dynamic_axes=dict(
        input=dict({
            0: 'batch',
            2: 'height',
            3: 'width'
        }),
        dets=dict({
            0: 'batch',
            1: 'num_dets'
        }),
        labels=dict({
            0: 'batch',
            1: 'num_dets'
        })))
codebase_config = dict(
    type='mmrotate',
    task='RotatedDetection',
    post_processing=dict(
        score_threshold=0.05,
        iou_threshold=0.1,
        pre_top_k=3000,
        keep_top_k=2000,
        max_output_boxes_per_class=2000))

calib_config = dict(create_calib=True, calib_file='calib_data.h5')

backend_config = dict(
    type='tensorrt',
    common_config=dict(int8_mode=True, max_workspace_size=1073741824),
    model_inputs=[
        dict(
            input_shapes=dict(
                input=dict(
                    min_shape=[1, 3, 320, 320],
                    opt_shape=[1, 3, 1024, 1024],
                    max_shape=[1, 3, 1024, 1024])))
    ])

``` 

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
