### PR TITLE
[Fix] Relax module adapter template constraints

### DIFF
--- a/csrc/mmdeploy/codebase/mmdet/yolo_head.cpp
+++ b/csrc/mmdeploy/codebase/mmdet/yolo_head.cpp
@@ -188,10 +188,6 @@ Result<Detections> YOLOHead::GetBBoxes(const Value& prep_res,
   return objs;
 }
 
-Result<Value> YOLOV3Head::operator()(const Value& prep_res, const Value& infer_res) {
-  return YOLOHead::operator()(prep_res, infer_res);
-}
-
 std::array<float, 4> YOLOV3Head::yolo_decode(float box_x, float box_y, float box_w, float box_h,
                                              float stride,
                                              const std::vector<std::vector<float>>& anchor, int j,
@@ -201,10 +197,6 @@ std::array<float, 4> YOLOV3Head::yolo_decode(float box_x, float box_y, float box
   box_w = expf(box_w) * anchor[a][0];
   box_h = expf(box_h) * anchor[a][1];
   return std::array<float, 4>{box_x, box_y, box_w, box_h};
-}
-
-Result<Value> YOLOV5Head::operator()(const Value& prep_res, const Value& infer_res) {
-  return YOLOHead::operator()(prep_res, infer_res);
 }
 
 std::array<float, 4> YOLOV5Head::yolo_decode(float box_x, float box_y, float box_w, float box_h,

--- a/csrc/mmdeploy/codebase/mmdet/yolo_head.h
+++ b/csrc/mmdeploy/codebase/mmdet/yolo_head.h
@@ -33,7 +33,6 @@ class YOLOHead : public MMDetection {
 class YOLOV3Head : public YOLOHead {
  public:
   using YOLOHead::YOLOHead;
-  Result<Value> operator()(const Value& prep_res, const Value& infer_res);
   std::array<float, 4> yolo_decode(float box_x, float box_y, float box_w, float box_h, float stride,
                                    const std::vector<std::vector<float>>& anchor, int j, int i,
                                    int a) const override;
@@ -42,7 +41,6 @@ class YOLOV3Head : public YOLOHead {
 class YOLOV5Head : public YOLOHead {
  public:
   using YOLOHead::YOLOHead;
-  Result<Value> operator()(const Value& prep_res, const Value& infer_res);
   std::array<float, 4> yolo_decode(float box_x, float box_y, float box_w, float box_h, float stride,
                                    const std::vector<std::vector<float>>& anchor, int j, int i,
                                    int a) const override;

--- a/csrc/mmdeploy/experimental/module_adapter.h
+++ b/csrc/mmdeploy/experimental/module_adapter.h
@@ -63,12 +63,12 @@ Result<Value> Invoke(Ret (*f)(Args...), const Value& args) {
 }
 
 // member function pointer
-template <typename Ret, typename C, typename... Args>
-Result<Value> Invoke(Ret (C::*f)(Args...) const, C* inst, const Value& args) {
+template <typename Ret, typename C0, typename C1, typename... Args>
+Result<Value> Invoke(Ret (C0::*f)(Args...) const, C1* inst, const Value& args) {
   return InvokeImpl<Ret, Args...>::apply(f, args, inst);
 }
-template <typename Ret, typename C, typename... Args>
-Result<Value> Invoke(Ret (C::*f)(Args...), C* inst, const Value& args) {
+template <typename Ret, typename C0, typename C1, typename... Args>
+Result<Value> Invoke(Ret (C0::*f)(Args...), C1* inst, const Value& args) {
   return InvokeImpl<Ret, Args...>::apply(f, args, inst);
 }
 


### PR DESCRIPTION
Relax module adpater template constraints so that derived class does not have to forward `operator()` to base class.