### PR TITLE
[Fix] recover scope mechanism for mmyolo

### DIFF
--- a/mmdeploy/codebase/base/mmcodebase.py
+++ b/mmdeploy/codebase/base/mmcodebase.py
@@ -47,8 +47,7 @@ class MMCodebase(metaclass=ABCMeta):
                 type=task.value,
                 model_cfg=model_cfg,
                 deploy_cfg=deploy_cfg,
-                device=device,
-                _scope_='mmdeploy'))
+                device=device))
 
     @classmethod
     def register_deploy_modules(cls):
@@ -84,4 +83,4 @@ def get_codebase_class(codebase: Codebase) -> MMCodebase:
         logger.warn(f'Import mmdeploy.codebase.{codebase.value}.deploy failed'
                     'Please check whether the module is the custom module.'
                     f'{e}')
-    return CODEBASE.build({'type': codebase.value, '_scope_': 'mmdeploy'})
+    return CODEBASE.build({'type': codebase.value})


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

#1450 changes scope will lead mmyolo scope switch failed

## Modification

Recover the scope before #1450 for mmyolo and mmdet.

## BC-breaking (Optional)

None.

## Use cases (Optional)

Uses in mmyolo.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
