### PR TITLE
[Enhancement] Add a device field for `mmdeploy_mat_t`

### DIFF
--- a/csrc/mmdeploy/apis/c/mmdeploy/common.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/common.cpp
@@ -49,9 +49,7 @@ int mmdeploy_common_create_input(const mmdeploy_mat_t* mats, int mat_count,
   try {
     auto input = std::make_unique<Value>(Value{Value::kArray});
     for (int i = 0; i < mat_count; ++i) {
-      mmdeploy::Mat _mat{mats[i].height,         mats[i].width, PixelFormat(mats[i].format),
-                         DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
-      input->front().push_back({{"ori_img", _mat}});
+      input->front().push_back({{"ori_img", Cast(mats[i])}});
     }
     *value = Cast(input.release());
   } catch (const std::exception& e) {

--- a/csrc/mmdeploy/apis/c/mmdeploy/common.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/common.h
@@ -54,6 +54,8 @@ typedef enum mmdeploy_status_t {
 
 // clang-format on
 
+typedef struct mmdeploy_device* mmdeploy_device_t;
+
 typedef struct mmdeploy_mat_t {
   uint8_t* data;
   int height;
@@ -61,6 +63,7 @@ typedef struct mmdeploy_mat_t {
   int channel;
   mmdeploy_pixel_format_t format;
   mmdeploy_data_type_t type;
+  mmdeploy_device_t device;
 } mmdeploy_mat_t;
 
 typedef struct mmdeploy_rect_t {
@@ -78,8 +81,6 @@ typedef struct mmdeploy_point_t {
 typedef struct mmdeploy_value* mmdeploy_value_t;
 
 typedef struct mmdeploy_context* mmdeploy_context_t;
-
-typedef struct mmdeploy_device* mmdeploy_device_t;
 
 typedef enum mmdeploy_context_type_t {
   MMDEPLOY_TYPE_DEVICE = 0,

--- a/csrc/mmdeploy/apis/c/mmdeploy/common_internal.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/common_internal.h
@@ -90,7 +90,7 @@ class wrapped<T, std::void_t<decltype(Cast(T{}))>> {
   T release() noexcept { return std::exchange(v_, nullptr); }
 
   auto operator*() { return Cast(v_); }
-  auto operator->() { return Cast(v_); }
+  auto operator-> () { return Cast(v_); }
 
   T* ptr() noexcept { return &v_; }
 

--- a/csrc/mmdeploy/apis/c/mmdeploy/common_internal.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/common_internal.h
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "handle.h"
+#include "mmdeploy/core/mat.h"
 #include "mmdeploy/core/value.h"
 #include "model.h"
 #include "pipeline.h"
@@ -25,19 +26,26 @@ inline Value Take(mmdeploy_value_t v) {
 
 inline Value* Cast(mmdeploy_context_t c) { return reinterpret_cast<Value*>(c); }
 
-mmdeploy_value_t Take(Value v) {
+inline mmdeploy_value_t Take(Value v) {
   return Cast(new Value(std::move(v)));  // NOLINT
 }
 
-mmdeploy_pipeline_t Cast(AsyncHandle* pipeline) {
+inline mmdeploy_pipeline_t Cast(AsyncHandle* pipeline) {
   return reinterpret_cast<mmdeploy_pipeline_t>(pipeline);
 }
 
-AsyncHandle* Cast(mmdeploy_pipeline_t pipeline) { return reinterpret_cast<AsyncHandle*>(pipeline); }
+inline AsyncHandle* Cast(mmdeploy_pipeline_t pipeline) {
+  return reinterpret_cast<AsyncHandle*>(pipeline);
+}
 
-mmdeploy_model_t Cast(Model* model) { return reinterpret_cast<mmdeploy_model_t>(model); }
+inline mmdeploy_model_t Cast(Model* model) { return reinterpret_cast<mmdeploy_model_t>(model); }
 
-Model* Cast(mmdeploy_model_t model) { return reinterpret_cast<Model*>(model); }
+inline Model* Cast(mmdeploy_model_t model) { return reinterpret_cast<Model*>(model); }
+
+inline Mat Cast(const mmdeploy_mat_t& mat) {
+  return Mat{mat.height,         mat.width, PixelFormat(mat.format),
+             DataType(mat.type), mat.data,  mat.device ? *(const Device*)mat.device : Device{0}};
+}
 
 template <typename F>
 std::invoke_result_t<F> Guard(F f) {
@@ -82,7 +90,7 @@ class wrapped<T, std::void_t<decltype(Cast(T{}))>> {
   T release() noexcept { return std::exchange(v_, nullptr); }
 
   auto operator*() { return Cast(v_); }
-  auto operator-> () { return Cast(v_); }
+  auto operator->() { return Cast(v_); }
 
   T* ptr() noexcept { return &v_; }
 

--- a/csrc/mmdeploy/apis/c/mmdeploy/pose_detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/pose_detector.cpp
@@ -121,8 +121,7 @@ int mmdeploy_pose_detector_create_input(const mmdeploy_mat_t* mats, int mat_coun
     };
 
     for (int i = 0; i < mat_count; ++i) {
-      mmdeploy::Mat _mat{mats[i].height,         mats[i].width, PixelFormat(mats[i].format),
-                         DataType(mats[i].type), mats[i].data,  Device{"cpu"}};
+      auto _mat = Cast(mats[i]);
       if (bboxes && bbox_count) {
         for (int j = 0; j < bbox_count[i]; ++j) {
           add_bbox(_mat, bboxes++);

--- a/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.cpp
@@ -106,8 +106,7 @@ int mmdeploy_text_recognizer_create_input(const mmdeploy_mat_t* images, int imag
     };
 
     for (int i = 0; i < image_count; ++i) {
-      Mat _mat{images[i].height,         images[i].width, PixelFormat(images[i].format),
-               DataType(images[i].type), images[i].data,  Device{"cpu"}};
+      auto _mat = Cast(images[i]);
       if (bboxes && bbox_count) {
         for (int j = 0; j < bbox_count[i]; ++j) {
           add_bbox(_mat, bboxes++);

--- a/csrc/mmdeploy/apis/cxx/mmdeploy/common.hpp
+++ b/csrc/mmdeploy/apis/cxx/mmdeploy/common.hpp
@@ -81,8 +81,8 @@ class Mat {
   Mat() : desc_{} {}
 
   Mat(int height, int width, int channels, mmdeploy_pixel_format_t format,
-      mmdeploy_data_type_t type, uint8_t* data)
-      : desc_{data, height, width, channels, format, type} {}
+      mmdeploy_data_type_t type, uint8_t* data, mmdeploy_device_t device = nullptr)
+      : desc_{data, height, width, channels, format, type, device} {}
 
   const mmdeploy_mat_t& desc() const noexcept { return desc_; }
 

--- a/csrc/mmdeploy/utils/opencv/opencv_utils.cpp
+++ b/csrc/mmdeploy/utils/opencv/opencv_utils.cpp
@@ -11,6 +11,8 @@
 namespace mmdeploy {
 namespace cpu {
 
+using namespace framework;
+
 Mat CVMat2Mat(const cv::Mat& mat, PixelFormat format) {
   std::shared_ptr<void> data(mat.data, [mat = mat](void* p) {});
   DataType type;

--- a/csrc/mmdeploy/utils/opencv/opencv_utils.h
+++ b/csrc/mmdeploy/utils/opencv/opencv_utils.h
@@ -12,13 +12,11 @@
 namespace mmdeploy {
 namespace cpu {
 
-using namespace framework;
+MMDEPLOY_API cv::Mat Mat2CVMat(const framework::Mat& mat);
+MMDEPLOY_API cv::Mat Tensor2CVMat(const framework::Tensor& tensor);
 
-MMDEPLOY_API cv::Mat Mat2CVMat(const Mat& mat);
-MMDEPLOY_API cv::Mat Tensor2CVMat(const Tensor& tensor);
-
-MMDEPLOY_API Mat CVMat2Mat(const cv::Mat& mat, PixelFormat format);
-MMDEPLOY_API Tensor CVMat2Tensor(const cv::Mat& mat);
+MMDEPLOY_API framework::Mat CVMat2Mat(const cv::Mat& mat, PixelFormat format);
+MMDEPLOY_API framework::Tensor CVMat2Tensor(const cv::Mat& mat);
 
 /**
  * @brief resize an image to specified size


### PR DESCRIPTION
## Modification

Add a device field for `mmdeployt_mat_t` so that it can be filled with data in external device memory.

## BC-breaking (Optional)

This breaks ABI compatibility with previous versions. All dependent sources must be recompiled & linked.