### PR TITLE
[WIP] adding onnxruntime DeformConv2D customop for CPU/CUDA EP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ if (MSVC)
 endif ()
 
 if(APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fobjc-arc")
 endif()
 

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -14,12 +14,16 @@ endif ()
 # nvcc compiler settings
 find_package(CUDA REQUIRED)
 
+message(STATUS "FoundCUDA              : ${CUDA_FOUND}")
+
 if (MSVC)
     set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc.exe)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/wd4819,/wd4828")
     if (HAVE_CXX_FLAG_UTF_8)
         set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/utf-8")
     endif ()
+    set(CMAKE_CUDA_COMPILER_WORKS "TRUE")
+    link_directories(${CUDA_SDK_ROOT_DIR}/lib/x64)
 else ()
     set(CMAKE_CUDA_COMPILER ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc)
     # Explicitly set the cuda host compiler. Because the default host compiler #

--- a/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
@@ -1,12 +1,27 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
+if (MSVC)
+    #Always enable exception handling, even for Windows ARM
+    string(APPEND CMAKE_CXX_FLAGS " /EHsc")
+    string(APPEND CMAKE_C_FLAGS " /EHsc")
+
+    # AVX2
+    string(APPEND CMAKE_CXX_FLAGS " /arch:AVX2")
+    string(APPEND CMAKE_C_FLAGS " /arch:AVX2")
+else()
+    # AVX2
+    string(APPEND CMAKE_CXX_FLAGS " -mavx2")
+    string(APPEND CMAKE_C_FLAGS " -mavx2")
+endif()
+
 project(mmdeploy_onnxruntime_ops)
 
 include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/modules/FindONNXRUNTIME.cmake)
 
 # add plugin source
-file(GLOB_RECURSE ORT_OPS_SRCS *.cpp)
+
+file(GLOB_RECURSE ORT_OPS_SRCS *.cpp *.cu)
 add_library(${PROJECT_NAME}_obj OBJECT "${ORT_OPS_SRCS}")
 target_compile_definitions(${PROJECT_NAME}_obj PRIVATE -DMMDEPLOY_API_EXPORTS=1)
 target_compile_options(${PROJECT_NAME}_obj PRIVATE
@@ -22,7 +37,7 @@ target_include_directories(${PROJECT_NAME}_obj PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/csrc>)
-target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime)
+target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas)
 
 mmdeploy_add_library(${PROJECT_NAME} SHARED EXCLUDE "")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_obj)

--- a/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 project(mmdeploy_onnxruntime_ops)
 
+include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/modules/FindONNXRUNTIME.cmake)
 
 # add plugin source
@@ -12,6 +13,9 @@ target_compile_options(${PROJECT_NAME}_obj PRIVATE
         $<$<COMPILE_LANGUAGE:CXX>:-fvisibility=hidden>)
 set_target_properties(${PROJECT_NAME}_obj PROPERTIES POSITION_INDEPENDENT_CODE 1)
 mmdeploy_export(${PROJECT_NAME}_obj)
+
+target_include_directories(${PROJECT_NAME}_obj
+        PRIVATE ${CUDA_TOOLKIT_ROOT_DIR}/include)
 
 target_include_directories(${PROJECT_NAME}_obj PUBLIC
         $<BUILD_INTERFACE:${ONNXRUNTIME_DIR}/include>

--- a/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(${PROJECT_NAME}_obj PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/csrc>)
-target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudnn)
+target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudart)
 
 mmdeploy_add_library(${PROJECT_NAME} SHARED EXCLUDE "")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_obj)

--- a/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
@@ -1,5 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES "OFF")
+endif()
+
 if (MSVC)
     #Always enable exception handling, even for Windows ARM
     string(APPEND CMAKE_CXX_FLAGS " /EHsc")
@@ -37,7 +41,7 @@ target_include_directories(${PROJECT_NAME}_obj PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/csrc>)
-target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas)
+target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudnn)
 
 mmdeploy_add_library(${PROJECT_NAME} SHARED EXCLUDE "")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_obj)

--- a/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/CMakeLists.txt
@@ -20,12 +20,23 @@ endif()
 
 project(mmdeploy_onnxruntime_ops)
 
-include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
+if (!APPLE)
+    include(${CMAKE_SOURCE_DIR}/cmake/cuda.cmake)
+endif()
 include(${CMAKE_SOURCE_DIR}/cmake/modules/FindONNXRUNTIME.cmake)
 
 # add plugin source
 
 file(GLOB_RECURSE ORT_OPS_SRCS *.cpp *.cu)
+if (NOT FOUND_CUDA)
+    set (EXCLUDE_CUDA_DIR "/cuda/")
+    foreach (TMP_PATH ${ORT_OPS_SRCS})
+        string (FIND ${TMP_PATH} ${EXCLUDE_CUDA_DIR} EXCLUDE_DIR_FOUND)
+        if (NOT ${EXCLUDE_DIR_FOUND} EQUAL -1)
+            list (REMOVE_ITEM ORT_OPS_SRCS ${TMP_PATH})
+        endif ()
+    endforeach(TMP_PATH)
+endif()
 add_library(${PROJECT_NAME}_obj OBJECT "${ORT_OPS_SRCS}")
 target_compile_definitions(${PROJECT_NAME}_obj PRIVATE -DMMDEPLOY_API_EXPORTS=1)
 target_compile_options(${PROJECT_NAME}_obj PRIVATE
@@ -41,7 +52,11 @@ target_include_directories(${PROJECT_NAME}_obj PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/csrc>)
-target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudart)
+if (FOUND_CUDA)
+    target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime cublas cudart)
+else()
+    target_link_libraries(${PROJECT_NAME}_obj PUBLIC onnxruntime)
+endif()
 
 mmdeploy_add_library(${PROJECT_NAME} SHARED EXCLUDE "")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_NAME}_obj)

--- a/csrc/mmdeploy/backend_ops/onnxruntime/common/common_cuda_helper.hpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/common/common_cuda_helper.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+#ifndef COMMON_CUDA_HELPER
+#define COMMON_CUDA_HELPER
+
+#include <cublas_v2.h>
+#include <cuda.h>
+#include <stdio.h>
+
+#include <algorithm>
+
+#define CUDA_1D_KERNEL_LOOP(i, n) \
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); i += blockDim.x * gridDim.x)
+
+#define THREADS_PER_BLOCK 512
+
+#define DIVUP(m, n) ((m) / (n) + ((m) % (n) > 0))
+inline int GET_BLOCKS(const int N) {
+  int optimal_block_num = DIVUP(N, THREADS_PER_BLOCK);
+  int max_block_num = 4096;
+  return std::min(optimal_block_num, max_block_num);
+}
+
+#define cudaCheckError()                                                               \
+  {                                                                                    \
+    cudaError_t e = cudaGetLastError();                                                \
+    if (e != cudaSuccess) {                                                            \
+      printf("Cuda failure %s:%d: '%s'\n", __FILE__, __LINE__, cudaGetErrorString(e)); \
+      exit(0);                                                                         \
+    }                                                                                  \
+  }
+
+/**
+ * Returns a view of the original tensor with its dimensions permuted.
+ *
+ * @param[out] dst pointer to the destination tensor
+ * @param[in] src pointer to the source tensor
+ * @param[in] src_size shape of the src tensor
+ * @param[in] permute The desired ordering of dimensions
+ * @param[in] src_dim dim of src tensor
+ * @param[in] stream cuda stream handle
+ */
+template <class scalar_t>
+void memcpyPermute(scalar_t* dst, const scalar_t* src, int* src_size, int* permute, int src_dim,
+                   cudaStream_t stream = 0);
+
+template <typename scalar_t>
+cublasStatus_t cublasGemmWrap(cublasHandle_t handle, cublasOperation_t transa,
+                              cublasOperation_t transb, int m, int n, int k, const scalar_t* alpha,
+                              const scalar_t* A, int lda, const scalar_t* B, int ldb,
+                              const scalar_t* beta, scalar_t* C, int ldc);
+
+template <typename scalar_t>
+__device__ __forceinline__ scalar_t bilinear_interpolate(const scalar_t* __restrict__ input,
+                                                         const int height, const int width,
+                                                         scalar_t y, scalar_t x) {
+  // deal with cases that inverse elements are out of feature map boundary
+  if (y < -1.0 || y > height || x < -1.0 || x > width) return 0;
+
+  y = min(scalar_t(height - 1), max(scalar_t(0), y));
+  x = min(scalar_t(width - 1), max(scalar_t(0), x));
+
+  const int y_low = floor(y);
+  const int x_low = floor(x);
+  const int y_high = ceil(y);
+  const int x_high = ceil(x);
+
+  const scalar_t v1 = input[y_low * width + x_low];
+  const scalar_t v2 = input[y_low * width + x_high];
+  const scalar_t v3 = input[y_high * width + x_low];
+  const scalar_t v4 = input[y_high * width + x_high];
+
+  // lerp can be performed by fma
+  const scalar_t ly = y - y_low;
+  const scalar_t lx = x - x_low;
+  const scalar_t v_low = fma(v2 - v1, lx, v1);
+  const scalar_t v_high = fma(v4 - v3, lx, v3);
+  const scalar_t val = fma(v_high - v_low, ly, v_low);
+
+  return val;
+}
+
+#endif  // COMMON_CUDA_HELPER

