### PR TITLE
Improve CI test of rust-mmdeploy

### DIFF
--- a/.github/workflows/rust_api.yml
+++ b/.github/workflows/rust_api.yml
@@ -64,10 +64,4 @@ jobs:
           export ONNXRUNTIME_DIR=/home/runner/work/mmdeploy/mmdeploy/onnxruntime-linux-x64-1.8.1
           export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH
           cargo build
-          cargo run --example classifier cpu ../mmdeploy-converted-models/resnet ./images/demos/mmcls_demo.jpg
-          cargo run --example detector cpu ../mmdeploy-converted-models/faster-rcnn-ort ./images/demos/mmdet_demo.jpg
-          cargo run --example segmentor cpu ../mmdeploy-converted-models/deeplabv3 ./images/demos/mmseg_demo.png
-          cargo run --example pose_detector cpu ../mmdeploy-converted-models/hrnet ./images/demos/mmpose_demo.jpg
-          cargo run --example rotated_detector cpu ../mmdeploy-converted-models/retinanet ./images/demos/mmrotate_demo.jpg
-          cargo run --example ocr cpu ../mmdeploy-converted-models/dbnet ../mmdeploy-converted-models/crnn ./images/demos/mmocr_demo.jpg
-          cargo run --example restorer cpu ../mmdeploy-converted-models/edsr ./images/demos/mmediting_demo.png
+          sh ci_test.sh


### PR DESCRIPTION
## Motivation

The current test commands are highly dependent on the structure of  `mmdeploy-converted-models` and examples of `rust-mmdeploy`. I write a test script in `rust-mmdeploy`, so that the CI test in `mmdeploy` can decouple with the other two repos. Besides, this decouple made the further development of `rust-mmdeploy` more scalable.

## Modification

Update `rust_api.yml` in `.github/workflows`. Replace running test commands with running a test scripts.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
