### PR TITLE
[WIP] Support deploy MMRazor quantized model 

### DIFF
--- a/configs/mmcls/classification_openvino_dynamic-224x224-quantize.py
+++ b/configs/mmcls/classification_openvino_dynamic-224x224-quantize.py
@@ -1,0 +1,32 @@
+_base_ = ['./classification_dynamic.py', '../_base_/backends/openvino.py']
+
+onnx_config = dict(input_shape=None)
+
+backend_config = dict(
+    model_inputs=[dict(opt_shapes=dict(input=[1, 3, 224, 224]))])
+
+# TODO save in mmrazor's checkpoint
+quantizer = dict(
+    type='mmrazor.TensorRTQuantizer',
+    is_qat=True,
+    skipped_methods=[
+        'mmcls.models.heads.ClsHead._get_loss',
+        'mmcls.models.heads.ClsHead._get_predictions'
+    ],
+    prepare_custom_config_dict=None,
+    convert_custom_config_dict=None,
+    qconfig=dict(
+        qtype='affine',
+        w_observer=dict(type='mmrazor.MinMaxObserver'),
+        a_observer=dict(type='mmrazor.EMAMinMaxObserver'),
+        w_fake_quant=dict(type='mmrazor.FakeQuantize'),
+        a_fake_quant=dict(type='mmrazor.FakeQuantize'),
+        w_qscheme=dict(
+            bit=8,
+            is_symmetry=True,
+            is_per_channel=True,
+            is_pot_scale=False,
+        ),
+        a_qscheme=dict(
+            bit=8, is_symmetry=False, is_per_channel=False,
+            is_pot_scale=False)))

--- a/configs/mmdet/detection/detection_openvino_dynamic-800x1344-quantize.py
+++ b/configs/mmdet/detection/detection_openvino_dynamic-800x1344-quantize.py
@@ -1,0 +1,27 @@
+_base_ = ['../_base_/base_openvino_dynamic-800x1344.py']
+
+# TODO save in mmrazor's checkpoint
+quantizer = dict(
+    type='mmrazor.OpenvinoQuantizer',
+    is_qat=False,
+    skipped_methods=[
+        'mmdet.models.dense_heads.base_dense_head'
+        '.BaseDenseHead.predict_by_feat',
+    ],
+    prepare_custom_config_dict=None,
+    convert_custom_config_dict=None,
+    qconfig=dict(
+        qtype='affine',
+        w_observer=dict(type='mmrazor.MSEObserver'),
+        a_observer=dict(type='mmrazor.EMAMSEObserver'),
+        w_fake_quant=dict(type='mmrazor.FakeQuantize'),
+        a_fake_quant=dict(type='mmrazor.FakeQuantize'),
+        w_qscheme=dict(
+            bit=8,
+            is_symmetry=True,
+            is_per_channel=True,
+            is_pot_scale=False,
+        ),
+        a_qscheme=dict(
+            bit=8, is_symmetry=False, is_per_channel=False,
+            is_pot_scale=False)))

--- a/mmdeploy/apis/onnx/optimizer.py
+++ b/mmdeploy/apis/onnx/optimizer.py
@@ -1,12 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Callable
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
+
+# import torch
+# torch.onnx.utils._model_to_graph
 
 
 @FUNCTION_REWRITER.register_rewriter('torch.onnx.utils._model_to_graph')
-def model_to_graph__custom_optimizer(ctx, *args, **kwargs):
+def model_to_graph__custom_optimizer(*args, **kwargs):
     """Rewriter of _model_to_graph, add custom passes."""
+    ctx = FunctionContextContextCaller.get_instance(
+        'torch.onnx.utils._model_to_graph')
+
     graph, params_dict, torch_out = ctx.origin_func(*args, **kwargs)
 
     custom_passes = getattr(ctx, 'onnx_custom_passes', None)

--- a/mmdeploy/codebase/mmcls/models/classifiers/base.py
+++ b/mmdeploy/codebase/mmcls/models/classifiers/base.py
@@ -12,7 +12,6 @@ from mmdeploy.core import FUNCTION_REWRITER
 @FUNCTION_REWRITER.register_rewriter(
     'mmcls.models.classifiers.BaseClassifier.forward', backend='default')
 def base_classifier__forward(
-        ctx,
         self,
         batch_inputs: Tensor,
         data_samples: Optional[List[BaseDataElement]] = None,

--- a/mmdeploy/codebase/mmcls/models/necks/gap.py
+++ b/mmdeploy/codebase/mmcls/models/necks/gap.py
@@ -9,7 +9,7 @@ from mmdeploy.utils import Backend
 @FUNCTION_REWRITER.register_rewriter(
     'mmcls.models.necks.GlobalAveragePooling.forward',
     backend=Backend.DEFAULT.value)
-def gap__forward(ctx, self, inputs):
+def gap__forward(self, inputs):
     """Rewrite `forward` of GlobalAveragePooling for default backend.
 
     Replace `view` with `flatten` to export simple onnx graph.

--- a/mmdeploy/codebase/mmdet/models/dense_heads/base_dense_head.py
+++ b/mmdeploy/codebase/mmdet/models/dense_heads/base_dense_head.py
@@ -15,7 +15,7 @@ from mmdeploy.codebase.mmdet.deploy import (gather_topk,
                                             pad_with_value_if_necessary)
 from mmdeploy.codebase.mmdet.models.layers import multiclass_nms
 from mmdeploy.codebase.mmdet.ops import ncnn_detection_output_forward
-from mmdeploy.core import FUNCTION_REWRITER, mark
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller, mark
 from mmdeploy.utils import Backend, is_dynamic_shape
 
 
@@ -23,7 +23,6 @@ from mmdeploy.utils import Backend, is_dynamic_shape
     func_name='mmdet.models.dense_heads.base_dense_head.'
     'BaseDenseHead.predict_by_feat')
 def base_dense_head__predict_by_feat(
-        ctx,
         self,
         cls_scores: List[Tensor],
         bbox_preds: List[Tensor],
@@ -65,10 +64,13 @@ def base_dense_head__predict_by_feat(
             tuple[Tensor, Tensor, Tensor]: batch_mlvl_bboxes,
                 batch_mlvl_scores, batch_mlvl_centerness
     """
+
+    ctx = FunctionContextContextCaller.get_instance(
+        'mmdet.models.dense_heads.base_dense_head.'
+        'BaseDenseHead.predict_by_feat')
     deploy_cfg = ctx.cfg
     is_dynamic_flag = is_dynamic_shape(deploy_cfg)
     num_levels = len(cls_scores)
-
     featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]
     mlvl_priors = self.prior_generator.grid_priors(
         featmap_sizes, dtype=bbox_preds[0].dtype, device=bbox_preds[0].device)