--- a/csrc/mmdeploy/backend_ops/onnxruntime/common/ort_utils.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/common/ort_utils.h
@@ -33,5 +33,9 @@ class OrtOpsRegistry {
   static char __domain_##domain##name[] = #domain; \
   static OrtOpsRegistry<__domain_##domain##name, name> ort_ops_registry_##domain##name {}
 
+inline size_t getAlignedSize(size_t origin_size, size_t aligned_number = 16) {
+  return size_t((origin_size + aligned_number - 1) / aligned_number) * aligned_number;
+}
+
 }  // namespace mmdeploy
 #endif  // ORT_MMCV_UTILS_H

--- a/csrc/mmdeploy/backend_ops/onnxruntime/common_impl/ort_cuda_helper.cu
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/common_impl/ort_cuda_helper.cu
@@ -1,0 +1,93 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+#include "common_cuda_helper.hpp"
+#include <onnxruntime_cxx_api.h>
+#include <cuda_fp16.h>
+
+namespace mmdeploy {
+  const int MAXTENSORDIMS = 10;
+
+  struct TensorDesc {
+    int shape[MAXTENSORDIMS];
+    int stride[MAXTENSORDIMS];
+    int dim;
+  };
+}
+
+using mmdeploy::TensorDesc;
+
+template <class scalar_t>
+__global__ void copy_permute_kernel(scalar_t *__restrict__ dst, const scalar_t *__restrict__ src,
+                                    int n, TensorDesc ts_src_stride, TensorDesc ts_dst_stride,
+                                    TensorDesc ts_permute) {
+  const int src_dim = ts_src_stride.dim;
+  const auto src_stride = ts_src_stride.stride;
+  const auto dst_stride = ts_dst_stride.stride;
+  const auto permute = ts_permute.shape;
+  CUDA_1D_KERNEL_LOOP(index, n) {
+    size_t dst_index = index;
+    size_t src_index = 0;
+    for (int i = 0; i < src_dim; ++i) {
+      int dim_index = dst_index / dst_stride[i];
+      dst_index = dst_index % dst_stride[i];
+      src_index += dim_index * src_stride[permute[i]];
+    }
+    dst[index] = src[src_index];
+  }
+}
+
+template <class scalar_t>
+void memcpyPermute(scalar_t *dst, const scalar_t *src, int *src_size, int *permute, int src_dim,
+                   cudaStream_t stream) {
+  size_t copy_size = 1;
+  TensorDesc ts_permute;
+  memcpy(&(ts_permute.shape[0]), permute, src_dim * sizeof(int));
+
+  TensorDesc ts_src_stride;
+  TensorDesc ts_dst_stride;
+  ts_src_stride.dim = src_dim;
+  ts_dst_stride.dim = src_dim;
+  int *src_stride = &(ts_src_stride.stride[0]);
+  int *dst_stride = &(ts_dst_stride.stride[0]);
+  int *dst_size = &(ts_dst_stride.shape[0]);
+  src_stride[src_dim - 1] = 1;
+  dst_stride[src_dim - 1] = 1;
+
+  for (int i = src_dim - 1; i >= 0; --i) {
+    dst_size[i] = src_size[permute[i]];
+    if (i < src_dim - 1) {
+      src_stride[i] = src_stride[i + 1] * src_size[i + 1];
+    }
+  }
+
+  for (int i = src_dim - 1; i >= 0; --i) {
+    copy_size *= dst_size[i];
+    if (i < src_dim - 1) {
+      dst_stride[i] = dst_stride[i + 1] * dst_size[i + 1];
+    }
+  }
+
+  copy_permute_kernel<scalar_t><<<GET_BLOCKS(copy_size), THREADS_PER_BLOCK, 0, stream>>>(
+      dst, src, copy_size, ts_src_stride, ts_dst_stride, ts_permute);
+}
+
+template void memcpyPermute<float>(float *dst, const float *src, int *src_size, int *permute,
+                                   int src_dim, cudaStream_t stream);
+template void memcpyPermute<__half>(__half *dst, const __half *src, int *src_size, int *permute,
+                                  int src_dim, cudaStream_t stream);
+
+
+template <>
+cublasStatus_t cublasGemmWrap<float>(cublasHandle_t handle, cublasOperation_t transa,
+                                     cublasOperation_t transb, int m, int n, int k,
+                                     const float *alpha, const float *A, int lda, const float *B,
+                                     int ldb, const float *beta, float *C, int ldc) {
+  return cublasSgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+}
+
+template <>
+cublasStatus_t cublasGemmWrap<__half>(cublasHandle_t handle, cublasOperation_t transa,
+                                    cublasOperation_t transb, int m, int n, int k,
+                                    const __half *alpha, const __half *A, int lda, const __half *B,
+                                    int ldb, const __half *beta, __half *C, int ldc) {
+  return cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+}

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
@@ -184,19 +184,18 @@ MMCVDeformConvKernel::MMCVDeformConvKernel(const OrtApi& api,
                                            const OrtKernelInfo *info)
     : api_(api), ort_(api_), info_(info) {
   std::vector<int64_t> stride =
-      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "stride");
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "strides");
   stride_height_ = stride[0];
   stride_width_ = stride[1];
   std::vector<int64_t> padding =
-      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "padding");
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "pads");
   padding_height_ = padding[0];
   padding_width_ = padding[1];
   std::vector<int64_t> dilation =
-      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "dilation");
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "dilations");
   dilation_height_ = dilation[0];
   dilation_width_ = dilation[1];
-  deformable_group_ =
-      ort_.KernelInfoGetAttribute<int64_t>(info, "deform_groups");
+  deformable_group_ = ort_.KernelInfoGetAttribute<int64_t>(info, "deformable_groups");
   group_ = ort_.KernelInfoGetAttribute<int64_t>(info, "groups");
 
   // create allocator
@@ -265,5 +264,8 @@ void MMCVDeformConvKernel::Compute(OrtKernelContext *context) {
       dilation_width, columns, out_ptr);
 }
 
