### PR TITLE
[Fix] fix layer norm when torch>=1.12

### DIFF
--- a/mmdeploy/pytorch/ops/layer_norm.py
+++ b/mmdeploy/pytorch/ops/layer_norm.py
@@ -2,7 +2,6 @@
 # Modified from:
 # https://github.com/pytorch/pytorch/blob/9ade03959392e5a90b74261012de1d806cab2253/torch/onnx/symbolic_opset9.py
 
-import torch
 from torch.onnx.symbolic_helper import parse_args
 
 from mmdeploy.core import SYMBOLIC_REWRITER
@@ -22,17 +21,6 @@ def layer_norm__default(ctx, g, input, normalized_shape, weight, bias, eps,
     """
     import torch.onnx.symbolic_helper as sym_help
     from torch.onnx.symbolic_opset9 import add, mul, pow, sqrt, sub
-    if sym_help._operator_export_type == \
-            torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
-        return g.op(
-            'ATen',
-            input,
-            weight,
-            bias,
-            normalized_shape_i=normalized_shape,
-            eps_f=eps,
-            cudnn_enable_i=cudnn_enable,
-            operator_s='layer_norm')
 
     axes = [-i for i in range(len(normalized_shape), 0, -1)]
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`torch.onnx.symbolic_helper._operator_export_type` api has removed in torch1.12.0

## Modification

Remove related code

## BC-breaking (Optional)

None.

## Use cases (Optional)

None.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
