### PR TITLE
checkpoint load RuntimeError

### DIFF
--- a/mmdeploy/codebase/base/task.py
+++ b/mmdeploy/codebase/base/task.py
@@ -105,7 +105,10 @@ class BaseTask(metaclass=ABCMeta):
         model = MODELS.build(model)
         if model_checkpoint is not None:
             from mmengine.runner.checkpoint import load_checkpoint
-            load_checkpoint(model, model_checkpoint)
+            map_location = None
+            if self.device == 'cpu':
+                map_location = torch.device('cpu')
+            load_checkpoint(model, model_checkpoint, map_location=map_location)
 
         model = revert_sync_batchnorm(model)
         model = model.to(self.device)

--- a/mmdeploy/codebase/base/task.py
+++ b/mmdeploy/codebase/base/task.py
@@ -105,10 +105,7 @@ class BaseTask(metaclass=ABCMeta):
         model = MODELS.build(model)
         if model_checkpoint is not None:
             from mmengine.runner.checkpoint import load_checkpoint
-            map_location = None
-            if self.device == 'cpu':
-                map_location = torch.device('cpu')
-            load_checkpoint(model, model_checkpoint, map_location=map_location)
+            load_checkpoint(model, model_checkpoint, map_location=self.device)
 
         model = revert_sync_batchnorm(model)
         model = model.to(self.device)


### PR DESCRIPTION
Checkpoint loading error when 'device=cpu'.
> RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.