-REGISTER_ONNXRUNTIME_OPS(mmdeploy, MMCVDeformConvOp);
+static char __openvino[] = "org.openvinotoolkit";
+static OrtOpsRegistry<__openvino, MMCVDeformConvOp> ort_ops_registry_openvino {};
+
+//REGISTER_ONNXRUNTIME_OPS(mmdeploy, MMCVDeformConvOp);
 }  // namespace mmdeploy

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.cpp
@@ -1,0 +1,269 @@
+// Copyright (c) OpenMMLab. All rights reserved
+#include "deform_conv.h"
+
+#include <cmath>
+#include <vector>
+
+#include "ort_utils.h"
+
+
+namespace mmdeploy {
+
+void gemm_ref_fp32_deform(const float *A, const float *B, const float *V,
+                          const float *H, const int32_t trans_A,
+                          const int32_t trans_B, const int32_t M,
+                          const int32_t N, const int32_t K, const float alpha,
+                          const float beta, float *Y) {
+  if (!trans_A && !trans_B) {  // MK, KN; NN
+    for (int64_t m = 0; m < M; ++m) {
+      for (int64_t n = 0; n < N; ++n) {
+        float y = 0.0f;
+        for (int64_t k = 0; k < K; ++k) {
+          y += A[m * K + k] * B[k * N + n];
+        }
+        y *= alpha;
+        if (V) y += beta * V[n];
+        if (H) y += beta * H[m * N + n];
+        Y[m * N + n] = y;
+      }
+    }
+  }
+  if (trans_A && !trans_B) {  // KM, KN; TN
+    for (int64_t m = 0; m < M; ++m) {
+      for (int64_t n = 0; n < N; ++n) {
+        float y = 0.0f;
+        for (int64_t k = 0; k < K; ++k) {
+          y += A[k * M + m] * B[k * N + n];
+        }
+        y *= alpha;
+        if (V) y += beta * V[n];
+        if (H) y += beta * H[m * N + n];
+        Y[m * N + n] = y;
+      }
+    }
+  }
+  if (trans_A && trans_B) {  // KM, NK; TT
+    for (int64_t m = 0; m < M; ++m) {
+      for (int64_t n = 0; n < N; ++n) {
+        float y = 0.0f;
+        for (int64_t k = 0; k < K; ++k) {
+          y += A[k * M + m] * B[n * K + k];
+        }
+        y *= alpha;
+        if (V) y += beta * V[n];
+        if (H) y += beta * H[m * N + n];
+        Y[m * N + n] = y;
+      }
+    }
+  }
+  if (!trans_A && trans_B) {  // MK, NK; NT
+    for (int64_t m = 0; m < M; ++m) {
+      for (int64_t n = 0; n < N; ++n) {
+        float y = 0.0f;
+        for (int64_t k = 0; k < K; ++k) {
+          y += A[m * K + k] * B[n * K + k];
+        }
+        y *= alpha;
+        if (V) y += beta * V[n];
+        if (H) y += beta * H[m * N + n];
+        Y[m * N + n] = y;
+      }
+    }
+  }
+}
+
+float bilinear_interpolate(const float *src, const int64_t src_h,
+                           const int64_t src_w, const float h, const float w) {
+  if (h <= -1 || src_h <= h || w <= -1 || src_w <= w) {
+    return 0;
+  }
+
+  int64_t h_low = floor(h);
+  int64_t w_low = floor(w);
+  int64_t h_high = h_low + 1;
+  int64_t w_high = w_low + 1;
+
+  float lh = h - h_low;
+  float lw = w - w_low;
+  float hh = 1 - lh;
+  float hw = 1 - lw;
+
+  float v1 = 0;
+  if (h_low >= 0 && w_low >= 0) v1 = src[h_low * src_w + w_low];
+  float v2 = 0;
+  if (h_low >= 0 && w_high <= src_w - 1) v2 = src[h_low * src_w + w_high];
+  float v3 = 0;
+  if (h_high <= src_h - 1 && w_low >= 0) v3 = src[h_high * src_w + w_low];
+  float v4 = 0;
+  if (h_high <= src_h - 1 && w_high <= src_w - 1)
+    v4 = src[h_high * src_w + w_high];
+
+  float w1 = hh * hw, w2 = hh * lw, w3 = lh * hw, w4 = lh * lw;
+
+  float val = (w1 * v1 + w2 * v2 + w3 * v3 + w4 * v4);
+  return val;
+}
+
+void deformable_im2col(const float *input, const float *offset,
+                       const int64_t src_h, const int64_t src_w,
+                       const int64_t kernel_h, const int64_t kernel_w,
+                       const int64_t pad_h, const int64_t pad_w,
+                       const int64_t stride_h, const int64_t stride_w,
+                       const int64_t dilation_h, const int64_t dilation_w,
+                       const int64_t channels, const int64_t offset_groups,
+                       const int64_t dst_h, const int64_t dst_w,
+                       float *columns) {
+  const int64_t indices = channels * dst_h * dst_w;
+  for (int64_t index = 0; index != indices; ++index) {
+    const int64_t w_col = index % dst_w;
+    const int64_t h_col = (index / dst_w) % dst_h;
+    const int64_t c_im = index / (dst_w * dst_h);
+    const int64_t c_col = c_im * kernel_h * kernel_w;
+
+    int64_t c_per_offset_grp = channels / offset_groups;
+    const int64_t grp_idx = c_im / c_per_offset_grp;
+    auto columns_ptr =
+        columns + (c_col * (dst_h * dst_w) + h_col * dst_w + w_col);
+    auto input_ptr = input + c_im * (src_h * src_w);
+    auto offset_ptr =
+        offset + grp_idx * 2 * kernel_h * kernel_w * dst_h * dst_w;
+
+    for (int64_t kh = 0; kh < kernel_h; ++kh) {
+      for (int64_t kw = 0; kw < kernel_w; ++kw) {
+        const int data_offset_h_ptr =
+            ((2 * (kh * kernel_w + kw)) * dst_h + h_col) * dst_w + w_col;
+        const int data_offset_w_ptr =
+            ((2 * (kh * kernel_w + kw) + 1) * dst_h + h_col) * dst_w + w_col;
+
+        const float offset_h = offset_ptr[data_offset_h_ptr];
+        const float offset_w = offset_ptr[data_offset_w_ptr];
+        const float ih =
+            (h_col * stride_h - pad_h) + kh * dilation_h + offset_h;
+        const float iw =
+            (w_col * stride_w - pad_w) + kw * dilation_w + offset_w;
+        *columns_ptr = bilinear_interpolate(input_ptr, src_h, src_w, ih, iw);
+        columns_ptr += dst_h * dst_w;
+      }
+    }
+  }
+}
+
+void deformable_conv_forward(
+    const float *src, const float *offset, const float *filter,
+    const int64_t batch, const int64_t src_c, const int64_t src_h,
+    const int64_t src_w, const int64_t dst_c, const int64_t dst_h,
+    const int64_t dst_w, const int64_t group, const int64_t offset_group,
+    const int64_t channels, const int64_t num_output, const int64_t kernel_h,
+    const int64_t kernel_w, const int64_t stride_h, const int64_t stride_w,
+    const int64_t pad_h, const int64_t pad_w, const int64_t dilation_h,
+    const int64_t dilation_w, float *columns, float *dst) {
+  const int64_t ic_per_gp = channels / group;
+  const int64_t oc_per_gp = num_output / group;
+  for (int64_t b = 0; b < batch; ++b) {
+    for (int64_t g = 0; g < group; ++g) {
+      deformable_im2col(
+          src + b * src_c * src_h * src_w + g * ic_per_gp * src_h * src_w,
+          offset + b * offset_group * 2 * kernel_h * kernel_w * dst_h * dst_w,
+          src_h, src_w, kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w,
+          dilation_h, dilation_w, ic_per_gp, offset_group, dst_h, dst_w,
+          columns);
+      float *dst_ptr =
+          dst + b * dst_c * dst_h * dst_w + g * oc_per_gp * dst_h * dst_w;
+
+      memset(dst_ptr, 0.0f, sizeof(float) * oc_per_gp * dst_h * dst_w);
+
+      gemm_ref_fp32_deform(
+          filter + g * oc_per_gp * ic_per_gp * kernel_h * kernel_w, columns,
+          nullptr, dst_ptr, 0, 0, oc_per_gp, dst_h * dst_w,
+          ic_per_gp * kernel_h * kernel_w, 1.0f, 1.0f, dst_ptr);
+    }
+  }
+}
+
+MMCVDeformConvKernel::MMCVDeformConvKernel(const OrtApi& api,
+                                           const OrtKernelInfo *info)
+    : api_(api), ort_(api_), info_(info) {
+  std::vector<int64_t> stride =
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "stride");
+  stride_height_ = stride[0];
+  stride_width_ = stride[1];
+  std::vector<int64_t> padding =
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "padding");
+  padding_height_ = padding[0];
+  padding_width_ = padding[1];
+  std::vector<int64_t> dilation =
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "dilation");
+  dilation_height_ = dilation[0];
+  dilation_width_ = dilation[1];
+  deformable_group_ =
+      ort_.KernelInfoGetAttribute<int64_t>(info, "deform_groups");
+  group_ = ort_.KernelInfoGetAttribute<int64_t>(info, "groups");
+
+  // create allocator
+  allocator_ = Ort::AllocatorWithDefaultOptions();
+}
+
+void MMCVDeformConvKernel::Compute(OrtKernelContext *context) {
+  const int64_t stride_height = stride_height_;
+  const int64_t stride_width = stride_width_;
+  const int64_t padding_height = padding_height_;
+  const int64_t padding_width = padding_width_;
+  const int64_t dilation_height = dilation_height_;
+  const int64_t dilation_width = dilation_width_;
+  const int64_t deformable_group = deformable_group_;
+  const int64_t group = group_;
+
+  const OrtValue *input = ort_.KernelContext_GetInput(context, 0);
+  const float *input_data =
+      reinterpret_cast<const float *>(ort_.GetTensorData<float>(input));
+
+  const OrtValue *offset = ort_.KernelContext_GetInput(context, 1);
+  const float *offset_data =
+      reinterpret_cast<const float *>(ort_.GetTensorData<float>(offset));
+
+  const OrtValue *filter = ort_.KernelContext_GetInput(context, 2);
+  const float *filter_data =
+      reinterpret_cast<const float *>(ort_.GetTensorData<float>(filter));
+
+  OrtTensorDimensions input_dims(ort_, input);
+  OrtTensorDimensions filter_dims(ort_, filter);
+
+  int64_t batch_size = input_dims[0];
+  int64_t in_channels = input_dims[1];
+  int64_t in_height = input_dims[2];
+  int64_t in_width = input_dims[3];
+  int64_t out_channels = filter_dims[0];
+  int64_t kernel_height = filter_dims[2];
+  int64_t kernel_width = filter_dims[3];
+
+  // get output memory
+  int64_t out_height = floor((in_height + 2 * padding_height -
+                              dilation_height * (kernel_height - 1) - 1) /
+                                 stride_height +
+                             1);
+  int64_t out_width = floor(
+      (in_width + 2 * padding_width - dilation_width * (kernel_width - 1) - 1) /
+          stride_width +
+      1);
+
+  std::vector<int64_t> output_dims = {batch_size, out_channels, out_height,
+                                      out_width};
+
+  OrtValue *output = ort_.KernelContext_GetOutput(
+      context, 0, output_dims.data(), output_dims.size());
+  float *out_ptr = ort_.GetTensorMutableData<float>(output);
+
+  // allocate tmp memory
+  int64_t column_len = (in_channels / group) * kernel_height * kernel_width *
+                       out_height * out_width;
+  float *columns = (float *)allocator_.Alloc(sizeof(float) * column_len);
+  deformable_conv_forward(
+      input_data, offset_data, filter_data, batch_size, in_channels, in_height,
+      in_width, out_channels, out_height, out_width, group, deformable_group,
+      in_channels, out_channels, kernel_height, kernel_width, stride_height,
+      stride_width, padding_height, padding_width, dilation_height,
+      dilation_width, columns, out_ptr);
+}
+
+REGISTER_ONNXRUNTIME_OPS(mmdeploy, MMCVDeformConvOp);
+}  // namespace mmdeploy

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
@@ -8,8 +8,22 @@ namespace mmdeploy {
 
 struct MMCVDeformConvKernel {
   MMCVDeformConvKernel(const OrtApi& api, const OrtKernelInfo *info);
+  ~MMCVDeformConvKernel();
 
   void Compute(OrtKernelContext *context);
+
+ private:
+  OrtOp* op_gemm_{};
+  void initGemm(Ort::CustomOpApi ort);
+  void deformConv(OrtKernelContext *context,
+    const float *src, const float *offset, const float *filter,
+    const int64_t batch, const int64_t src_c, const int64_t src_h,
+    const int64_t src_w, const int64_t dst_c, const int64_t dst_h,
+    const int64_t dst_w, const int64_t group, const int64_t offset_group,
+    const int64_t channels, const int64_t num_output, const int64_t kernel_h,
+    const int64_t kernel_w, const int64_t stride_h, const int64_t stride_w,
+    const int64_t pad_h, const int64_t pad_w, const int64_t dilation_h,
+    const int64_t dilation_w, float *columns, float *dst);
 
  protected:
   const OrtApi& api_;

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
@@ -34,7 +34,7 @@ struct MMCVDeformConvOp
     return new MMCVDeformConvKernel(api, info);
   }
 
-  const char *GetName() const { return "DeformConv2d"; };
+  const char *GetName() const { return "CPUDeformableConv2D"; };
 
   size_t GetInputTypeCount() const { return 3; };
   ONNXTensorElementDataType GetInputType(size_t /*index*/) const {

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
@@ -34,7 +34,7 @@ struct MMCVDeformConvOp
     return new MMCVDeformConvKernel(api, info);
   }
 
-  const char *GetName() const { return "CPUDeformableConv2D"; };
+  const char *GetName() const { return "DeformableConv2D"; };
 
   size_t GetInputTypeCount() const { return 3; };
   ONNXTensorElementDataType GetInputType(size_t /*index*/) const {

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cpu/deform_conv.h
@@ -1,0 +1,61 @@
+// Copyright (c) OpenMMLab. All rights reserved
+#ifndef ONNXRUNTIME_DEFORM_CONV_H
+#define ONNXRUNTIME_DEFORM_CONV_H
+
+#include <onnxruntime_cxx_api.h>
+
+namespace mmdeploy {
+
+struct MMCVDeformConvKernel {
+  MMCVDeformConvKernel(const OrtApi& api, const OrtKernelInfo *info);
+
+  void Compute(OrtKernelContext *context);
+
+ protected:
+  const OrtApi& api_;
+  Ort::CustomOpApi ort_;
+  const OrtKernelInfo *info_;
+  Ort::AllocatorWithDefaultOptions allocator_;
+
+  int64_t stride_height_;
+  int64_t stride_width_;
+  int64_t padding_height_;
+  int64_t padding_width_;
+  int64_t dilation_height_;
+  int64_t dilation_width_;
+  int64_t deformable_group_;
+  int64_t group_;
+  int64_t im2col_step_;
+};
+
+struct MMCVDeformConvOp
+    : Ort::CustomOpBase<MMCVDeformConvOp, MMCVDeformConvKernel> {
+  void *CreateKernel(const OrtApi& api, const OrtKernelInfo *info) const {
+    return new MMCVDeformConvKernel(api, info);
+  }
+
+  const char *GetName() const { return "DeformConv2d"; };
+
+  size_t GetInputTypeCount() const { return 3; };
+  ONNXTensorElementDataType GetInputType(size_t /*index*/) const {
+    return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  };
+
+  OrtCustomOpInputOutputCharacteristic GetInputCharacteristic(
+      size_t index) const {
+    return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_REQUIRED;
+  }
+
+  size_t GetOutputTypeCount() const { return 1; };
+  ONNXTensorElementDataType GetOutputType(size_t /*index*/) const {
+    return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  };
+
+  // force cpu
+  const char *GetExecutionProviderType() const {
+    return "CPUExecutionProvider";
+  };
+};
+
+}  // namespace mmdeploy
+#endif

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.cpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) OpenMMLab. All rights reserved
+
+#include <cmath>
+#include <vector>
+#include <cuda_runtime.h>
+
+#include "ort_utils.h"
+#include "deform_conv.h"
+#include "deform_conv_kernel.hpp"
+
+namespace mmdeploy {
+
+MMCVDeformConvCUDAKernel::MMCVDeformConvCUDAKernel(const OrtApi& api,
+                                           const OrtKernelInfo *info)
+    : api_(api), ort_(api_), info_(info) {
+  std::vector<int64_t> stride =
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "stride");
+  stride_height_ = stride[0];
+  stride_width_ = stride[1];
+  std::vector<int64_t> padding =
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "padding");
+  padding_height_ = padding[0];
+  padding_width_ = padding[1];
+  std::vector<int64_t> dilation =
+      ort_.KernelInfoGetAttribute<std::vector<int64_t>>(info, "dilation");
+  dilation_height_ = dilation[0];
+  dilation_width_ = dilation[1];
+  deformable_group_ =
+      ort_.KernelInfoGetAttribute<int64_t>(info, "deform_groups");
+  group_ = ort_.KernelInfoGetAttribute<int64_t>(info, "groups");
+
+  // create allocator
+  allocator_ = Ort::AllocatorWithDefaultOptions();
+
+  // create cublas handle
+  cublasStatus_t stat = cublasCreate(&m_cublas_handle);
+  if (stat != CUBLAS_STATUS_SUCCESS) {
+    ORT_CXX_API_THROW("CUBLAS initialization failed", ORT_FAIL);
+  }
+}
+
+void MMCVDeformConvCUDAKernel::Compute(OrtKernelContext *context) {
+  const int64_t stride_height = stride_height_;
+  const int64_t stride_width = stride_width_;
+  const int64_t padding_height = padding_height_;
+  const int64_t padding_width = padding_width_;
+  const int64_t dilation_height = dilation_height_;
+  const int64_t dilation_width = dilation_width_;
+  const int64_t deformable_group = deformable_group_;
+  const int64_t group = group_;
+
+  const OrtValue *input = ort_.KernelContext_GetInput(context, 0);
+  const float *input_data =
+      reinterpret_cast<const float *>(ort_.GetTensorData<float>(input));
+
+  const OrtValue *offset = ort_.KernelContext_GetInput(context, 1);
+  const float *offset_data =
+      reinterpret_cast<const float *>(ort_.GetTensorData<float>(offset));
+
+  const OrtValue *filter = ort_.KernelContext_GetInput(context, 2);
+  const float *filter_data =
+      reinterpret_cast<const float *>(ort_.GetTensorData<float>(filter));
+
+  OrtTensorDimensions input_dims(ort_, input);
+  OrtTensorDimensions filter_dims(ort_, filter);
+
+  int64_t batch_size = input_dims[0];
+  int64_t in_channels = input_dims[1];
+  int64_t in_height = input_dims[2];
+  int64_t in_width = input_dims[3];
+  int64_t out_channels = filter_dims[0];
+  int64_t kernel_height = filter_dims[2];
+  int64_t kernel_width = filter_dims[3];
+
+  // get input data type
+  auto data_type = ort_.GetTensorElementType(ort_.GetTensorTypeAndShape(input));
+
+  int64_t sizeof_dtype = (data_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16)? sizeof(Ort::Float16_t): sizeof(float);
+
+  // get output memory
+  int64_t output_height = floor((in_height + 2 * padding_height -
+                              dilation_height * (kernel_height - 1) - 1) /
+                                 stride_height +
+                             1);
+  int64_t output_width = floor(
+      (in_width + 2 * padding_width - dilation_width * (kernel_width - 1) - 1) /
+          stride_width +
+      1);
+
+  std::vector<int64_t> output_dims = {batch_size, out_channels, output_height,
+                                      output_width};
+
+  OrtValue *output = ort_.KernelContext_GetOutput(
+      context, 0, output_dims.data(), output_dims.size());
+  float *output_ptr = ort_.GetTensorMutableData<float>(output);
+
+
+  // adopted from trt_deform_conv.cpp -- DeformableConvPluginDynamic::getWorkspaceSize
+  int im2col_step = std::min(int64_t(32), batch_size);
+
+  size_t col_size = mmdeploy::getAlignedSize(in_channels * kernel_width * kernel_height * im2col_step * output_height *
+                                             output_width * sizeof_dtype);
+
+  size_t out_size = 0;
+  if (im2col_step != 1)
+    out_size = mmdeploy::getAlignedSize(batch_size * out_channels * output_height * output_width * sizeof_dtype);
+
+  // allocate workspace
+  long workspace_size = col_size + out_size;
+
+  float* workspace;
+  cudaMalloc(&workspace, workspace_size);
+  cudaMemset(workspace, 0, workspace_size);
+
+  auto stream = reinterpret_cast<cudaStream_t>(ort_.KernelContext_GetGPUComputeStream(context));
+
+  switch (data_type) {
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
+      deform_conv<float>((float *)input, (float *)filter, (float *)offset, (float *)output_ptr, workspace,
+                         batch_size, in_channels, in_height, in_width, out_channels, kernel_width, kernel_height,
+                         stride_height, stride_width, padding_height, padding_width, dilation_height,
+                         dilation_width, group, deformable_group, im2col_step, m_cublas_handle, stream);
+      break;
+    case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
+      deform_conv<Ort::Float16_t>((Ort::Float16_t *)input, (Ort::Float16_t *)filter, (Ort::Float16_t *)offset, 
+                        (Ort::Float16_t *)output_ptr, workspace, batch_size,
+                        in_channels, in_height, in_width, out_channels, kernel_width, kernel_height, stride_height,
+                        stride_width, padding_height, padding_width, dilation_height, dilation_width,
+                        group, deformable_group, im2col_step, m_cublas_handle, stream);
+      break;
+    default:
+      cudaFree(&workspace);
+      ORT_CXX_API_THROW("invalid tensor datatype in deform_conv::CUDAKernel::Compute", ORT_FAIL);
+      return;
+  }
+
+  cudaFree(&workspace);
+}
+
+REGISTER_ONNXRUNTIME_OPS(mmdeploy, MMCVDeformConvCUDAOp);
+}  // namespace mmdeploy

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.cpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <vector>
+#include <sstream>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 
@@ -33,6 +34,10 @@ MMCVDeformConvCUDAKernel::MMCVDeformConvCUDAKernel(const OrtApi& api,
   // create allocator
   allocator_ = Ort::AllocatorWithDefaultOptions();
 
+  int device;
+  cudaGetDevice( &device );
+  cudaDeviceGetAttribute(&cuda_dev_memory_pools_supported_, cudaDevAttrMemoryPoolsSupported, device);
+
   // create cublas handle
   cublasStatus_t stat = cublasCreate(&cublas_handle_);
   if (stat != CUBLAS_STATUS_SUCCESS) {
@@ -50,6 +55,10 @@ void MMCVDeformConvCUDAKernel::Compute(OrtKernelContext *context) {
   const int64_t deformable_group = deformable_group_;
   const int64_t group = group_;
   const cublasHandle_t cublas_handle = cublas_handle_;
+
+  cudaStream_t stream = reinterpret_cast<cudaStream_t>(ort_.KernelContext_GetGPUComputeStream(context));
+  cudaStreamSynchronize(stream);
+  cublasSetStream(cublas_handle_, stream);
 
   const OrtValue *input = ort_.KernelContext_GetInput(context, 0);
   const float *input_data =
@@ -103,38 +112,55 @@ void MMCVDeformConvCUDAKernel::Compute(OrtKernelContext *context) {
   long workspace_size = col_size + out_size;
 
   void* workspace;
-  auto status = cudaMalloc(&workspace, workspace_size);
+  auto status = cuda_malloc(&workspace, workspace_size, stream);
   if (status != cudaSuccess) {
-    ORT_CXX_API_THROW("cuda malloc error in deform_conv::CUDAKernel::Compute", ORT_FAIL);
+    std::stringstream ss;
+    ss << "cudaMalloc(" << workspace_size << ") error in deform_conv::CUDAKernel::Comput, status:" << status;
+    ORT_CXX_API_THROW(ss.str(), ORT_FAIL);
   }
-  cudaMemset(workspace, 0, workspace_size);
-
-  auto stream = reinterpret_cast<cudaStream_t>(ort_.KernelContext_GetGPUComputeStream(context));
-
+  cudaMemsetAsync(workspace, 0, workspace_size, stream);
   switch (data_type) {
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT:
       deform_conv<float>((float *)input_data, (float *)filter_data, (float *)offset_data, (float *)output_ptr, workspace,
                          batch_size, in_channels, in_height, in_width, out_channels, kernel_width, kernel_height,
-                         stride_height, stride_width, padding_height, padding_width, dilation_height,
-                         dilation_width, group, deformable_group, im2col_step, cublas_handle, stream);
+                         stride_width, stride_height, padding_width, padding_height, dilation_width, dilation_height,
+                         group, deformable_group, im2col_step, cublas_handle, stream);
       break;
     case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16:
       deform_conv<__half>((__half *)input_data, (__half *)filter_data, (__half *)offset_data, (__half *)output_ptr, workspace,
                          batch_size, in_channels, in_height, in_width, out_channels, kernel_width, kernel_height,
-                         stride_height, stride_width, padding_height, padding_width, dilation_height,
-                         dilation_width, group, deformable_group, im2col_step, cublas_handle, stream);
+                         stride_width, stride_height, padding_width, padding_height, dilation_width, dilation_height,
+                         group, deformable_group, im2col_step, cublas_handle, stream);
       break;
     default:
-      cudaFree(workspace);
+      cuda_free(workspace, stream);
       ORT_CXX_API_THROW("invalid tensor datatype in deform_conv::CUDAKernel::Compute", ORT_FAIL);
       return;
   }
-
-  cudaFree(workspace);
+  cuda_free(workspace, stream);
 }
+
+cudaError_t MMCVDeformConvCUDAKernel::cuda_malloc(void **pointer, size_t size, cudaStream_t stream) {
+  if (cuda_dev_memory_pools_supported_) {
+    return cudaMallocAsync(pointer, size, stream);
+  } else {
+    return cudaMalloc(pointer, size);
+  }
+}
+
+void MMCVDeformConvCUDAKernel::cuda_free(void *pointer, cudaStream_t stream) {
+  if (cuda_dev_memory_pools_supported_) {
+    cudaFreeAsync(pointer, stream);
+  } else {
+    cudaFree(pointer);
+  }
+}
+
 
 static char __openvino_cuda[] = "org.openvinotoolkit";
 static OrtOpsRegistry<__openvino_cuda, MMCVDeformConvCUDAOp> ort_ops_registry_cuda_openvino {};
 
 //REGISTER_ONNXRUNTIME_OPS(mmdeploy, MMCVDeformConvCUDAOp);
 }  // namespace mmdeploy
