### PR TITLE
[Enhancement] Avoid copying dense arrays in C API

### DIFF
--- a/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
@@ -38,8 +38,6 @@ using ResultType = mmdeploy::Structure<mmdeploy_detection_t,                    
                                        std::deque<mmdeploy_instance_mask_t>,       //
                                        std::vector<mmdeploy::framework::Buffer>>;  //
 
-ResultType CreateResultType(size_t num_dets) { return ResultType({num_dets, 1, 1, 1}); }
-
 }  // namespace
 
 int mmdeploy_detector_create(mmdeploy_model_t model, const char* device_name, int device_id,
@@ -119,7 +117,7 @@ int mmdeploy_detector_get_result(mmdeploy_value_t output, mmdeploy_detection_t**
       total += detector_outputs[i].size();
     }
 
-    ResultType r = CreateResultType(total);
+    ResultType r({total, 1, 1, 1});
     auto [result_data, result_count_vec, masks, buffers] = r.pointers();
 
     auto result_ptr = result_data;
@@ -160,7 +158,7 @@ int mmdeploy_detector_get_result(mmdeploy_value_t output, mmdeploy_detection_t**
 void mmdeploy_detector_release_result(mmdeploy_detection_t* results, const int* result_count,
                                       int count) {
   auto num_dets = std::accumulate(result_count, result_count + count, 0);
-  auto deleter = CreateResultType(num_dets);
+  ResultType deleter({static_cast<size_t>(num_dets), 1, 1, 1}, results);
 }
 
 void mmdeploy_detector_destroy(mmdeploy_detector_t detector) {

--- a/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
@@ -2,6 +2,7 @@
 
 #include "detector.h"
 
+#include <deque>
 #include <numeric>
 
 #include "mmdeploy/apis/c/mmdeploy/common_internal.h"
@@ -11,6 +12,7 @@
 #include "mmdeploy/codebase/mmdet/mmdet.h"
 #include "mmdeploy/core/device.h"
 #include "mmdeploy/core/model.h"
+#include "mmdeploy/core/mpl/structure.h"
 #include "mmdeploy/core/utils/formatter.h"
 #include "mmdeploy/core/value.h"
 
@@ -30,6 +32,13 @@ Value config_template(Model model) {
   };
   // clang-format on
 }
+
+using ResultType = mmdeploy::Structure<mmdeploy_detection_t,                       //
+                                       std::vector<int>,                           //
+                                       std::deque<mmdeploy_instance_mask_t>,       //
+                                       std::vector<mmdeploy::framework::Buffer>>;  //
+
+ResultType CreateResultType(size_t num_dets) { return ResultType({num_dets, 1, 1, 1}); }
 
 }  // namespace
 
@@ -103,26 +112,18 @@ int mmdeploy_detector_get_result(mmdeploy_value_t output, mmdeploy_detection_t**
     Value& value = Cast(output)->front();
     auto detector_outputs = from_value<vector<mmdet::Detections>>(value);
 
-    vector<int> _result_count;
-    _result_count.reserve(detector_outputs.size());
-    for (const auto& det_output : detector_outputs) {
-      _result_count.push_back((int)det_output.size());
+    vector<int> _result_count(detector_outputs.size());
+    size_t total = 0;
+    for (size_t i = 0; i < detector_outputs.size(); ++i) {
+      _result_count[i] = static_cast<int>(detector_outputs[i].size());
+      total += detector_outputs[i].size();
     }
-    auto total = std::accumulate(_result_count.begin(), _result_count.end(), 0);
 
-    std::unique_ptr<int[]> result_count_data(new int[_result_count.size()]{});
-    auto result_count_ptr = result_count_data.get();
-    std::copy(_result_count.begin(), _result_count.end(), result_count_data.get());
+    ResultType r = CreateResultType(total);
 
-    auto deleter = [&](mmdeploy_detection_t* p) {
-      mmdeploy_detector_release_result(p, result_count_ptr, (int)detector_outputs.size());
-    };
-    std::unique_ptr<mmdeploy_detection_t[], decltype(deleter)> result_data(
-        new mmdeploy_detection_t[total]{}, deleter);
-    // ownership transferred to result_data
-    result_count_data.release();
+    auto [result_data, result_count_vec, masks, buffers] = r.pointers();
 
-    auto result_ptr = result_data.get();
+    auto result_ptr = result_data;
 
     for (const auto& det_output : detector_outputs) {
       for (const auto& detection : det_output) {
@@ -133,18 +134,20 @@ int mmdeploy_detector_get_result(mmdeploy_value_t output, mmdeploy_detection_t**
         auto mask_byte_size = detection.mask.byte_size();
         if (mask_byte_size) {
           auto& mask = detection.mask;
-          result_ptr->mask = new mmdeploy_instance_mask_t{};
-          result_ptr->mask->data = new char[mask_byte_size];
+          result_ptr->mask = &masks->emplace_back();
+          buffers->push_back(mask.buffer());
+          result_ptr->mask->data = mask.data<char>();
           result_ptr->mask->width = mask.width();
           result_ptr->mask->height = mask.height();
-          std::copy(mask.data<char>(), mask.data<char>() + mask_byte_size, result_ptr->mask->data);
         }
         ++result_ptr;
       }
     }
 
-    *result_count = result_count_ptr;
-    *results = result_data.release();
+    *result_count_vec = std::move(_result_count);
+    *result_count = result_count_vec->data();
+    *results = result_data;
+    r.release();
 
     return MMDEPLOY_SUCCESS;
   } catch (const std::exception& e) {
@@ -157,17 +160,8 @@ int mmdeploy_detector_get_result(mmdeploy_value_t output, mmdeploy_detection_t**
 
 void mmdeploy_detector_release_result(mmdeploy_detection_t* results, const int* result_count,
                                       int count) {
-  auto result_ptr = results;
-  for (int i = 0; i < count; ++i) {
-    for (int j = 0; j < result_count[i]; ++j, ++result_ptr) {
-      if (result_ptr->mask) {
-        delete[] result_ptr->mask->data;
-        delete result_ptr->mask;
-      }
-    }
-  }
-  delete[] results;
-  delete[] result_count;
+  auto num_dets = std::accumulate(result_count, result_count + count, 0);
+  auto deleter = CreateResultType(num_dets);
 }
 
 void mmdeploy_detector_destroy(mmdeploy_detector_t detector) {

--- a/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
@@ -120,7 +120,6 @@ int mmdeploy_detector_get_result(mmdeploy_value_t output, mmdeploy_detection_t**
     }
 
     ResultType r = CreateResultType(total);
-
     auto [result_data, result_count_vec, masks, buffers] = r.pointers();
 
     auto result_ptr = result_data;

--- a/csrc/mmdeploy/apis/c/mmdeploy/restorer.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/restorer.cpp
@@ -108,10 +108,9 @@ int mmdeploy_restorer_get_result(mmdeploy_value_t output, mmdeploy_mat_t** resul
     const Value& value = Cast(output)->front();
 
     auto restorer_output = from_value<std::vector<mmedit::RestorerOutput>>(value);
-
     auto count = restorer_output.size();
-    ResultType r(count);
 
+    ResultType r(count);
     auto [_results, buffers] = r.pointers();
 
     for (int i = 0; i < count; ++i) {

--- a/csrc/mmdeploy/apis/c/mmdeploy/restorer.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/restorer.cpp
@@ -8,6 +8,7 @@
 #include "mmdeploy/codebase/mmedit/mmedit.h"
 #include "mmdeploy/core/device.h"
 #include "mmdeploy/core/graph.h"
+#include "mmdeploy/core/mpl/structure.h"
 #include "mmdeploy/core/utils/formatter.h"
 #include "pipeline.h"
 
@@ -26,6 +27,8 @@ Value config_template(const Model& model) {
   };
   // clang-format on
 }
+
+using ResultType = mmdeploy::Structure<mmdeploy_mat_t, mmdeploy::framework::Buffer>;
 
 }  // namespace
 
@@ -69,10 +72,7 @@ int mmdeploy_restorer_apply(mmdeploy_restorer_t restorer, const mmdeploy_mat_t* 
 }
 
 void mmdeploy_restorer_release_result(mmdeploy_mat_t* results, int count) {
-  for (int i = 0; i < count; ++i) {
-    delete[] results[i].data;
-  }
-  delete[] results;
+  ResultType deleter{static_cast<size_t>(count), results};
 }
 
 void mmdeploy_restorer_destroy(mmdeploy_restorer_t restorer) {
@@ -110,26 +110,25 @@ int mmdeploy_restorer_get_result(mmdeploy_value_t output, mmdeploy_mat_t** resul
     auto restorer_output = from_value<std::vector<mmedit::RestorerOutput>>(value);
 
     auto count = restorer_output.size();
+    ResultType r(count);
 
-    auto deleter = [&](mmdeploy_mat_t* p) {
-      mmdeploy_restorer_release_result(p, static_cast<int>(count));
-    };
-
-    std::unique_ptr<mmdeploy_mat_t[], decltype(deleter)> _results(new mmdeploy_mat_t[count]{},
-                                                                  deleter);
+    auto [_results, buffers] = r.pointers();
 
     for (int i = 0; i < count; ++i) {
       auto upscale = restorer_output[i];
       auto& res = _results[i];
-      res.data = new uint8_t[upscale.byte_size()];
-      memcpy(res.data, upscale.data<uint8_t>(), upscale.byte_size());
+      res.data = upscale.data<uint8_t>();
+      buffers[i] = upscale.buffer();
       res.format = (mmdeploy_pixel_format_t)upscale.pixel_format();
       res.height = upscale.height();
       res.width = upscale.width();
       res.channel = upscale.channel();
       res.type = (mmdeploy_data_type_t)upscale.type();
     }
-    *results = _results.release();
+
+    *results = _results;
+    r.release();
+
     return MMDEPLOY_SUCCESS;
   } catch (const std::exception& e) {
     MMDEPLOY_ERROR("unhandled exception: {}", e.what());

--- a/csrc/mmdeploy/apis/c/mmdeploy/segmentor.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/segmentor.cpp
@@ -8,6 +8,7 @@
 #include "mmdeploy/core/device.h"
 #include "mmdeploy/core/graph.h"
 #include "mmdeploy/core/mat.h"
+#include "mmdeploy/core/mpl/structure.h"
 #include "mmdeploy/core/tensor.h"
 #include "mmdeploy/core/utils/formatter.h"
 #include "pipeline.h"
@@ -28,6 +29,8 @@ Value config_template(const Model& model) {
   };
   // clang-format on
 }
+
+using ResultType = mmdeploy::Structure<mmdeploy_segmentation_t, mmdeploy::framework::Buffer>;
 
 }  // namespace
 
@@ -71,14 +74,7 @@ int mmdeploy_segmentor_apply(mmdeploy_segmentor_t segmentor, const mmdeploy_mat_
 }
 
 void mmdeploy_segmentor_release_result(mmdeploy_segmentation_t* results, int count) {
-  if (results == nullptr) {
-    return;
-  }
-
-  for (auto i = 0; i < count; ++i) {
-    delete[] results[i].mask;
-  }
-  delete[] results;
+  ResultType deleter(static_cast<size_t>(count), results);
 }
 
 void mmdeploy_segmentor_destroy(mmdeploy_segmentor_t segmentor) {
@@ -109,15 +105,13 @@ int mmdeploy_segmentor_apply_async(mmdeploy_segmentor_t segmentor, mmdeploy_send
 int mmdeploy_segmentor_get_result(mmdeploy_value_t output, mmdeploy_segmentation_t** results) {
   try {
     const auto& value = Cast(output)->front();
-
     size_t image_count = value.size();
 
-    auto deleter = [&](mmdeploy_segmentation_t* p) {
-      mmdeploy_segmentor_release_result(p, static_cast<int>(image_count));
-    };
-    unique_ptr<mmdeploy_segmentation_t[], decltype(deleter)> _results(
-        new mmdeploy_segmentation_t[image_count]{}, deleter);
-    auto results_ptr = _results.get();
+    ResultType r(image_count);
+
+    auto [results_data, buffers] = r.pointers();
+    auto results_ptr = results_data;
+
     for (auto i = 0; i < image_count; ++i, ++results_ptr) {
       auto& output_item = value[i];
       MMDEPLOY_DEBUG("the {}-th item in output: {}", i, output_item);
@@ -126,13 +120,15 @@ int mmdeploy_segmentor_get_result(mmdeploy_value_t output, mmdeploy_segmentation
       results_ptr->width = segmentor_output.width;
       results_ptr->classes = segmentor_output.classes;
       auto mask_size = results_ptr->height * results_ptr->width;
-      results_ptr->mask = new int[mask_size];
-      const auto& mask = segmentor_output.mask;
-      std::copy_n(mask.data<int>(), mask_size, results_ptr->mask);
+      auto& mask = segmentor_output.mask;
+      results_ptr->mask = mask.data<int>();
+      buffers[i] = mask.buffer();
     }
-    *results = _results.release();
-    return MMDEPLOY_SUCCESS;
 
+    *results = results_data;
+    r.release();
+
+    return MMDEPLOY_SUCCESS;
   } catch (const std::exception& e) {
     MMDEPLOY_ERROR("exception caught: {}", e.what());
   } catch (...) {

--- a/csrc/mmdeploy/apis/c/mmdeploy/segmentor.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/segmentor.cpp
@@ -108,8 +108,8 @@ int mmdeploy_segmentor_get_result(mmdeploy_value_t output, mmdeploy_segmentation
     size_t image_count = value.size();
 
     ResultType r(image_count);
-
     auto [results_data, buffers] = r.pointers();
+
     auto results_ptr = results_data;
 
     for (auto i = 0; i < image_count; ++i, ++results_ptr) {

--- a/csrc/mmdeploy/core/mpl/structure.h
+++ b/csrc/mmdeploy/core/mpl/structure.h
@@ -1,0 +1,231 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#ifndef MMDEPLOY_CSRC_MMDEPLOY_CORE_MPL_STRUCTURE_H_
+#define MMDEPLOY_CSRC_MMDEPLOY_CORE_MPL_STRUCTURE_H_
+
+#include <array>
+#include <memory>
+#include <tuple>
+#include <utility>
+
+namespace mmdeploy {
+
+namespace _structure {
+
+using std::array;
+using std::index_sequence;
+using std::integral_constant;
+using std::tuple;
+
+// [p0][T0]...[p1][T1]...[pn][Tn]...[px][X]
+// ^                                     |
+// |-------------------------------------|
+template <size_t Size>
+class Storage {
+  static constexpr auto S = Size + 1;
+  using Indices = std::make_index_sequence<S>;
+
+ public:
+  Storage(const Storage&) = delete;
+  Storage(Storage&&) noexcept = delete;
+  Storage& operator=(const Storage&) = delete;
+  Storage& operator=(Storage&&) noexcept = delete;
+
+  Storage(const array<size_t, Size>& sizes, const array<size_t, Size>& aligns) {
+    create(std::make_index_sequence<Size>{}, sizes, aligns);
+  }
+
+  template <size_t offset>
+  Storage(const array<size_t, Size>& sizes, const array<size_t, Size>& aligns,
+          integral_constant<size_t, offset> index, void* ptr) noexcept {
+    create(std::make_index_sequence<Size>{}, sizes, aligns, index, ptr);
+  }
+
+  template <size_t... i, typename... As>
+  void create(index_sequence<i...>, const array<size_t, Size>& sizes,
+              const array<size_t, Size>& aligns, As&&... as) {
+    std::tie(data_, pointers_) =
+        Creator{{sizes[i]..., sizeof(void*)}, {aligns[i]..., alignof(void*)}}.create((As &&) as...);
+  }
+
+  ~Storage() {
+    if (data_) {
+      delete[] static_cast<uint8_t*>(data_);
+      release();
+    }
+  }
+
+  void* data() const noexcept { return data_; }
+
+  template <size_t i>
+  void* at() const noexcept {
+    return pointers_[i];
+  }
+
+  array<void*, S>& pointers() { return pointers_; }
+
+  void* release() noexcept {
+    std::fill_n(pointers_.data(), S, nullptr);
+    return std::exchange(data_, nullptr);
+  }
+
+ private:
+  struct Creator {
+    const array<size_t, S>& sizes_;
+    const array<size_t, S>& aligns_;
+
+    tuple<void*, array<void*, S>> create() {
+      auto space = get_space(Indices{});
+      void* data = new uint8_t[space];
+      auto ptr = data;
+      array<void*, S> pointers{};
+      // build the layout according to sizes and alignments
+      align<0>(ptr, space, pointers, Indices{});
+      // store a pointer to the head of data in the last slot
+      *reinterpret_cast<void**>(pointers.back()) = data;
+      return {data, pointers};
+    }
+
+    template <size_t offset>
+    tuple<void*, array<void*, S>> create(integral_constant<size_t, offset>, void* ptr) {
+      auto space = get_space(Indices{});
+      array<void*, S> pointers{};
+      // recover the layout after offset
+      align<offset>(ptr, space, pointers, std::make_index_sequence<S - offset>{});
+      // recover data pointer
+      auto data = ptr = *reinterpret_cast<void**>(pointers.back());
+      // recover the layout before offset
+      align<0>(ptr, space, pointers, std::make_index_sequence<offset>{});
+      return {data, pointers};
+    }
+
+   private:
+    template <size_t... i>
+    size_t get_space(index_sequence<i...>) const noexcept {
+      return ((sizes_[i] + aligns_[i]) + ...);
+    }
+
+    template <size_t offset, size_t... i>
+    void align(void*& ptr, size_t& space, array<void*, S>& pointers,
+               index_sequence<i...>) noexcept {
+      (align(ptr, space, pointers, integral_constant<size_t, offset + i>{}), ...);
+    }
+
+    template <size_t i>
+    void align(void*& ptr, size_t& space, array<void*, S>& pointers,
+               integral_constant<size_t, i>) noexcept {
+      pointers[i] = std::align(aligns_[i], sizes_[i], ptr, space);
+      ptr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(ptr) + sizes_[i]);
+      space -= sizes_[i];
+    }
+  };
+
+ private:
+  void* data_{};
+  array<void*, S> pointers_{};
+};
+
+template <typename T, typename Ts, typename Is, typename = void>
+struct get_type_index {};
+
+template <typename T, typename... Ts, size_t... Is>
+struct get_type_index<T, tuple<Ts...>, index_sequence<Is...>,
+                      std::enable_if_t<(std::is_same_v<T, Ts> + ...) == 1>>
+    : integral_constant<size_t, ((std::is_same_v<T, Ts> * Is) + ...)> {};
+
+template <typename T>
+using _size_t = size_t;
+
+template <typename... Ts>
+class Structure : public Storage<sizeof...(Ts)> {
+  static constexpr auto Size = sizeof...(Ts);
+  using Base = Storage<Size>;
+  using Indices = std::index_sequence_for<Ts...>;
+
+ public:
+  explicit Structure() : Structure(1) {}
+
+  explicit Structure(size_t length) : Structure(array<size_t, Size>{_size_t<Ts>(length)...}) {}
+
+  explicit Structure(const array<size_t, Size>& lengths)
+      : Base(get_sizes(lengths, Indices{}), {alignof(Ts)...}), lengths_{lengths} {
+    construct(Indices{});
+  }
+
+  template <typename T, size_t index = get_type_index<T, tuple<Ts...>, Indices>::value>
+  explicit Structure(T* p) : Structure(1, integral_constant<size_t, index>{}, p) {}
+
+  template <typename T, size_t index = get_type_index<T, tuple<Ts...>, Indices>::value>
+  explicit Structure(size_t length, T* p)
+      : Structure(length, integral_constant<size_t, index>{}, p) {}
+
+  template <typename T, size_t index = get_type_index<T, tuple<Ts...>, Indices>::value>
+  explicit Structure(const array<size_t, Size>& lengths, T* p)
+      : Structure(lengths, integral_constant<size_t, index>{}, p) {}
+
+  template <size_t i>
+  explicit Structure(integral_constant<size_t, i> index, void* p) : Structure(1, index, p) {}
+
+  template <size_t i>
+  explicit Structure(size_t length, integral_constant<size_t, i> index, void* p)
+      : Structure({_size_t<Ts>(length)...}, index, p) {}
+
+  template <size_t i>
+  explicit Structure(const array<size_t, Size>& lengths, integral_constant<size_t, i> index,
+                     void* p)
+      : Base(get_sizes(lengths, Indices{}), {alignof(Ts)...}, index, p), lengths_{lengths} {}
+
+  ~Structure() {
+    if (this->data()) {
+      destruct(Indices{});
+    }
+  }
+
+  template <size_t i>
+  decltype(auto) get() const {
+    using T = std::tuple_element_t<i, tuple<Ts...>>;
+    return reinterpret_cast<T*>(this->template at<i>());
+  }
+
+  tuple<Ts*...> pointers() const noexcept { return pointers(Indices{}); }
+
+ private:
+  template <size_t... i>
+  static array<size_t, Size> get_sizes(const array<size_t, Size>& lengths,
+                                       index_sequence<i...>) noexcept {
+    return {(sizeof(Ts) * lengths[i])...};
+  }
+
+  template <size_t... i>
+  tuple<Ts*...> pointers(index_sequence<i...>) const noexcept {
+    return {get<i>()...};
+  }
+
+  template <size_t... i>
+  void construct(index_sequence<i...>) {
+    (create_n(get<i>(), lengths_[i]), ...);
+  }
+
+  template <typename T>
+  static void create_n(T* data, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+      new (data + i) T{};
+    }
+  }
+
+  template <size_t... i>
+  void destruct(index_sequence<i...>) {
+    (std::destroy_n(get<i>(), lengths_[i]), ...);
+  }
+
+ private:
+  array<size_t, Size> lengths_;
+};
+
+}  // namespace _structure
+
+using _structure::Structure;
+
+}  // namespace mmdeploy
+
+#endif  // MMDEPLOY_CSRC_MMDEPLOY_CORE_MPL_STRUCTURE_H_

--- a/csrc/mmdeploy/core/mpl/structure.h
+++ b/csrc/mmdeploy/core/mpl/structure.h
@@ -125,13 +125,25 @@ class Storage {
   array<void*, S> pointers_{};
 };
 
+template <typename T, typename... Ts>
+struct _count {
+  static constexpr size_t value = (std::is_same_v<T, Ts> + ...);
+};
+
+template <typename T, typename Is, typename... Ts>
+struct _find {};
+
+template <typename T, size_t... Is, typename... Ts>
+struct _find<T, std::index_sequence<Is...>, Ts...> {
+  static constexpr size_t value = ((std::is_same_v<T, Ts> * Is) + ...);
+};
+
 template <typename T, typename Ts, typename Is, typename = void>
 struct get_type_index {};
 
-template <typename T, typename... Ts, size_t... Is>
-struct get_type_index<T, tuple<Ts...>, index_sequence<Is...>,
-                      std::enable_if_t<(std::is_same_v<T, Ts> + ...) == 1>>
-    : integral_constant<size_t, ((std::is_same_v<T, Ts> * Is) + ...)> {};
+template <typename T, typename... Ts, typename Is>
+struct get_type_index<T, tuple<Ts...>, Is, std::enable_if_t<_count<T, Ts...>::value == 1>>
+    : integral_constant<size_t, _find<T, Is, Ts...>::value> {};
 
 template <typename T>
 using _size_t = size_t;

--- a/csrc/mmdeploy/core/mpl/structure.h
+++ b/csrc/mmdeploy/core/mpl/structure.h
@@ -130,20 +130,14 @@ struct _count {
   static constexpr size_t value = (std::is_same_v<T, Ts> + ...);
 };
 
-template <typename T, typename Is, typename... Ts>
-struct _find {};
-
-template <typename T, size_t... Is, typename... Ts>
-struct _find<T, std::index_sequence<Is...>, Ts...> {
-  static constexpr size_t value = ((std::is_same_v<T, Ts> * Is) + ...);
-};
-
 template <typename T, typename Ts, typename Is, typename = void>
 struct get_type_index {};
 
-template <typename T, typename... Ts, typename Is>
-struct get_type_index<T, tuple<Ts...>, Is, std::enable_if_t<_count<T, Ts...>::value == 1>>
-    : integral_constant<size_t, _find<T, Is, Ts...>::value> {};
+template <typename T, typename... Ts, size_t... Is>
+struct get_type_index<T, tuple<Ts...>, std::index_sequence<Is...>,
+                      std::enable_if_t<_count<T, Ts...>::value == 1>> {
+  static constexpr size_t value = ((std::is_same_v<T, Ts> * Is) + ...);
+};
 
 template <typename T>
 using _size_t = size_t;


### PR DESCRIPTION
Add a tuple-like class that can recover the structure of itself using a pointer to anyone of its elements. And use it to avoid copying when returning dense arrays in C API.