### PR TITLE
[Fix] fix cls head in SDK

### DIFF
--- a/csrc/mmdeploy/codebase/mmcls/linear_cls.cpp
+++ b/csrc/mmdeploy/codebase/mmcls/linear_cls.cpp
@@ -37,7 +37,6 @@ class LinearClsHead : public MMClassification {
     }
 
     auto class_num = (int)output.shape(1);
-    topk_ = topk_ < class_num ? topk_ : class_num;
 
     OUTCOME_TRY(auto _scores, MakeAvailableOnDevice(output, kHost, stream()));
     OUTCOME_TRY(stream().Wait());
@@ -48,13 +47,14 @@ class LinearClsHead : public MMClassification {
  private:
   Value GetLabels(const Tensor& scores, int class_num) const {
     auto scores_data = scores.data<float>();
+    auto topk = std::min(topk_, class_num);
     Labels output;
-    output.reserve(topk_);
+    output.reserve(topk);
     std::vector<int> idx(class_num);
     iota(begin(idx), end(idx), 0);
-    partial_sort(begin(idx), begin(idx) + topk_, end(idx),
+    partial_sort(begin(idx), begin(idx) + topk, end(idx),
                  [&](int i, int j) { return scores_data[i] > scores_data[j]; });
-    for (int i = 0; i < topk_; ++i) {
+    for (int i = 0; i < topk; ++i) {
       auto label = Label{idx[i], scores_data[idx[i]]};
       MMDEPLOY_DEBUG("label_id: {}, score: {}", label.label_id, label.score);
       output.push_back(label);

--- a/csrc/mmdeploy/codebase/mmcls/linear_cls.cpp
+++ b/csrc/mmdeploy/codebase/mmcls/linear_cls.cpp
@@ -37,6 +37,7 @@ class LinearClsHead : public MMClassification {
     }
 
     auto class_num = (int)output.shape(1);
+    topk_ = topk_ < class_num ? topk_ : class_num;
 
     OUTCOME_TRY(auto _scores, MakeAvailableOnDevice(output, kHost, stream()));
     OUTCOME_TRY(stream().Wait());


### PR DESCRIPTION
when `topk` is greater than `class_num`. Appeared in customized datasets.