### PR TITLE
fix ort-gpu inference

### DIFF
--- a/mmdeploy/backend/onnxruntime/wrapper.py
+++ b/mmdeploy/backend/onnxruntime/wrapper.py
@@ -92,6 +92,8 @@ class ORTWrapper(BaseWrapper):
         for name in self._output_names:
             self.io_binding.bind_output(name)
         # run session to get outputs
+        if self.device_type == 'cuda':
+            torch.cuda.synchronize()
         self.__ort_execute(self.io_binding)
         output_list = self.io_binding.copy_outputs_to_cpu()
         outputs = {}


### PR DESCRIPTION
## Motivation

When use onnxruntime-gpu, it seems we need to synchronize stream before run session.

