### PR TITLE
[Improvements] Support TorchAllocator as TensorRT Gpu Allocator

### DIFF
--- a/csrc/mmdeploy/backend_ops/tensorrt/modulated_deform_conv/trt_modulated_deform_conv.cpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/modulated_deform_conv/trt_modulated_deform_conv.cpp
@@ -224,11 +224,11 @@ nvinfer1::IPluginV2 *ModulatedDeformableConvPluginDynamicCreator::createPlugin(
     }
     std::string field_name(fc->fields[i].name);
 
-    if (field_name.compare("deformable_group") == 0) {
+    if (field_name.compare("deform_groups") == 0) {
       deformableGroup = static_cast<const int *>(fc->fields[i].data)[0];
     }
 
-    if (field_name.compare("group") == 0) {
+    if (field_name.compare("groups") == 0) {
       group = static_cast<const int *>(fc->fields[i].data)[0];
     }
 

--- a/csrc/mmdeploy/backend_ops/tensorrt/modulated_deform_conv/trt_modulated_deform_conv_kernel.cu
+++ b/csrc/mmdeploy/backend_ops/tensorrt/modulated_deform_conv/trt_modulated_deform_conv_kernel.cu
@@ -85,8 +85,8 @@ void ModulatedDeformConvForwardCUDAKernelLauncher(
   scalar_t* columns = (scalar_t*)workspace;
 
   const size_t input_step = channels * height * width;
-  const size_t offset_step = deformable_group * kernel_h * kernel_w * 2 * height * width;
-  const size_t mask_step = deformable_group * kernel_h * kernel_w * height * width;
+  const size_t offset_step = deformable_group * kernel_h * kernel_w * 2 * height_out * width_out;
+  const size_t mask_step = deformable_group * kernel_h * kernel_w * height_out * width_out;
   const size_t out_step = channels_out * height_out * width_out;
   const size_t out_group_step = out_step / group;
   const size_t col_g_step = channels * kernel_w * kernel_h / group * height_out * width_out;

--- a/mmdeploy/backend/tensorrt/__init__.py
+++ b/mmdeploy/backend/tensorrt/__init__.py
@@ -33,7 +33,8 @@ if is_available():
 
     try:
         # import wrapper if pytorch is available
+        from .torch_allocator import TorchAllocator
         from .wrapper import TRTWrapper
-        __all__ += ['TRTWrapper']
+        __all__ += ['TorchAllocator', 'TRTWrapper']
     except Exception:
         pass

--- a/mmdeploy/backend/tensorrt/torch_allocator.py
+++ b/mmdeploy/backend/tensorrt/torch_allocator.py
@@ -1,0 +1,63 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import tensorrt as trt
+import torch
+
+from mmdeploy.utils import get_root_logger
+
+
+class TorchAllocator(trt.IGpuAllocator):
+    """PyTorch Cuda Allocator Wrapper."""
+
+    def __init__(self, device_id: int = 0) -> None:
+        super().__init__()
+
+        self.device_id = device_id
+        self.mems = set()
+
+    def __del__(self):
+        """destructor."""
+        mems = self.mems.copy()
+        (self.deallocate(mem) for mem in mems)
+
+    def allocate(self: trt.IGpuAllocator, size: int, alignment: int,
+                 flags: int) -> int:
+        """allocate gpu memory.
+
+        Args:
+            self (trt.IGpuAllocator): gpu allocator
+            size (int): memory size.
+            alignment (int): memory alignment.
+            flags (int): flags.
+
+        Returns:
+            int: memory address.
+        """
+        torch_stream = torch.cuda.current_stream(self.device_id)
+        logger = get_root_logger()
+        logger.debug(f'allocate {size} memory with TorchAllocator.')
+        assert alignment >= 0
+        if alignment > 0:
+            size = size | (alignment - 1) + 1
+        mem = torch.cuda.caching_allocator_alloc(
+            size, device=self.device_id, stream=torch_stream)
+        self.mems.add(mem)
+        return mem
+
+    def deallocate(self: trt.IGpuAllocator, memory: int) -> bool:
+        """deallocate memory.
+
+        Args:
+            self (trt.IGpuAllocator): gpu allocator
+            memory (int): memory address.
+
+        Returns:
+            bool: deallocate success.
+        """
+        logger = get_root_logger()
+        logger.debug(f'deallocate {memory} with TorchAllocator.')
+        if memory not in self.mems:
+            return False
+
+        torch.cuda.caching_allocator_delete(memory)
+        self.mems.discard(memory)
+        return True


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

PyTorch memory pool wastes lots of memories. The PR share the pool with TensorRT through custom `IGpuAllocator`.

```python
a = torch.rand(large_memory_size, device='cuda')

del a

# torch would not release the pool, cudaMalloc might failed with OOM.
print(print(torch.cuda.memory_summary()))

model = TRTWrapper(engine_path)

x = torch.rand(1, 3, 224, 224, device='cuda')
out = model(dict(input=x))

print(print(torch.cuda.memory_summary()))

```

## Modification

- Custom `IGpuAllocator` wraps `torch.cuda.caching_allocator_xxx`.
- `TRTWrapper` with custom allocator.
- Fix bugs of MDCN

Got an error when applying the allocator on the Builder.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
