### PR TITLE
Fix rust_api CI

### DIFF
--- a/.github/workflows/rust_api.yml
+++ b/.github/workflows/rust_api.yml
@@ -49,17 +49,14 @@ jobs:
         run: |
           wget https://github.com/open-mmlab/mmdeploy/releases/download/v0.9.0/mmdeploy-0.9.0-linux-x86_64-onnxruntime1.8.1.tar.gz
           tar -zxvf mmdeploy-0.9.0-linux-x86_64-onnxruntime1.8.1.tar.gz
-          pushd mmdeploy-0.9.0-linux-x86_64-onnxruntime1.8.1
-          export MMDEPLOY_DIR=$(pwd)/sdk
-          export LD_LIBRARY_PATH=$MMDEPLOY_DIR/lib:$LD_LIBRARY_PATH
-          popd
-      - name: Install rust-mmdeploy
+      - name: Download rust-mmdeploy
         run: git clone https://github.com/liu-mengyang/rust-mmdeploy
-      - name: Install converted models
+      - name: Download converted models
         run: git clone https://github.com/liu-mengyang/mmdeploy-converted-models --depth=1
       - name: Test rustdemo
         run: |
           pushd rust-mmdeploy
+          export MMDEPLOY_DIR=/home/runner/work/mmdeploy/mmdeploy/onnxruntime-linux-x64-1.8.1/sdk
           export LD_LIBRARY_PATH=$MMDEPLOY_DIR/lib:$LD_LIBRARY_PATH
           export ONNXRUNTIME_DIR=/home/runner/work/mmdeploy/mmdeploy/onnxruntime-linux-x64-1.8.1
           export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH

--- a/.github/workflows/rust_api.yml
+++ b/.github/workflows/rust_api.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Test rustdemo
         run: |
           pushd rust-mmdeploy
-          export MMDEPLOY_DIR=/home/runner/work/mmdeploy/mmdeploy/onnxruntime-linux-x64-1.8.1/sdk
+          export MMDEPLOY_DIR=/home/runner/work/mmdeploy/mmdeploy/mmdeploy-0.9.0-linux-x86_64-onnxruntime1.8.1/sdk
           export LD_LIBRARY_PATH=$MMDEPLOY_DIR/lib:$LD_LIBRARY_PATH
           export ONNXRUNTIME_DIR=/home/runner/work/mmdeploy/mmdeploy/onnxruntime-linux-x64-1.8.1
           export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH

--- a/.github/workflows/rust_api.yml
+++ b/.github/workflows/rust_api.yml
@@ -47,19 +47,19 @@ jobs:
         run: sudo apt-get install libopencv-dev
       - name: Install mmdeploy with onnxruntime backend
         run: |
-          mkdir -p build && pushd build
-          export LD_LIBRARY_PATH=/home/runner/work/mmdeploy/mmdeploy/ncnn/install/lib/:$LD_LIBRARY_PATH
-          cmake -DMMDEPLOY_BUILD_SDK=ON -DMMDEPLOY_BUILD_SDK_MONOLITHIC=ON -DMMDEPLOY_TARGET_BACKENDS=ort -DMMDEPLOY_CODEBASES=all -DONNXRUNTIME_DIR=~/work/mmdeploy/mmdeploy/onnxruntime-linux-x64-1.8.1  ..
-          make install
+          wget https://github.com/open-mmlab/mmdeploy/releases/download/v0.9.0/mmdeploy-0.9.0-linux-x86_64-onnxruntime1.8.1.tar.gz
+          tar -zxvf mmdeploy-0.9.0-linux-x86_64-onnxruntime1.8.1.tar.gz
+          pushd mmdeploy-0.9.0-linux-x86_64-onnxruntime1.8.1
+          export MMDEPLOY_DIR=$(pwd)/sdk
+          export LD_LIBRARY_PATH=$MMDEPLOY_DIR/lib:$LD_LIBRARY_PATH
           popd
-      - name: Clone rust-mmdeploy
+      - name: Download rust-mmdeploy
         run: git clone https://github.com/liu-mengyang/rust-mmdeploy
       - name: Install converted models
         run: git clone https://github.com/liu-mengyang/mmdeploy-converted-models --depth=1
       - name: Test rustdemo
         run: |
           pushd rust-mmdeploy
-          export MMDEPLOY_DIR=/home/runner/work/mmdeploy/mmdeploy/build/install
           export LD_LIBRARY_PATH=$MMDEPLOY_DIR/lib:$LD_LIBRARY_PATH
           export ONNXRUNTIME_DIR=/home/runner/work/mmdeploy/mmdeploy/onnxruntime-linux-x64-1.8.1
           export LD_LIBRARY_PATH=$ONNXRUNTIME_DIR/lib:$LD_LIBRARY_PATH

--- a/.github/workflows/rust_api.yml
+++ b/.github/workflows/rust_api.yml
@@ -53,7 +53,7 @@ jobs:
           export MMDEPLOY_DIR=$(pwd)/sdk
           export LD_LIBRARY_PATH=$MMDEPLOY_DIR/lib:$LD_LIBRARY_PATH
           popd
-      - name: Download rust-mmdeploy
+      - name: Install rust-mmdeploy
         run: git clone https://github.com/liu-mengyang/rust-mmdeploy
       - name: Install converted models
         run: git clone https://github.com/liu-mengyang/mmdeploy-converted-models --depth=1


### PR DESCRIPTION
## Motivation

The current rust_api CI is compiling the latest mmdeploy, and then rust-mmdeploy will link their libraries. But the minor changes in nightly mmdeploy maybe also need to modify Rust code in rust-mmdeploy to pass the CI test which is difficult to manage the main mmdeploy project.

So that this PR will update rust_api CI to just download released pre-built package of mmdeploy rather than compiling the nightly mmdeploy.

## Modification

Update rust_api CI.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