+
+

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
@@ -1,0 +1,69 @@
+// Copyright (c) OpenMMLab. All rights reserved
+#ifndef ONNXRUNTIME_DEFORM_CONV_H
+#define ONNXRUNTIME_DEFORM_CONV_H
+
+#include <onnxruntime_cxx_api.h>
+#include <cuda_runtime.h>
+#include "cublas_v2.h"
+
+namespace mmdeploy {
+
+
+struct MMCVDeformConvCUDAKernel {
+  MMCVDeformConvCUDAKernel(const OrtApi& api, const OrtKernelInfo *info);
+
+  void Compute(OrtKernelContext *context);
+
+ protected:
+  const OrtApi& api_;
+  Ort::CustomOpApi ort_;
+  const OrtKernelInfo *info_;
+  Ort::AllocatorWithDefaultOptions allocator_;
+
+  cublasHandle_t m_cublas_handle;  // TODO:: release the cublas handle?
+
+  int64_t stride_height_;
+  int64_t stride_width_;
+  int64_t padding_height_;
+  int64_t padding_width_;
+  int64_t dilation_height_;
+  int64_t dilation_width_;
+  int64_t deformable_group_;
+  int64_t group_;
+  int64_t im2col_step_;
+
+};
+
+struct MMCVDeformConvCUDAOp
+    : Ort::CustomOpBase<MMCVDeformConvCUDAOp, MMCVDeformConvCUDAKernel> {
+  void *CreateKernel(const OrtApi& api, const OrtKernelInfo *info) const {
+
+    return new MMCVDeformConvCUDAKernel(api, info);
+  }
+
+  const char *GetName() const { return "DeformConv2d"; };
+
+  size_t GetInputTypeCount() const { return 3; };
+  ONNXTensorElementDataType GetInputType(size_t /*index*/) const {
+    return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  };
+
+  OrtCustomOpInputOutputCharacteristic GetInputCharacteristic(
+      size_t index) const {
+    return OrtCustomOpInputOutputCharacteristic::INPUT_OUTPUT_REQUIRED;
+  }
+
+  size_t GetOutputTypeCount() const { return 1; };
+
+  ONNXTensorElementDataType GetOutputType(size_t /*index*/) const {
+    return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+  };
+
+  // force CUDA EP
+  const char *GetExecutionProviderType() const {
+    return "CUDAExecutionProvider";
+  };
+};
+
+}  // namespace mmdeploy
+#endif

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
@@ -20,6 +20,7 @@ struct MMCVDeformConvCUDAKernel {
   const OrtKernelInfo *info_;
   Ort::AllocatorWithDefaultOptions allocator_;
 
+  int cuda_dev_memory_pools_supported_;
   cublasHandle_t cublas_handle_ = nullptr;  // TODO:: release the cublas handle?
 
   int64_t stride_height_;
@@ -32,6 +33,9 @@ struct MMCVDeformConvCUDAKernel {
   int64_t group_;
   int64_t im2col_step_;
 
+private:
+  cudaError_t cuda_malloc(void **pointer, size_t size, cudaStream_t stream);
+  void cuda_free(void *pointer, cudaStream_t stream);
 };
 
 struct MMCVDeformConvCUDAOp

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
@@ -20,7 +20,7 @@ struct MMCVDeformConvCUDAKernel {
   const OrtKernelInfo *info_;
   Ort::AllocatorWithDefaultOptions allocator_;
 
-  cublasHandle_t m_cublas_handle;  // TODO:: release the cublas handle?
+  cublasHandle_t cublas_handle_ = nullptr;  // TODO:: release the cublas handle?
 
   int64_t stride_height_;
   int64_t stride_width_;

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv.h
@@ -41,7 +41,7 @@ struct MMCVDeformConvCUDAOp
     return new MMCVDeformConvCUDAKernel(api, info);
   }
 
-  const char *GetName() const { return "DeformConv2d"; };
+  const char *GetName() const { return "DeformableConv2D"; };
 
   size_t GetInputTypeCount() const { return 3; };
   ONNXTensorElementDataType GetInputType(size_t /*index*/) const {

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cu
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cu
@@ -1,0 +1,172 @@
+/*!
+ ******************* BEGIN Caffe Copyright Notice and Disclaimer
+ *****************
+ *
+ * COPYRIGHT
+ *
+ * All contributions by the University of California:
+ * Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+ * All rights reserved.
+ *
+ * All other contributions:
+ * Copyright (c) 2014-2017, the respective contributors
+ * All rights reserved.
+ *
+ * Caffe uses a shared copyright model: each contributor holds copyright over
+ * their contributions to Caffe. The project versioning records all such
+ * contribution and copyright details. If a contributor wants to further mark
+ * their specific copyright on a particular contribution, they should indicate
+ * their copyright solely in the commit message of the change when it is
+ * committed.
+ *
+ * LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * CONTRIBUTION AGREEMENT
+ *
+ * By contributing to the BVLC/caffe repository through pull-request, comment,
+ * or otherwise, the contributor releases their content to the
+ * license and copyright terms herein.
+ *
+ ***************** END Caffe Copyright Notice and Disclaimer
+ *********************
+ *
+ * Copyright (c) 2018 Microsoft
+ * Licensed under The MIT License [see LICENSE for details]
+ * \file modulated_deformable_im2col.cuh
+ * \brief Function definitions of converting an image to
+ * column matrix based on kernel, padding, dilation, and offset.
+ * These functions are mainly used in deformable convolution operators.
+ * \ref: https://arxiv.org/abs/1703.06211
+ * \author Yuwen Xiong, Haozhi Qi, Jifeng Dai, Xizhou Zhu, Han Hu, Dazhi Cheng
+ */
+
+// modified from
+// https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/blob/mmdetection/mmdet/ops/dcn/src/deform_conv_cuda_kernel.cu
+
+#include "common_cuda_helper.cuh"
+#include "deform_conv_kernel.cuh"
+#include "deform_conv_kernel.hpp"
+#include "ort_utils.h"
+
+template <typename scalar_t>
+void deform_conv_im2col(const scalar_t* input, const scalar_t* offset, scalar_t* column,
+                        const int channels, const int height, const int width, const int ksize_h,
+                        const int ksize_w, const int pad_h, const int pad_w, const int stride_h,
+                        const int stride_w, const int dilation_h, const int dilation_w,
+                        const int parallel_imgs, const int deformable_group, cudaStream_t stream) {
+  int height_col = (height + 2 * pad_h - (dilation_h * (ksize_h - 1) + 1)) / stride_h + 1;
+  int width_col = (width + 2 * pad_w - (dilation_w * (ksize_w - 1) + 1)) / stride_w + 1;
+  int num_kernels = channels * height_col * width_col * parallel_imgs;
+  int channel_per_deformable_group = channels / deformable_group;
+
+  deformable_im2col_gpu_kernel<scalar_t><<<GET_BLOCKS(num_kernels), THREADS_PER_BLOCK, 0, stream>>>(
+      num_kernels, input, offset, height, width, ksize_h, ksize_w, pad_h, pad_w, stride_h, stride_w,
+      dilation_h, dilation_w, channel_per_deformable_group, parallel_imgs, channels,
+      deformable_group, height_col, width_col, column);
+
+  cudaCheckError();
+}
+
+template <typename scalar_t>
+void deform_conv(const scalar_t* input, const scalar_t* weight, const scalar_t* offset,
+                 scalar_t* output, void* workspace, int batchSize, int nInputPlane, int inputHeight,
+                 int inputWidth, int nOutputPlane, int kW, int kH, int dW, int dH, int padW,
+                 int padH, int dilationW, int dilationH, int group, int deformable_group,
+                 int im2col_step, cublasHandle_t cublas_handle, cudaStream_t stream) {
+  size_t word_size = sizeof(scalar_t);
+
+  im2col_step = std::min(int(batchSize), im2col_step);
+  long outputWidth = (inputWidth + 2 * padW - (dilationW * (kW - 1) + 1)) / dW + 1;
+  long outputHeight = (inputHeight + 2 * padH - (dilationH * (kH - 1) + 1)) / dH + 1;
+
+  long outputHW = outputHeight * outputWidth;
+  long kHW = kH * kW;
+  long columns_size =
+      mmdeploy::getAlignedSize(nInputPlane * kHW * im2col_step * outputHW * word_size);
+
+  // column buffer for img2col
+  char* workspace_ptr = reinterpret_cast<char*>(workspace);
+  scalar_t* columns = reinterpret_cast<scalar_t*>(workspace_ptr);
+  workspace_ptr = workspace_ptr + columns_size;
+
+  scalar_t* output_buffer;
+  if (im2col_step == 1) {
+    output_buffer = output;
+  } else {
+    // output need permute when im2col_step!=1
+    output_buffer = reinterpret_cast<scalar_t*>(workspace_ptr);
+  }
+
+  long input_elt_step = im2col_step * nInputPlane * inputHeight * inputWidth;
+  long offset_elt_step = im2col_step * deformable_group * 2 * kHW * outputHW;
+  long out_buffer_step = nOutputPlane * im2col_step * outputHW;
+  long col_g_step = nInputPlane * kHW * im2col_step * outputHW / group;
+  long weight_g_step = nOutputPlane * nInputPlane * kHW / (group * group);
+  long out_buffer_g_step = out_buffer_step / group;
+  int m = nOutputPlane / group;
+  int n = im2col_step * outputHW;
+  int k = nInputPlane * kHW / group;
+  scalar_t alpha = 1.f;
+  scalar_t beta = 0.f;
+
+  for (int elt = 0; elt < batchSize / im2col_step; elt++) {
+    const scalar_t* input_start = input + elt * input_elt_step;
+    const scalar_t* offset_start = offset + elt * offset_elt_step;
+
+    deform_conv_im2col<scalar_t>(input_start, offset_start, columns, nInputPlane, inputHeight,
+                                 inputWidth, kH, kW, padH, padW, dH, dW, dilationH, dilationW,
+                                 im2col_step, deformable_group, stream);
+
+    for (int g = 0; g < group; ++g) {
+      const scalar_t* weight_start = weight + g * weight_g_step;
+      scalar_t* col_start = columns + g * col_g_step;
+      scalar_t* out_buffer_start = output_buffer + elt * out_buffer_step + g * out_buffer_g_step;
+
+      cublasGemmWrap<scalar_t>(cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha, col_start,
+                               n, weight_start, k, &beta, out_buffer_start, n);
+      cudaCheckError();
+    }
+  }
+
+  if (im2col_step != 1) {
+    int output_buffer_shape[5] = {batchSize / im2col_step, nOutputPlane, im2col_step,
+                                  static_cast<int>(outputHeight), static_cast<int>(outputWidth)};
+    int output_buffer_permute[5] = {0, 2, 1, 3, 4};
+    memcpyPermute<scalar_t>(output, output_buffer, &output_buffer_shape[0],
+                            &output_buffer_permute[0], 5, stream);
+  }
+}
+
+template void deform_conv<float>(const float* input, const float* weight, const float* offset,
+                                 float* output, void* workspace, int batchSize, int nInputPlane,
+                                 int inputHeight, int inputWidth, int nOutputPlane, int kW, int kH,
+                                 int dW, int dH, int padW, int padH, int dilationW, int dilationH,
+                                 int group, int deformable_group, int im2col_step,
+                                 cublasHandle_t cublas_handle, cudaStream_t stream);
+
+template void deform_conv<__half>(const __half* input, const __half* weight, const __half* offset,
+                                  __half* output, void* workspace, int batchSize, int nInputPlane,
+                                  int inputHeight, int inputWidth, int nOutputPlane, int kW, int kH,
+                                  int dW, int dH, int padW, int padH, int dilationW, int dilationH,
+                                  int group, int deformable_group, int im2col_step,
+                                  cublasHandle_t cublas_handle, cudaStream_t stream);

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cu
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cu
@@ -63,7 +63,7 @@
 // modified from
 // https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/blob/mmdetection/mmdet/ops/dcn/src/deform_conv_cuda_kernel.cu
 
-#include "common_cuda_helper.cuh"
+#include "common_cuda_helper.hpp"
 #include "deform_conv_kernel.cuh"
 #include "deform_conv_kernel.hpp"
 #include "ort_utils.h"

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cuh
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cuh
@@ -65,7 +65,7 @@
 
 #include <cuda_fp16.h>
 
-#include "common_cuda_helper.cuh"
+#include "common_cuda_helper.hpp"
 
 template <typename scalar_t>
 __device__ __forceinline__ scalar_t deformable_im2col_bilinear(const scalar_t* __restrict__ input,

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cuh
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.cuh
@@ -1,0 +1,174 @@
+/*!
+ ******************* BEGIN Caffe Copyright Notice and Disclaimer
+ *****************
+ *
+ * COPYRIGHT
+ *
+ * All contributions by the University of California:
+ * Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+ * All rights reserved.
+ *
+ * All other contributions:
+ * Copyright (c) 2014-2017, the respective contributors
+ * All rights reserved.
+ *
+ * Caffe uses a shared copyright model: each contributor holds copyright over
+ * their contributions to Caffe. The project versioning records all such
+ * contribution and copyright details. If a contributor wants to further mark
+ * their specific copyright on a particular contribution, they should indicate
+ * their copyright solely in the commit message of the change when it is
+ * committed.
+ *
+ * LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ *FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * CONTRIBUTION AGREEMENT
+ *
+ * By contributing to the BVLC/caffe repository through pull-request, comment,
+ * or otherwise, the contributor releases their content to the
+ * license and copyright terms herein.
+ *
+ ***************** END Caffe Copyright Notice and Disclaimer
+ *********************
+ *
+ * Copyright (c) 2018 Microsoft
+ * Licensed under The MIT License [see LICENSE for details]
+ * \file modulated_deformable_im2col.cuh
+ * \brief Function definitions of converting an image to
+ * column matrix based on kernel, padding, dilation, and offset.
+ * These functions are mainly used in deformable convolution operators.
+ * \ref: https://arxiv.org/abs/1703.06211
+ * \author Yuwen Xiong, Haozhi Qi, Jifeng Dai, Xizhou Zhu, Han Hu, Dazhi Cheng
+ */
+
+// modified from
+// https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/blob/mmdetection/mmdet/ops/dcn/src/deform_conv_cuda_kernel.cu
+
+#include <cuda_fp16.h>
+
+#include "common_cuda_helper.cuh"
+
+template <typename scalar_t>
+__device__ __forceinline__ scalar_t deformable_im2col_bilinear(const scalar_t* __restrict__ input,
+                                                               const int height, const int width,
+                                                               float h, float w) {
+  if (h <= -1 || height <= h || w <= -1 || width <= w) {
+    return 0;
+  }
+
+  const int h_low = floorf(h);
+  const int w_low = floorf(w);
+
+  input += h_low * width;
+  const scalar_t v1 = (h_low >= 0 && w_low >= 0) ? input[w_low] : static_cast<scalar_t>(0.0f);
+  const int w_high = w_low + 1;
+  const scalar_t v2 =
+      (h_low >= 0 && w_high <= width - 1) ? input[w_high] : static_cast<scalar_t>(0.0f);
+  const scalar_t lw = w - w_low;
+  const scalar_t v_low = fmaf(v2 - v1, lw, v1);
+  input += width;
+  const scalar_t v3 =
+      (h_low <= height - 2 && w_low >= 0) ? input[w_low] : static_cast<scalar_t>(0.0f);
+  const scalar_t v4 =
+      (h_low <= height - 2 && w_high <= width - 1) ? input[w_high] : static_cast<scalar_t>(0.0f);
+  const scalar_t v_high = fmaf(v4 - v3, lw, v3);
+  const scalar_t lh = h - h_low;
+  const scalar_t val = fmaf(v_high - v_low, lh, v_low);
+  return val;
+}
+
+template <>
+__device__ __forceinline__ __half deformable_im2col_bilinear(const __half* __restrict__ input,
+                                                             const int height, const int width,
+                                                             float h, float w) {
+  if (h <= -1 || height <= h || w <= -1 || width <= w) {
+    return 0;
+  }
+
+  const int h_low = floorf(h);
+  const int w_low = floorf(w);
+
+  input += h_low * width;
+  const float v1 = (h_low >= 0 && w_low >= 0) ? __half2float(input[w_low]) : 0.0f;
+  const int w_high = w_low + 1;
+  const float v2 = (h_low >= 0 && w_high <= width - 1) ? __half2float(input[w_high]) : 0.0f;
+  const float lw = w - w_low;
+  const float v_low = fmaf(v2 - v1, lw, v1);
+  input += width;
+  const float v3 = (h_low <= height - 2 && w_low >= 0) ? __half2float(input[w_low]) : 0.0f;
+  const float v4 =
+      (h_low <= height - 2 && w_high <= width - 1) ? __half2float(input[w_high]) : 0.0f;
+  const float v_high = fmaf(v4 - v3, lw, v3);
+  const float lh = h - h_low;
+  const float val = fmaf(v_high - v_low, lh, v_low);
+  return __float2half(val);
+}
+
+template <typename scalar_t>
+__global__ void deformable_im2col_gpu_kernel(
+    const int n, const scalar_t* __restrict__ data_im, const scalar_t* __restrict__ data_offset,
+    const int height, const int width, const int kernel_h, const int kernel_w, const int pad_h,
+    const int pad_w, const int stride_h, const int stride_w, const int dilation_h,
+    const int dilation_w, const int channel_per_deformable_group, const int batch_size,
+    const int num_channels, const int deformable_group, const int height_col, const int width_col,
+    scalar_t* __restrict__ data_col) {
+  const int hw_col = height_col * width_col;
+  const int data_col_step = batch_size * hw_col;
+
+  CUDA_1D_KERNEL_LOOP(index, n) {
+    // index index of output matrix
+    int tmp_index = index;
+    const int w_col = tmp_index % width_col;
+    tmp_index /= width_col;
+    const int h_col = tmp_index % height_col;
+    tmp_index /= height_col;
+    const int b_col = tmp_index % batch_size;
+    const int c_im = tmp_index / batch_size;
+    const int c_col = c_im * kernel_h * kernel_w;
+
+    // compute deformable group index
+    const int deformable_group_index = c_im / channel_per_deformable_group;
+
+    const int h_in = h_col * stride_h - pad_h;
+    const int w_in = w_col * stride_w - pad_w;
+    scalar_t* __restrict__ data_col_ptr = data_col + c_col * data_col_step + index % data_col_step;
+    const scalar_t* __restrict__ data_im_ptr =
+        data_im + (b_col * num_channels + c_im) * height * width;
+    const scalar_t* __restrict__ data_offset_ptr =
+        data_offset +
+        ((b_col * deformable_group + deformable_group_index) << 1) * kernel_h * kernel_w * hw_col +
+        h_col * width_col + w_col;
+    for (int i = 0; i < kernel_h; ++i) {
+      for (int j = 0; j < kernel_w; ++j) {
+        const int data_offset_h = (i * kernel_w + j) * hw_col << 1;
+        const scalar_t offset_h = data_offset_ptr[data_offset_h];
+        const int data_offset_w = data_offset_h + hw_col;
+        const scalar_t offset_w = data_offset_ptr[data_offset_w];
+        const scalar_t h_im = h_in + i * dilation_h + (float)offset_h;
+        const scalar_t w_im = w_in + j * dilation_w + (float)offset_w;
+        const scalar_t val = deformable_im2col_bilinear(data_im_ptr, height, width, h_im, w_im);
+        *data_col_ptr = val;
+        data_col_ptr += data_col_step;
+      }
+    }
+  }
+}

--- a/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.hpp
+++ b/csrc/mmdeploy/backend_ops/onnxruntime/deform_conv/cuda/deform_conv_kernel.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) OpenMMLab. All rights reserved
+#ifndef ORT_DEFORM_CONV_KERNEL_HPP
+#define ORT_DEFORM_CONV_KERNEL_HPP
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+template <typename scalar_t>
+void deform_conv_im2col(const scalar_t* input, const scalar_t* offset, scalar_t* column,
+                        const int channels, const int height, const int width, const int ksize_h,
+                        const int ksize_w, const int pad_h, const int pad_w, const int stride_h,
+                        const int stride_w, const int dilation_h, const int dilation_w,
+                        const int parallel_imgs, const int deformable_group, cudaStream_t stream);
+
+template <typename scalar_t>
+void deform_conv(const scalar_t* input, const scalar_t* weight, const scalar_t* offset,
+                 scalar_t* output, void* workspace, int batchSize, int nInputPlane, int inputHeight,
+                 int inputWidth, int nOutputPlane, int kW, int kH, int dW, int dH, int padW,
+                 int padH, int dilationW, int dilationH, int group, int deformable_group,
+                 int im2col_step, cublasHandle_t cublas_handle, cudaStream_t stream);
+#endif  // ORT_DEFORM_CONV_KERNEL_HPP


### PR DESCRIPTION
## Motivation
 `DeformConv2D` customOp is missing in Onnxruntime, which blocks our Object Detection model deployment using Onnxruntime

## Modification

adding `DeformConv2D` customOp for Onnxruntime
- added CPU implementation, adopted from mmcv repo, onnxruntime
- added CUDA implementation, adopted from mmdeploy repo, backend_ops/tensorrt folder

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
