### PR TITLE
[Fix] fix ncnn torch 1.12 master

### DIFF
--- a/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.cpp
+++ b/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.cpp
@@ -1,6 +1,31 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 #include "fuse_pass.h"
 
+void fuse_identity(onnx::GraphProto* mutable_graph,
+                   std::map<std::string, onnx::TensorProto>& weights,
+                   std::map<std::string, int>& node_reference, std::set<std::string>& blob_names,
+                   int& reduced_node_count) {
+  const int node_count = mutable_graph->node_size();
+  for (int i = 0; i < node_count; ++i) {
+    onnx::NodeProto* node = mutable_graph->mutable_node(i);
+    for (int j = 0; j < node->input_size(); ++j) {
+      std::string output_name = node->input(j);
+      onnx::NodeProto* last_node = find_node_by_output_name(mutable_graph, output_name);
+      fprintf(stderr, "i %d j %d line 14!\n", i, j);
+      if (last_node && last_node->op_type() == "Identity") {
+        node->set_input(j, last_node->input(0));
+        node_reference[last_node->output(0)] -= 1;
+        node_reference[last_node->input(0)] += 1;
+        if (node_reference[last_node->output(0)] == 0) {
+          last_node->set_op_type("noop_reducedncnn");
+          node_reference[last_node->input(0)] -= 1;
+          reduced_node_count += 1;
+        }
+      }
+    }
+  }
+}
+
 void fuse_rewrite_gather(onnx::GraphProto* mutable_graph,
                          std::map<std::string, onnx::TensorProto>& weights,
                          std::map<std::string, int>& node_reference,

--- a/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.cpp
+++ b/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.cpp
@@ -5,6 +5,10 @@ void fuse_identity(onnx::GraphProto* mutable_graph,
                    std::map<std::string, onnx::TensorProto>& weights,
                    std::map<std::string, int>& node_reference, std::set<std::string>& blob_names,
                    int& reduced_node_count) {
+  // fuse
+  // identity -->  op
+  // to
+  // noop_reducencnn --> op
   const int node_count = mutable_graph->node_size();
   for (int i = 0; i < node_count; ++i) {
     onnx::NodeProto* node = mutable_graph->mutable_node(i);

--- a/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.cpp
+++ b/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.cpp
@@ -11,7 +11,6 @@ void fuse_identity(onnx::GraphProto* mutable_graph,
     for (int j = 0; j < node->input_size(); ++j) {
       std::string output_name = node->input(j);
       onnx::NodeProto* last_node = find_node_by_output_name(mutable_graph, output_name);
-      fprintf(stderr, "i %d j %d line 14!\n", i, j);
       if (last_node && last_node->op_type() == "Identity") {
         node->set_input(j, last_node->input(0));
         node_reference[last_node->output(0)] -= 1;

--- a/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.h
+++ b/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/fuse_pass.h
@@ -4,6 +4,11 @@
 #include "shape_inference.h"
 #include "utils.h"
 
+void fuse_identity(onnx::GraphProto* mutable_graph,
+                   std::map<std::string, onnx::TensorProto>& weights,
+                   std::map<std::string, int>& node_reference, std::set<std::string>& blob_names,
+                   int& reduced_node_count);
+
 void fuse_rewrite_gather(onnx::GraphProto* mutable_graph,
                          std::map<std::string, onnx::TensorProto>& weights,
                          std::map<std::string, int>& node_reference,

--- a/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/onnx2ncnn.cpp
+++ b/csrc/mmdeploy/backend_ops/ncnn/onnx2ncnn/onnx2ncnn.cpp
@@ -206,6 +206,7 @@ int main(int argc, char** argv) {
   // op chain fusion
   int reduced_node_count = 0;
   {
+    fuse_identity(mutable_graph, weights, node_reference, blob_names, reduced_node_count);
     fuse_conv_reshape(mutable_graph, weights, node_reference, blob_names, reduced_node_count);
     fuse_weight_reshape(mutable_graph, weights, node_reference, blob_names, reduced_node_count);
     fuse_weight_transpose(mutable_graph, weights, node_reference, blob_names, reduced_node_count);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In torch 1.12, some constant initializer which uses in multiple places will generate `Identity` ops in onnx, which will failed in ncnn.
So we fix the fuse pass in the onnx2ncnn to remove these `Identity` nodes.

## Modification

Fuse_pass.cpp and onnx2ncnn.cpp

## BC-breaking (Optional)

None.

## Use cases (Optional)

In torch1.12 ncnn deployment which failed before. A typical example are models which have some `Resize` ops which reuse `scale` initializers.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