@@ -97,7 +99,6 @@ def base_dense_head__predict_by_feat(
     mlvl_valid_bboxes = []
     mlvl_valid_scores = []
     mlvl_valid_priors = []
-
     for cls_score, bbox_pred, score_factors, priors in zip(
             mlvl_cls_scores, mlvl_bbox_preds, mlvl_score_factor, mlvl_priors):
         assert cls_score.size()[-2:] == bbox_pred.size()[-2:]
@@ -173,7 +174,6 @@ def base_dense_head__predict_by_feat(
 
     if not with_nms:
         return batch_bboxes, batch_scores
-
     post_params = get_post_processing_params(deploy_cfg)
     max_output_boxes_per_class = post_params.max_output_boxes_per_class
     iou_threshold = cfg.nms.get('iou_threshold', post_params.iou_threshold)
@@ -195,7 +195,6 @@ def base_dense_head__predict_by_feat(
     'BaseDenseHead.predict_by_feat',
     backend=Backend.RKNN.value)
 def base_dense_head__predict_by_feat__rknn(
-        ctx,
         self,
         cls_scores: List[Tensor],
         bbox_preds: List[Tensor],
@@ -237,6 +236,10 @@ def base_dense_head__predict_by_feat__rknn(
             tuple[Tensor, Tensor, Tensor]: batch_mlvl_bboxes,
                 batch_mlvl_scores, batch_mlvl_centerness
     """
+    ctx = FunctionContextContextCaller.get_instance(
+        'mmdet.models.dense_heads.base_dense_head.'
+        'BaseDenseHead.predict_by_feat')
+
     # mark nodes for partition
     @mark('BaseDenseHead', outputs=['BaseDenseHead.cls', 'BaseDenseHead.loc'])
     def __mark_dense_head(cls_scores, bbox_preds):
@@ -321,7 +324,6 @@ def base_dense_head__predict_by_feat__rknn(
     'BaseDenseHead.predict_by_feat',
     backend=Backend.NCNN.value)
 def base_dense_head__predict_by_feat__ncnn(
-        ctx,
         self,
         cls_scores: List[Tensor],
         bbox_preds: List[Tensor],
@@ -360,6 +362,9 @@ def base_dense_head__predict_by_feat__ncnn(
     Returns:
         output__ncnn (Tensor): outputs, shape is [N, num_det, 6].
     """
+    ctx = FunctionContextContextCaller.get_instance(
+        'mmdet.models.dense_heads.base_dense_head.'
+        'BaseDenseHead.predict_by_feat')
     assert len(cls_scores) == len(bbox_preds)
     deploy_cfg = ctx.cfg
     assert not is_dynamic_shape(deploy_cfg), 'base_dense_head for ncnn\

--- a/mmdeploy/codebase/mmdet/models/dense_heads/yolo_head.py
+++ b/mmdeploy/codebase/mmdet/models/dense_heads/yolo_head.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 import numpy as np
 import torch
-from mmdet.utils.typing import OptConfigType
+from mmdet.utils import OptConfigType
 from torch import Tensor
 
 from mmdeploy.codebase.mmdet.deploy import (get_post_processing_params,

--- a/mmdeploy/codebase/mmdet/models/task_modules/coders/delta_xywh_bbox_coder.py
+++ b/mmdeploy/codebase/mmdet/models/task_modules/coders/delta_xywh_bbox_coder.py
@@ -9,8 +9,7 @@ from mmdeploy.core import FUNCTION_REWRITER
     func_name='mmdet.models.task_modules.coders.delta_xywh_bbox_coder.'
     'DeltaXYWHBBoxCoder.decode',
     backend='default')
-def deltaxywhbboxcoder__decode(ctx,
-                               self,
+def deltaxywhbboxcoder__decode(self,
                                bboxes,
                                pred_bboxes,
                                max_shape=None,
@@ -51,8 +50,7 @@ def deltaxywhbboxcoder__decode(ctx,
     func_name='mmdet.models.task_modules.coders'
     '.delta_xywh_bbox_coder.delta2bbox',
     backend='default')
-def delta2bbox(ctx,
-               rois,
+def delta2bbox(rois,
                deltas,
                means=(0., 0., 0., 0.),
                stds=(1., 1., 1., 1.),
@@ -143,8 +141,7 @@ def delta2bbox(ctx,
     func_name='mmdet.models.task_modules.coders.'
     'delta_xywh_bbox_coder.delta2bbox',
     backend='ncnn')
-def delta2bbox__ncnn(ctx,
-                     rois,
+def delta2bbox__ncnn(rois,
                      deltas,
                      means=(0., 0., 0., 0.),
                      stds=(1., 1., 1., 1.),

--- a/mmdeploy/codebase/mmdet/models/task_modules/coders/distance_point_bbox_coder.py
+++ b/mmdeploy/codebase/mmdet/models/task_modules/coders/distance_point_bbox_coder.py
@@ -8,11 +8,7 @@ from mmdeploy.core import FUNCTION_REWRITER
     func_name='mmdet.models.task_modules.coders.distance_point_bbox_coder'
     '.DistancePointBBoxCoder.decode',
     backend='default')
-def distancepointbboxcoder__decode(ctx,
-                                   self,
-                                   points,
-                                   pred_bboxes,
-                                   max_shape=None):
+def distancepointbboxcoder__decode(self, points, pred_bboxes, max_shape=None):
     """Rewrite `mmdet.models.task_modules.coders.distance_point_bbox_coder. \
     DistancePointBBoxCoder.decode`
 

--- a/mmdeploy/codebase/mmdet/models/task_modules/coders/tblr_bbox_coder.py
+++ b/mmdeploy/codebase/mmdet/models/task_modules/coders/tblr_bbox_coder.py
@@ -7,8 +7,7 @@ from mmdeploy.core import FUNCTION_REWRITER
 @FUNCTION_REWRITER.register_rewriter(
     func_name='mmdet.models.task_modules.coders.tblr_bbox_coder.tblr2bboxes',
     backend='default')
-def tblr2bboxes(ctx,
-                priors,
+def tblr2bboxes(priors,
                 tblr,
                 normalizer=4.0,
                 normalize_by_wh=True,

--- a/mmdeploy/codebase/mmdet/models/task_modules/prior_generators/anchor.py
+++ b/mmdeploy/codebase/mmdet/models/task_modules/prior_generators/anchor.py
@@ -4,7 +4,7 @@ from typing import Tuple
 import torch
 from torch.onnx import symbolic_helper
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 
 
 class GridPriorsTRTOp(torch.autograd.Function):
@@ -70,7 +70,6 @@ grid_priors_trt = GridPriorsTRTOp.apply
     'AnchorGenerator.single_level_grid_priors',
     backend='tensorrt')
 def anchorgenerator__single_level_grid_priors__trt(
-        ctx,
         self,
         featmap_size: Tuple[int],
         level_idx: int,
@@ -91,6 +90,10 @@ def anchorgenerator__single_level_grid_priors__trt(
         Returns:
             torch.Tensor: Anchors in the overall feature maps.
     """
+    ctx = FunctionContextContextCaller.get_instance(
+        'mmdet.models.task_modules.prior_generators.'
+        'AnchorGenerator.single_level_grid_priors')
+
     feat_h, feat_w = featmap_size
     if isinstance(feat_h, int) and isinstance(feat_w, int):
         return ctx.origin_func(self, featmap_size, level_idx, dtype,

--- a/mmdeploy/codebase/mmdet/models/task_modules/prior_generators/point_generator.py
+++ b/mmdeploy/codebase/mmdet/models/task_modules/prior_generators/point_generator.py
@@ -10,7 +10,6 @@ from mmdeploy.utils.constants import Backend
     '.single_level_grid_priors',
     backend=Backend.TENSORRT.value)
 def mlvl_point_generator__single_level_grid_priors__tensorrt(
-        ctx,
         self,
         featmap_size,
         level_idx,

--- a/mmdeploy/codebase/mmdet/structures/bbox/transforms.py
+++ b/mmdeploy/codebase/mmdet/structures/bbox/transforms.py
@@ -8,7 +8,7 @@ from mmdeploy.core import FUNCTION_REWRITER
 @FUNCTION_REWRITER.register_rewriter(
     func_name='mmdet.structures.bbox.transforms.distance2bbox'  # noqa
 )
-def distance2bbox__default(ctx, points, distance, max_shape=None):
+def distance2bbox__default(points, distance, max_shape=None):
     """Rewrite `mmdet.core.bbox.transforms.distance2bbox`
 
     Decode distance prediction to bounding box.

--- a/mmdeploy/codebase/mmdet3d/models/base.py
+++ b/mmdeploy/codebase/mmdet3d/models/base.py
@@ -9,8 +9,7 @@ from mmdeploy.core import FUNCTION_REWRITER
 @FUNCTION_REWRITER.register_rewriter(
     'mmdet3d.models.detectors.Base3DDetector.forward'  # noqa: E501
 )
-def basedetector__forward(ctx,
-                          self,
+def basedetector__forward(self,
                           inputs: list,
                           data_samples=None,
                           **kwargs) -> Tuple[List[torch.Tensor]]:

--- a/mmdeploy/core/__init__.py
+++ b/mmdeploy/core/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from .exporters import *  # noqa: F401,F403
 from .optimizers import *  # noqa: F401,F403
 from .rewriters import *  # noqa: F401,F403

--- a/mmdeploy/core/exporters/__init__.py
+++ b/mmdeploy/core/exporters/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .openvino_quantize_exporter import OpenVinoQuantizeExportor
+from .tensorrt_quantize_exporter import TensorRTQuantizeExporter
+
+__all__ = ['OpenVinoQuantizeExportor', 'TensorRTQuantizeExporter']

--- a/mmdeploy/core/exporters/base_quantize_exporter.py
+++ b/mmdeploy/core/exporters/base_quantize_exporter.py
@@ -1,0 +1,310 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import onnx
+from mmengine import print_log
+from onnx import numpy_helper
+
+from ..optimizers import ONNXOptimUtils
+
+SUPPORT_QWEIGHT_NODE = ['Gemm', 'Conv', 'ConvTranspose']
+
+PERCHANNEL_FAKEQUANTIZER = [
+    'FakeQuantizeLearnablePerchannelAffine', 'FixedPerChannelAffine',
+    'FakeQuantizeDSQPerchannel'
+]
+PERTENSOR_FAKEQUANTIZER = [
+    'LearnablePerTensorAffine', 'FixedPerTensorAffine',
+    'FakeQuantizeDSQPertensor', 'FakeQuantizeTqtAffine'
+]
+
+ALL_FAKEQUANTIZER = PERCHANNEL_FAKEQUANTIZER + PERTENSOR_FAKEQUANTIZER
+
+
+def _parse_attrs(node_attrs):
+    attrs = {}
+    for attr in node_attrs:
+        if attr.type == onnx.AttributeProto.AttributeType.INTS:
+            attrs[attr.name] = tuple(attr.ints)
+        elif attr.type == onnx.AttributeProto.AttributeType.INT:
+            attrs[attr.name] = attr.i
+        elif attr.type == onnx.AttributeProto.AttributeType.FLOATS:
+            attrs[attr.name] = tuple(attr.floats)
+        elif attr.type == onnx.AttributeProto.AttributeType.FLOAT:
+            attrs[attr.name] = attr.f
+        elif attr.type == onnx.AttributeProto.AttributeType.TENSOR:
+            attrs[attr.name] = numpy_helper.to_array(attr.t)
+        elif attr.type == onnx.AttributeProto.AttributeType.STRING:
+            attrs[attr.name] = str(attr.s)
+        elif attr.type == onnx.AttributeProto.AttributeType.STRINGS:
+            attrs[attr.name] = tuple([str(x) for x in attr.strings])
+        else:
+            raise Exception('ATTR Type [{}] Not Supported!'.format(attr.type))
+    return attrs
+
+
+class BaseQuantizeExportor():
+
+    optimizer = ONNXOptimUtils
+
+    def __init__(self, onnx_model, export_path) -> None:
+
+        if isinstance(onnx_model, str):
+            self.onnx_model = onnx.load(onnx_model)
+        elif isinstance(onnx_model, onnx.GraphProto):
+            self.onnx_model = onnx_model
+        else:
+            raise TypeError
+
+        self.export_path = export_path
+        self._init_mappings_from_onnx(self.onnx_model)
+
+        self.optimizer.remove_fake_pad_op(self.onnx_model, self.name2data,
+                                          self.input2node, self.output2node)
+
+        self._remap_input_and_node()
+        self._remap_output_and_node()
+
+    @property
+    def graph(self):
+        return self.onnx_model.graph
+
+    def _init_mappings_from_onnx(self, onnx_model):
+
+        self.input2node = self.optimizer.map_input_and_node(onnx_model)
+        self.output2node = self.optimizer.map_output_and_node(onnx_model)
+        self.name2data = self.optimizer.map_name_and_data(onnx_model)
+        self.name2init = self.optimizer.map_name_and_initializer(onnx_model)
+
+    def _remap_input_and_node(self):
+        self.input2node = self.optimizer.map_input_and_node(self.onnx_model)
+
+    def _remap_output_and_node(self):
+        self.output2node = self.optimizer.map_output_and_node(self.onnx_model)
+
+    def parse_qparams(self, node):
+        tensor_name, scale, zero_point = node.input[:3]
+
+        scale, zero_point = self.name2data[scale], self.name2data[zero_point]
+        if len(node.input) > 3:
+            qmin, qmax = node.input[-2:]
+            qmin, qmax = self.name2data[qmin], self.name2data[qmax]
+        elif len(node.attribute) > 0:
+            qparams = _parse_attrs(node.attribute)
+            qmin = qparams['quant_min']
+            qmax = qparams['quant_max']
+        else:
+            print_log(f'qmin and qmax are not found for <{node.name}>!')
+            qmax = qmin = None
+        return tensor_name, scale, zero_point, qmin, qmax
+
+    def collect_symbolic_nodes(self, onnx_model):
+        symbolic_nodes = list()
+        for node in onnx_model.graph.node:
+            if node.op_type in ALL_FAKEQUANTIZER:
+                symbolic_nodes.append(node)
+        return symbolic_nodes
+
+    def _get_constant_inputs(self, node):
+        constant_nodes = list()
+        output2node = self.output2node
+        for inp in node.input:
+            if inp in output2node and output2node[inp].op_type == 'Constant':
+                cnode = output2node[inp]
+
+                constant_nodes.append(cnode)
+        return constant_nodes
+
+    def _collect_symbolic_constant_inputs(self, symbolic_nodes):
+
+        collected_constant_names = set()
+        constant_inputs = list()
+        for node in symbolic_nodes:
+            constant_inputs = self._get_constant_inputs(node)
+            for constant in constant_inputs:
+                if constant.name in collected_constant_names:
+                    continue
+                constant_inputs.append(constant)
+                collected_constant_names.add(constant.name)
+        return constant_inputs
+
+    def _remove_symbolic_related_from_onnx(self, symbolic_nodes,
+                                           symbolic_constant_inputs):
+        for node in symbolic_nodes:
+            self.onnx_model.graph.node.remove(node)
+
+        for constant in symbolic_constant_inputs:
+            remove = True
+            for node in self.onnx_model.graph.node:
+                for input_name in node.input:
+                    if input_name == constant.output[0]:
+                        remove = False
+                        break
+            if remove:
+                self.onnx_model.graph.node.remove(constant)
+
+    def export(self, onnx_path):
+        pass
+
+
+class QTableQuantizeExportor(BaseQuantizeExportor):
+
+    def __init__(self, onnx_model, export_path) -> None:
+        super().__init__(onnx_model, export_path)
+
+        self._qtables = dict()
+
+    @property
+    def qtables(self):
+        return self._qtables
+
+    def register_qtables(self, value, key):
+        assert value not in self._qtables
+        self._qtables[value] = key
+
+    def post_process_qtables(self):
+
+        def find_the_closest_tensor(node):
+            if node.input[0] in self.qtables:
+                return node.input[0]
+            elif (node.op_type in ['Flatten', 'Resize']
+                  and node.output[0] in self.input2node):
+
+                next_node = self.input2node[node.output[0]][0][0]
+                return find_the_closest_tensor(next_node)
+            else:
+                return None
+
+        for node in self.graph.node:
+            if node.op_type in ['Flatten', 'Resize']:
+                tensor_name = find_the_closest_tensor(node)
+                if tensor_name:
+                    self.qtables[node.input[0]] = self.qtables[tensor_name]
+                    print_log(
+                        f'Pass <{tensor_name}> clip range to <{node.name}> '
+                        f'input <{node.input[0]}>.')
+
+    def _is_fakequant_for_weight(self, node):
+
+        if node.output[0] not in self.input2node:
+
+            assert node.output[0] in [out.name for out in self.graph.output], \
+                        f'{node.name} not in graph.'
+
+            self.input2node[node.output[0]] = []
+        next_nodes = self.input2node[node.output[0]]
+
+        flag = True
+        for n in next_nodes:
+            if n[1] == 1 and n[0].op_type in SUPPORT_QWEIGHT_NODE:
+                continue
+            else:
+                flag = False
+                break
+
+        return flag
+
+    def _is_fakequant_for_bias(self, node):
+
+        if node.output[0] not in self.input2node:
+
+            assert node.output[0] in [out.name for out in self.graph.output], \
+                        f'{node.name} not in graph.'
+
+            self.input2node[node.output[0]] = []
+        next_nodes = self.input2node[node.output[0]]
+
+        flag = True
+        for n in next_nodes:
+            if n[1] == 2 and n[0].op_type in SUPPORT_QWEIGHT_NODE:
+                continue
+            else:
+                flag = False
+                break
+
+        return flag
+
+    def _is_fakequant_for_activation(self, node):
+
+        return (not self._is_fakequant_for_weight(node)
+                and not self._is_fakequant_for_bias(node))
+
+    def deal_with_weight_fakequant(self, node):
+
+        next_nodes = self.input2node[node.output[0]]
+        next_node = next_node, idx = next_nodes[0]
+        next_node.input[idx] = node.input[0]
+
+    def deal_with_activation_fakequant(self, node):
+        next_nodes = self.input2node[node.output[0]]
+        for next_node, idx in next_nodes:
+            next_node.input[idx] = node.input[0]
+
+    def deal_with_per_channel_node(self, node):
+        # fake quantize for weights
+        # suppose per-channel quantize only for weight
+        if not self.is_fakequant_for_weight(node):
+            raise RuntimeError('Only support per-channel quantize for weight')
+        self.deal_with_weight_fakequant(node)
+
+    def deal_with_per_tensor_node(self, node):
+
+        if self._is_fakequant_for_weight(node):
+            self.deal_with_per_tensor_weight(node)
+        elif self._is_fakequant_for_bias(node):
+            self.deal_with_per_tensor_bias(node)
+        elif self._is_fakequant_for_activation(node):
+            self.deal_with_per_tensor_activation(node)
+        else:
+            raise NotImplementedError
+
+    def deal_with_per_tensor_weight(self, node):
+        # fake quantize for weights
+        self.deal_with_weight_fakequant(node)
+
+    def deal_with_per_tensor_bias(self, node):
+        # fake quantize for bias
+        raise RuntimeError(f"{self.backend} don't support per-tensor quantize "
+                           f'for bias')
+
+    def deal_with_per_tensor_activation(self, node):
+
+        # fake quantize for activations
+
+        self.deal_with_activation_fakequant(node)
+        tensor_name, _, _, _, _ = self.parse_qparams(node)
+        for out in self.graph.output:
+            if out.name == node.output[0]:
+                out.name = tensor_name
+
+    def _remove_symbolic_and_collect_params(self):
+        symbolic_nodes = self.collect_symbolic_nodes(self.onnx_model)
+
+        collect_func = self._collect_symbolic_constant_inputs
+        symbolic_constant_inputs = collect_func(symbolic_nodes)
+
+        for node in symbolic_nodes:
+            if node.op_type in PERCHANNEL_FAKEQUANTIZER:
+                self.deal_with_per_channel_node(node)
+            else:
+                self.deal_with_per_tensor_node(node)
+
+        self._remove_symbolic_related_from_onnx(symbolic_nodes,
+                                                symbolic_constant_inputs)
+
+        self.optimizer.optimize(self.onnx_model)
+
+        self._remap_input_and_node()
+        self._remap_output_and_node()
+
+        self.post_process_qtables()
+
+    def export_qtables(self):
+
+        pass
+
+    def export(self):
+        self._remove_symbolic_and_collect_params()
+
+        onnx.save(self.onnx_model, self.export_path)
+
+        self.export_qtables()

--- a/mmdeploy/core/exporters/openvino_quantize_exporter.py
+++ b/mmdeploy/core/exporters/openvino_quantize_exporter.py
@@ -1,0 +1,130 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+from .base_quantize_exporter import BaseQuantizeExportor
+
+
+class OpenVinoQuantizeExportor(BaseQuantizeExportor):
+
+    def __init__(self, onnx_model, export_path) -> None:
+        super().__init__(onnx_model, export_path)
+
+    def _build_backend_node_from_symbolic(self, node, tensor_name, qmin, qmax):
+        qmax = int(qmax)
+        qmin = int(qmin)
+        levels = qmax - qmin + 1
+        # adjust weight levels
+        if levels == 128:
+            levels = 256
+            qmax = qmax * 2 + 1
+            qmin = qmin * 2
+        output_name = node.output[0]
+        # Create a node (FakeQuantize)
+        keys = ['input_min', 'input_max', 'output_min', 'output_max']
+        input_names = [f'{tensor_name}_{key}' for key in keys]
+        backend_node = helper.make_node(
+            'FakeQuantize',  # node name
+            [tensor_name, *input_names],  # inputs
+            [output_name],  # outputs
+            levels=levels,  # Attributes
+            domain='org.openvinotoolkit',
+            name=node.name)
+        return backend_node
+
+    def _build_backend_initializer(self, names, scale, zero_point, qmin, qmax,
+                                   shape):
+
+        scale = np.abs(np.asarray(scale, dtype=np.float64).reshape(-1))
+        zero_point = np.clip(
+            np.asarray(np.round(zero_point), dtype=np.int32).reshape(-1),
+            a_min=qmin,
+            a_max=qmax)
+
+        qrange = float(qmax - qmin)
+        input_range = scale * qrange
+        input_high = (qmax - zero_point).astype(
+            np.float64) * input_range / qrange
+        input_low = input_high - input_range
+        input_low_size = input_low.size
+
+        if input_low_size != 1:
+            input_low = input_low.reshape(*shape)
+            input_high = input_high.reshape(*shape)
+
+        input_low = input_low.astype(np.float32)
+        input_high = input_high.astype(np.float32)
+
+        initializers = list()
+        for init_name, value_tensor in zip(
+                names, [input_low, input_high, input_low, input_high]):
+            init = numpy_helper.from_array(value_tensor)
+            init.name = init_name
+            initializers.append(init)
+        return initializers
+
+    def build_backend_nodes_and_initializers(self, symbolic_nodes):
+        backend_nodes = list()
+        backend_initializers = list()
+        for node in symbolic_nodes:
+            tensor_name, scale, zero_point, qmin, qmax = self.parse_qparams(
+                node)
+            new_node = self._build_backend_node_from_symbolic(
+                node, tensor_name, qmin, qmax)
+            backend_nodes.append(new_node)
+
+            try:
+                next_node = self.input2node[node.output[0]][0][0]
+                # node for save weights
+                fake_node = self.output2node[next_node.input[1]]
+                tensor = self.name2data[fake_node.input[0]]
+                shape_length = len(tensor.shape)
+                new_shape = [
+                    -1,
+                ] + [
+                    1,
+                ] * (
+                    shape_length - 1)
+            except Exception:
+                new_shape = [
+                    -1,
+                ]
+
+            new_init_names = new_node.input[1:]
+            new_initializers = self._build_backend_initializer(
+                new_init_names, scale, zero_point, qmin, qmax, new_shape)
+            backend_initializers.extend(new_initializers)
+        return backend_nodes, backend_initializers
+
+    def _insert_initializers_to_onnx(self, initializers):
+        inserted_init_names = set()
+        for init in initializers:
+            if init.name in inserted_init_names:
+                continue
+
+            self.onnx_model.graph.initializer.append(init)
+            inserted_init_names.add(init.name)
+
+    def _replace_symbolic_related(self):
+
+        symbolic_nodes = self.collect_symbolic_nodes(self.onnx_model)
+
+        collect_func = self._collect_symbolic_constant_inputs
+        symbolic_constant_inputs = collect_func(symbolic_nodes)
+
+        build_func = self.build_backend_nodes_and_initializers
+        new_nodes, new_initializers = build_func(symbolic_nodes)
+
+        self._insert_initializers_to_onnx(new_initializers)
+
+        self._remove_symbolic_related_from_onnx(symbolic_nodes,
+                                                symbolic_constant_inputs)
+
+        self.onnx_model.graph.node.extend(new_nodes)
+        self.optimizer.optimize(self.onnx_model)
+
+    def export(self):
+        self._replace_symbolic_related()
+        onnx.save(self.onnx_model, self.export_path)

--- a/mmdeploy/core/exporters/tensorrt_quantize_exporter.py
+++ b/mmdeploy/core/exporters/tensorrt_quantize_exporter.py
@@ -1,0 +1,22 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from mmengine.fileio import dump
+
+from .base_quantize_exporter import QTableQuantizeExportor
+
+
+class TensorRTQuantizeExporter(QTableQuantizeExportor):
+
+    def __init__(self, onnx_model, export_path) -> None:
+        super().__init__(onnx_model, export_path)
+
+    def deal_with_per_tensor_activation(self, node):
+        super().deal_with_per_tensor_activation(node)
+
+        name, scale, _, qmin, qmax = self.parse_qparams(node)
+        self.qtables[name] = float(scale * max(-qmin, qmax))
+
+    def export_qtables(self):
+        context = {'tensorrt': {'blob_range': self.qtables}}
+        qtables_path = self.export_path.replace('.onnx', '_qtables.json')
+
+        dump(context, qtables_path, 'json')

--- a/mmdeploy/core/optimizers/__init__.py
+++ b/mmdeploy/core/optimizers/__init__.py
@@ -1,11 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .extractor import create_extractor, parse_extractor_io_string
 from .function_marker import mark, reset_mark_function_count
+from .optim_utils import ONNXOptimUtils
 from .optimize import (attribute_to_dict, get_new_name, remove_identity,
                        remove_imports, rename_value)
 
 __all__ = [
     'mark', 'reset_mark_function_count', 'create_extractor',
     'parse_extractor_io_string', 'remove_identity', 'attribute_to_dict',
-    'rename_value', 'get_new_name', 'remove_imports'
+    'rename_value', 'get_new_name', 'remove_imports', 'ONNXOptimUtils'
 ]

--- a/mmdeploy/core/optimizers/function_marker.py
+++ b/mmdeploy/core/optimizers/function_marker.py
@@ -4,7 +4,8 @@ from typing import Any, Callable, Dict, Optional, Sequence
 
 import torch
 
-from mmdeploy.core.rewriters import FUNCTION_REWRITER
+from mmdeploy.core.rewriters import (FUNCTION_REWRITER,
+                                     FunctionContextContextCaller)
 from mmdeploy.utils import IR, cfg_apply_marks, get_partition_config
 
 MARK_FUNCTION_COUNT = dict()
@@ -62,8 +63,10 @@ class Mark(torch.autograd.Function):
 
 @FUNCTION_REWRITER.register_rewriter(
     'mmdeploy.core.optimizers.function_marker.Mark.symbolic')
-def mark_symbolic(rewriter, g, x, *args):
+def mark_symbolic(g, x, *args):
     """Rewrite symbolic of mark op."""
+    rewriter = FunctionContextContextCaller.get_instance(
+        'mmdeploy.core.optimizers.function_marker.Mark.symbolic')
     if cfg_apply_marks(rewriter.cfg):
         return rewriter.origin_func(g, x, *args)
     return x
@@ -71,9 +74,11 @@ def mark_symbolic(rewriter, g, x, *args):
 
 @FUNCTION_REWRITER.register_rewriter(
     'mmdeploy.core.optimizers.function_marker.Mark.forward')
-def forward_of_mark(rewriter, ctx, x, dtype, shape, func, func_id, type, name,
-                    id, attrs) -> torch.Tensor:
+def forward_of_mark(ctx, x, dtype, shape, func, func_id, type, name, id,
+                    attrs) -> torch.Tensor:
     """Rewrite forward of mark op."""
+    rewriter = FunctionContextContextCaller.get_instance(
+        'mmdeploy.core.optimizers.function_marker.Mark.forward')
     deploy_cfg = rewriter.cfg
     # save calib data
     apply_marks = cfg_apply_marks(deploy_cfg)

--- a/mmdeploy/core/optimizers/optim_utils.py
+++ b/mmdeploy/core/optimizers/optim_utils.py
@@ -1,0 +1,194 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import copy
+
+from mmengine import print_log
+from onnx import numpy_helper
+
+
+class ONNXOptimUtils():
+
+    @classmethod
+    def map_name_and_data(cls, onnx_model):
+        params = {}
+        for init in onnx_model.graph.initializer:
+            params[init.name] = numpy_helper.to_array(init)
+        for node in onnx_model.graph.node:
+            if node.op_type == 'Constant':
+                for attr in node.attribute:
+                    if attr.name == 'value':
+                        params[node.output[0]] = numpy_helper.to_array(attr.t)
+        return params
+
+    @classmethod
+    def map_name_and_initializer(cls, onnx_model, allow_redundant=True):
+
+        initializers = dict()
+
+        for idx, init in enumerate(onnx_model.graph.initializer):
+            initializers[init.name] = (init, idx)
+
+        return initializers
+
+    @classmethod
+    def map_output_and_node(cls, onnx_model):
+        output2node = dict()
+        for node in onnx_model.graph.node:
+            for output_name in node.output:
+                output2node[output_name] = node
+        return output2node
+
+    @classmethod
+    def map_input_and_node(cls, onnx_model):
+
+        input2node = dict()
+        for node in onnx_model.graph.node:
+            for idx, input_name in enumerate(node.input):
+                if input_name not in input2node:
+                    input2node[input_name] = []
+                input2node[input_name].append([node, idx])
+        return input2node
+
+    @classmethod
+    def remove_node_from_onnx(cls, node, onnx_model):
+        onnx_model.graph.node.remove(node)
+
+    @classmethod
+    def remove_initializer_from_onnx(cls, initializer, onnx_model):
+        onnx_model.graph.initializer.remove(initializer)
+
+    @classmethod
+    def remove_fake_pad_op(cls, onnx_model, name2data, inp2node, out2node):
+        nodes_to_be_removed = []
+        for idx, node in enumerate(onnx_model.graph.node):
+            if node.op_type == 'Pad':
+                pads = name2data[node.input[1]]
+                if all([x == 0 for x in pads]):
+                    print_log(f'Remove pad op: <{node.name}>.')
+                    next_nodes = inp2node[node.output[0]]
+                    for next_node, idx in next_nodes:
+                        next_node.input[idx] = node.input[0]
+                    nodes_to_be_removed.append(node)
+
+        for node in nodes_to_be_removed:
+            onnx_model.graph.node.remove(node)
+
+    @classmethod
+    def insert_node_to_onnx(cls, node, onnx_model, idx=0):
+        onnx_model.graph.node.insert(idx, node)
+
+    @classmethod
+    def find_standalone_nodes(cls,
+                              onnx_model,
+                              input2node=None,
+                              output2node=None):
+
+        if input2node is None:
+            input2node = cls.map_input_and_node(onnx_model)
+        if output2node is None:
+            output2node = cls.map_output_and_node(onnx_model)
+
+        def _is_standalone_node(node, input2node, output2node):
+            standalone = True
+            for input_name in node.input:
+                if input_name in output2node:
+                    standalone = False
+                    break
+
+            if not standalone:
+                return False
+
+            for out_node in node.output:
+                if out_node in input2node:
+                    standalone = False
+
+            return standalone
+
+        standalone_nodes = list()
+        for node in onnx_model.graph.node:
+
+            if _is_standalone_node(node, input2node, output2node):
+                standalone_nodes.append(node)
+        return standalone_nodes
+
+    @classmethod
+    def find_redundant_initializers(cls, onnx_model, input2node=None):
+        if input2node is None:
+            input2node = cls.map_input_and_node(onnx_model)
+
+        initializers = cls.map_name_and_initializer(onnx_model)
+        redundant_initializers = list()
+        redundant_set = set()
+        for name, init_and_idx in initializers.items():
+            if name not in input2node and name not in redundant_set:
+                redundant_initializers.append(init_and_idx[0])
+                redundant_set.add(name)
+        return redundant_initializers
+
+    @classmethod
+    def topo_sort(cls, onnx_model, initializers=None, inplace=True):
+
+        def _is_zero_in_degree(node, exist_inputs, initializers):
+            flag = True
+            for input_name in node.input:
+                if (input_name not in exist_inputs
+                        and input_name not in initializers):
+                    flag = False
+                    break
+
+            return flag
+
+        if inplace:
+            _onnx_model = onnx_model
+        else:
+            _onnx_model = copy.deepcopy(onnx_model)
+
+        if initializers is None:
+            initializers = cls.map_name_and_initializer(
+                _onnx_model, allow_redundant=True)
+
+        visited_inputs = [node.name for node in _onnx_model.graph.input]
+        num_nodes = len(_onnx_model.graph.node)
+
+        sorted_nodes = list()
+
+        while len(sorted_nodes) < num_nodes:
+            find_new_node = False
+            for i in range(num_nodes):
+                node = _onnx_model.graph.node[i]
+
+                if node.name in sorted_nodes:
+                    continue
+
+                if _is_zero_in_degree(node, visited_inputs, initializers):
+
+                    find_new_node = True
+                    sorted_nodes.append(node.name)
+                    _onnx_model.graph.node.append(node)
+                    for output_name in node.output:
+                        visited_inputs.append(output_name)
+
+            assert find_new_node, 'Graph is illegel, error occurred!'
+
+        for i in range(num_nodes):
+            remove_node = _onnx_model.graph.node[0]
+            _onnx_model.graph.node.remove(remove_node)
+
+        return _onnx_model
+
+    @classmethod
+    def optimize(cls, onnx_model):
+
+        standalone_nodes = cls.find_standalone_nodes(onnx_model)
+        for node in standalone_nodes:
+            cls.remove_node_from_onnx(node, onnx_model)
+            print_log(f'Remove node {node.name}')
+
+        redundant_inits = cls.find_redundant_initializers(onnx_model)
+        for init in redundant_inits:
+            cls.remove_initializer_from_onnx(init, onnx_model)
+            print_log(f'Remove initializer {init.name}')
+
+        sorted_onnx_model = cls.topo_sort(onnx_model)
+
+        return sorted_onnx_model

--- a/mmdeploy/core/rewriters/__init__.py
+++ b/mmdeploy/core/rewriters/__init__.py
@@ -1,11 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .rewriter_manager import (FUNCTION_REWRITER, MODULE_REWRITER,
                                SYMBOLIC_REWRITER, RewriterContext, patch_model)
+from .rewriter_utils import FunctionContextContextCaller
 
 __all__ = [
-    'FUNCTION_REWRITER',
-    'RewriterContext',
-    'MODULE_REWRITER',
-    'patch_model',
-    'SYMBOLIC_REWRITER',
+    'FUNCTION_REWRITER', 'RewriterContext', 'MODULE_REWRITER', 'patch_model',
+    'SYMBOLIC_REWRITER', 'FunctionContextContextCaller'
 ]

--- a/mmdeploy/pytorch/functions/adaptive_pool.py
+++ b/mmdeploy/pytorch/functions/adaptive_pool.py
@@ -3,14 +3,17 @@
 import torch.nn.functional as F
 from torch.nn.modules.utils import _pair
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 from mmdeploy.utils import Backend, get_root_logger, is_dynamic_shape
 
 
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.nn.functional.adaptive_avg_pool2d')
-def adaptive_avg_pool2d__default(ctx, input, output_size):
+def adaptive_avg_pool2d__default(input, output_size):
     """Rewrite `adaptive_avg_pool2d` for default backend."""
+
+    ctx = FunctionContextContextCaller.get_instance(
+        'torch.nn.functional.adaptive_avg_pool2d')
     output_size = _pair(output_size)
     if int(output_size[0]) == int(output_size[1]) == 1:
         out = ctx.origin_func(input, output_size)
@@ -39,6 +42,8 @@ def adaptive_avg_pool2d__default(ctx, input, output_size):
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.nn.functional.adaptive_avg_pool2d',
     backend=Backend.TORCHSCRIPT.value)
-def adaptive_avg_pool2d__ncnn(ctx, input, output_size):
+def adaptive_avg_pool2d__ncnn(input, output_size):
     """Rewrite `adaptive_avg_pool2d` for ncnn and torchscript backend."""
+    ctx = FunctionContextContextCaller.get_instance(
+        'torch.nn.functional.adaptive_avg_pool2d')
     return ctx.origin_func(input, output_size)

--- a/mmdeploy/pytorch/functions/atan2.py
+++ b/mmdeploy/pytorch/functions/atan2.py
@@ -7,7 +7,6 @@ from mmdeploy.core import FUNCTION_REWRITER
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.atan2', backend='default')
 def atan2__default(
-    ctx,
     input1: torch.Tensor,
     input2: torch.Tensor,
 ):

--- a/mmdeploy/pytorch/functions/chunk.py
+++ b/mmdeploy/pytorch/functions/chunk.py
@@ -7,7 +7,7 @@ from mmdeploy.utils import IR
 
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.chunk', backend='ncnn')
-def chunk__ncnn(ctx, self, num_chunks: int, dim: int = 0) -> torch.Tensor:
+def chunk__ncnn(self, num_chunks: int, dim: int = 0) -> torch.Tensor:
     """Rewrite `chunk` for NCNN backend.
 
     Chunk in ncnn are not supported, so it should be rewritten.
@@ -36,10 +36,7 @@ def chunk__ncnn(ctx, self, num_chunks: int, dim: int = 0) -> torch.Tensor:
 
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.chunk', ir=IR.TORCHSCRIPT)
-def chunk__torchscript(ctx,
-                       self,
-                       num_chunks: int,
-                       dim: int = 0) -> torch.Tensor:
+def chunk__torchscript(self, num_chunks: int, dim: int = 0) -> torch.Tensor:
     """Rewrite `chunk` for Torchscript.
 
     Replace chunk op with split op

--- a/mmdeploy/pytorch/functions/expand.py
+++ b/mmdeploy/pytorch/functions/expand.py
@@ -1,16 +1,17 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 
 
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.expand', backend='ncnn')
-def expand__ncnn(ctx, self, *sizes) -> torch.Tensor:
+def expand__ncnn(self, *sizes) -> torch.Tensor:
     """Rewrite `expand` for NCNN backend.
 
     Do not expand on batch dim for tensor with ndim >= 3
     """
+    ctx = FunctionContextContextCaller.get_instance('torch.Tensor.expand')
     if self.ndim < 3 or sizes[0] not in [1, -1]:
         return ctx.origin_func(*sizes)
     return self

--- a/mmdeploy/pytorch/functions/group_norm.py
+++ b/mmdeploy/pytorch/functions/group_norm.py
@@ -9,7 +9,6 @@ from mmdeploy.core import FUNCTION_REWRITER
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.nn.functional.group_norm', backend='ncnn')
 def group_norm__ncnn(
-    ctx,
     input: torch.Tensor,
     num_groups: int,
     weight: Union[torch.Tensor, torch.NoneType] = None,

--- a/mmdeploy/pytorch/functions/linear.py
+++ b/mmdeploy/pytorch/functions/linear.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 
 import torch
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 
 
 class GemmOp(torch.autograd.Function):
@@ -30,7 +30,6 @@ class GemmOp(torch.autograd.Function):
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.nn.functional.linear', backend='ncnn')
 def linear__ncnn(
-    ctx,
     input: torch.Tensor,
     weight: torch.Tensor,
     bias: Optional[Union[torch.Tensor, torch.NoneType]] = None,
@@ -41,6 +40,10 @@ def linear__ncnn(
     add extra reshape and transpose to support linear operation of different
     input shape.
     """
+
+    ctx = FunctionContextContextCaller.get_instance(
+        'torch.nn.functional.linear')
+
     origin_func = ctx.origin_func
     dim = input.dim()
 

--- a/mmdeploy/pytorch/functions/mod.py
+++ b/mmdeploy/pytorch/functions/mod.py
@@ -4,17 +4,20 @@ from typing import Union
 import torch
 from packaging import version
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 from mmdeploy.utils.constants import Backend
 
 
 # TODO add version control when MOD is supported by TensorRT
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.__mod__', backend=Backend.TENSORRT.value)
-def mod__tensorrt(ctx, input: torch.Tensor, other: Union[torch.Tensor,
-                                                         torch.NumberType],
-                  *args, **kwargs) -> torch.Tensor:
+def mod__tensorrt(input: torch.Tensor, other: Union[torch.Tensor,
+                                                    torch.NumberType], *args,
+                  **kwargs) -> torch.Tensor:
     """Rewrite `mod` when exporting model to ONNX for TensorRT backend."""
+
+    ctx = FunctionContextContextCaller.get_instance('torch.Tensor.__mod__')
+
     if version.parse(torch.__version__) > version.parse('1.10.0'):
         return input - (input // other) * other
     return ctx.origin_func(input, other, *args, **kwargs)

--- a/mmdeploy/pytorch/functions/multi_head_attention_forward.py
+++ b/mmdeploy/pytorch/functions/multi_head_attention_forward.py
@@ -46,7 +46,6 @@ class ScaledDotProductAttentionTRT(torch.autograd.Function):
     func_name='torch.nn.functional._scaled_dot_product_attention',
     backend=Backend.TENSORRT.value)
 def _scaled_dot_product_attention__tensorrt(
-    ctx,
     q: Tensor,
     k: Tensor,
     v: Tensor,

--- a/mmdeploy/pytorch/functions/pad.py
+++ b/mmdeploy/pytorch/functions/pad.py
@@ -3,7 +3,7 @@ import torch
 import torch.onnx.symbolic_helper as sym_help
 from packaging.version import parse as version_parse
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 
 
 # modified from
@@ -11,7 +11,7 @@ from mmdeploy.core import FUNCTION_REWRITER
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.onnx.symbolic_opset11._prepare_onnx_paddings',
     backend='tensorrt')
-def _prepare_onnx_paddings__tensorrt(ctx, g, input, pad):
+def _prepare_onnx_paddings__tensorrt(g, input, pad):
     """Rewrite `_prepare_onnx_paddings` for TensorRT backend.
 
     For codes like `x = torch.nn.ZeroPad2d((0, a, 0, b))(x)`, where a and b are
@@ -26,6 +26,9 @@ def _prepare_onnx_paddings__tensorrt(ctx, g, input, pad):
             ..., dim_m_begin, dim_m_end,
             where m is in range [0, n].
     """
+    ctx = FunctionContextContextCaller.get_instance(
+        'torch.onnx.symbolic_opset11._prepare_onnx_paddings')
+
     torch_version = version_parse(torch.__version__)
     if torch_version.major == 1 and torch_version.minor < 10:
         return ctx.origin_func(g, input, pad)

--- a/mmdeploy/pytorch/functions/repeat.py
+++ b/mmdeploy/pytorch/functions/repeat.py
@@ -3,19 +3,19 @@ from typing import Sequence, Union
 
 import torch
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 
 
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.repeat', backend='tensorrt')
-def tensor__repeat__tensorrt(ctx, input: torch.Tensor,
-                             *size: Union[torch.Size, Sequence[int]]):
+def tensor__repeat__tensorrt(input: torch.Tensor, *size: Union[torch.Size,
+                                                               Sequence[int]]):
     """Rewrite `repeat` for TensorRT backend.
 
     Some layers in TensorRT can not be applied on batch axis. add extra axis
     before operation and remove it afterward.
     """
-
+    ctx = FunctionContextContextCaller.get_instance('torch.Tensor.repeat')
     origin_func = ctx.origin_func
     if input.dim() == 1 and len(size) == 1:
         return origin_func(input.unsqueeze(0), *([1] + list(size))).squeeze(0)

--- a/mmdeploy/pytorch/functions/size.py
+++ b/mmdeploy/pytorch/functions/size.py
@@ -1,18 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 
 
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.size', backend='ncnn')
-def tensor__size__ncnn(ctx, self, *args):
+def tensor__size__ncnn(self, *args):
     """Rewrite `size` for ncnn backend.
 
     ONNX Shape node is not supported in ncnn. This function return integer
     instead of Torch.Size to avoid ONNX Shape node.
     """
-
+    ctx = FunctionContextContextCaller.get_instance('torch.Tensor.size')
     ret = ctx.origin_func(self, *args)
     if isinstance(ret, torch.Tensor):
         ret = int(ret)

--- a/mmdeploy/pytorch/functions/tensor_getitem.py
+++ b/mmdeploy/pytorch/functions/tensor_getitem.py
@@ -3,16 +3,18 @@ from typing import Iterable
 
 import torch
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 
 
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.__getitem__', backend='ascend')
-def tensor__getitem__ascend(ctx, self, key) -> torch.Tensor:
+def tensor__getitem__ascend(self, key) -> torch.Tensor:
     """Rewrite `getitem` for ascend backend.
 
     Ascend does not support negative select
     """
+    ctx = FunctionContextContextCaller.get_instance('torch.Tensor.__getitem__')
+
     if not isinstance(key, (tuple, list)):
         if isinstance(key, int) and key < 0:
             key = self.dim() + key

--- a/mmdeploy/pytorch/functions/tensor_setitem.py
+++ b/mmdeploy/pytorch/functions/tensor_setitem.py
@@ -4,12 +4,14 @@ from typing import Sequence
 import torch
 from packaging.version import parse
 
-from mmdeploy.core import FUNCTION_REWRITER, SYMBOLIC_REWRITER
+from mmdeploy.core import (FUNCTION_REWRITER, SYMBOLIC_REWRITER,
+                           FunctionContextContextCaller)
 
 
 @FUNCTION_REWRITER.register_rewriter(func_name='torch.Tensor.__setitem__')
-def tensor__setitem__default(ctx, self, key, value):
+def tensor__setitem__default(self, key, value):
     """Rewrite `setitem` to ease the index put."""
+    ctx = FunctionContextContextCaller.get_instance('torch.Tensor.__setitem__')
 
     # only support torch>=1.9.0
     if parse(torch.__version__) < parse('1.9.0'):

--- a/mmdeploy/pytorch/functions/topk.py
+++ b/mmdeploy/pytorch/functions/topk.py
@@ -3,15 +3,14 @@ from typing import Optional
 
 import torch
 
-from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.core import FUNCTION_REWRITER, FunctionContextContextCaller
 from mmdeploy.utils import get_root_logger
 
 
 @FUNCTION_REWRITER.register_rewriter(func_name='torch.topk', backend='default')
 @FUNCTION_REWRITER.register_rewriter(
     func_name='torch.Tensor.topk', backend='default')
-def topk__dynamic(ctx,
-                  input: torch.Tensor,
+def topk__dynamic(input: torch.Tensor,
                   k: int,
                   dim: Optional[int] = None,
                   largest: bool = True,
@@ -20,7 +19,7 @@ def topk__dynamic(ctx,
 
     Cast k to tensor and makesure k is smaller than input.shape[dim].
     """
-
+    ctx = FunctionContextContextCaller.get_instance('torch.topk')
     if dim is None:
         dim = int(input.ndim - 1)
     size = input.shape[dim]

--- a/mmdeploy/pytorch/functions/triu.py
+++ b/mmdeploy/pytorch/functions/triu.py
@@ -5,12 +5,12 @@ from mmdeploy.core import FUNCTION_REWRITER
 
 
 @FUNCTION_REWRITER.register_rewriter(func_name='torch.triu')
-def triu__default(ctx,
-                  input: torch.Tensor,
+def triu__default(input: torch.Tensor,
                   diagonal: int = 0,
                   *args,
                   **kwargs) -> torch.Tensor:
     """Rewrite `triu` for exporting model to ONNX."""
+
     assert len(input.shape) >= 2
     height, width = input.shape[-2:]
     arange0 = torch.arange(width, device=input.device).unsqueeze(0)

--- a/mmdeploy/pytorch/symbolics/__init__.py
+++ b/mmdeploy/pytorch/symbolics/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from . import adaptive_pool  # noqa: F401,F403
+from . import fake_quant  # noqa: F401,F403
 from . import gelu  # noqa: F401,F403
 from . import grid_sampler  # noqa: F401,F403
 from . import hardsigmoid  # noqa: F401,F403

--- a/mmdeploy/pytorch/symbolics/adaptive_pool.py
+++ b/mmdeploy/pytorch/symbolics/adaptive_pool.py
@@ -3,6 +3,8 @@
 from mmdeploy.core import SYMBOLIC_REWRITER
 
 
+# from torch import fake_quantize_per_tensor_affine
+# from torch import fake_quantize_per_channel_affine
 @SYMBOLIC_REWRITER.register_symbolic(
     'adaptive_avg_pool2d', is_pytorch=True, backend='ncnn')
 def adaptive_avg_pool2d__ncnn(ctx, g, x, output_size):
@@ -11,3 +13,57 @@ def adaptive_avg_pool2d__ncnn(ctx, g, x, output_size):
     Align symbolic of adaptive_avg_pool2d in ncnn.
     """
     return g.op('mmdeploy::AdaptiveAvgPool2d', x, output_size)
+
+
+# @SYMBOLIC_REWRITER.register_symbolic(
+#     'fake_quantize_per_tensor_affine', is_pytorch=True, backend='snpe')
+# def fake_quantize_per_tensor_affine__default(ctx, g, x, scale, zero_point, quant_min, quant_max ):
+#     """Register ncnn symbolic function for `adaptive_avg_pool2d`.
+
+#     Align symbolic of adaptive_avg_pool2d in ncnn.
+#     """
+#     return g.op('mmdeploy::FixedPerTensorAffine', x,  scale, zero_point, quant_min, quant_max)
+
+# @SYMBOLIC_REWRITER.register_symbolic(
+#     'fake_quantize_per_channel_affine', is_pytorch=True, backend='snpe')
+# def fake_quantize_per_tensor_affine__default(ctx, g, x, scale, zero_point, quant_min, quant_max ):
+#     """Register ncnn symbolic function for `adaptive_avg_pool2d`.
+
+#     Align symbolic of adaptive_avg_pool2d in ncnn.
+#     """
+#     return g.op('mmdeploy::FixedPerChannelAffine', x,  scale, zero_point, quant_min, quant_max)
+
+from torch.onnx import register_custom_op_symbolic
+
+# Register symbolic op for torch.quantize_function op.
+
+
+def _fake_quantize_learnable_per_tensor_affine(g, x, scale, zero_point,
+                                               quant_min, quant_max,
+                                               grad_factor):
+    return g.op('::LearnablePerTensorAffine', x, scale, zero_point, quant_min,
+                quant_max)
+
+
+register_custom_op_symbolic('::_fake_quantize_learnable_per_tensor_affine',
+                            _fake_quantize_learnable_per_tensor_affine, 11)
+
+
+def fake_quantize_per_channel_affine(g, x, scale, zero_point, ch_axis,
+                                     quant_min, quant_max):
+    return g.op('mmdeploy::FixedPerChannelAffine', x, scale, zero_point,
+                ch_axis, quant_min, quant_max)
+
+
+register_custom_op_symbolic('::fake_quantize_per_channel_affine',
+                            fake_quantize_per_channel_affine, 11)
+
+
+def fake_quantize_per_tensor_affine(g, x, scale, zero_point, quant_min,
+                                    quant_max):
+    return g.op('mmdeploy::FixedPerTensorAffine', x, scale, zero_point,
+                quant_min, quant_max)
+
+
+register_custom_op_symbolic('::fake_quantize_per_tensor_affine',
+                            fake_quantize_per_tensor_affine, 11)

--- a/mmdeploy/pytorch/symbolics/fake_quant.py
+++ b/mmdeploy/pytorch/symbolics/fake_quant.py
@@ -1,0 +1,26 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from mmdeploy.core import SYMBOLIC_REWRITER
+
+
+@SYMBOLIC_REWRITER.register_symbolic(
+    'fake_quantize_per_tensor_affine', is_pytorch=True)
+def fake_quantize_per_tensor_affine__default(ctx, g, x, scale, zero_point,
+                                             quant_min, quant_max):
+    """Register ncnn symbolic function for `adaptive_avg_pool2d`.
+
+    Align symbolic of adaptive_avg_pool2d in ncnn.
+    """
+    return g.op('mmdeploy::FixedPerTensorAffine', x, scale, zero_point,
+                quant_min, quant_max)
+
+
+@SYMBOLIC_REWRITER.register_symbolic(
+    'fake_quantize_per_channel_affine', is_pytorch=True)
+def fake_quantize_per_channel_affine__default(ctx, g, x, scale, zero_point,
+                                              ch_axis, quant_min, quant_max):
+    """Register ncnn symbolic function for `adaptive_avg_pool2d`.
+
+    Align symbolic of adaptive_avg_pool2d in ncnn.
+    """
+    return g.op('mmdeploy::FixedPerChannelAffine', x, scale, zero_point,
+                ch_axis, quant_min, quant_max)


### PR DESCRIPTION
## Motivation
The related pr in `MMRazor` is https://github.com/open-mmlab/mmrazor/pull/365

MMRazor is developing quantization algorithms, including PTQ and QAT.
This PR is a draft code to deploy `MMRazor` quantization model in `MMDeploy`, mainly with the following two points.

#### Export FX Graph
MMRazor quantized model is FX graph, and the current function rewriter cannot handle FX graph correctly.
The function rewriter has been fine-tuned in this PR, which can handle FX graph correctly.

#### Export Quantized ONNX
Different backends have different ONNX formats for quantized models, TensorRT and Openvion's quantized onnx exporters are implemented in this pr. 

## Modification
#### Function Rewriter
The original function rewriter is a wrapper, and the first arg is `ctx`.
In order to process FX Graph, wrapper is no longer used in this pr.
The original function is directly replaced by rewritten function, and `ctx` is removed from args.
`ctx` becomes a global variable.

#### Quantize ONNX Exporter
This pr adds a fake quant symbolic op, with which a temporary non-running onnx can be exported.
Then, different backends quantize onnx exporter will convert it to final deployed onnx.


```
python tools/deploy.py configs/mmdet/detection/detection_openvino_dynamic-800x1344-quantize.py  $RETINANET $FLOAT_CKPT demo/resources/det.jpg --show
```
