### PR TITLE
[bugfix] rename forward_test to predict

### DIFF
--- a/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection_model.py
@@ -352,7 +352,7 @@ class PartitionSingleStageModel(End2EndModel):
         ret = [r.cpu() for r in ret]
         return ret
 
-    def forward_test(self, imgs: Tensor, *args, **kwargs):
+    def predict(self, imgs: Tensor, *args, **kwargs):
         """Implement forward test.
 
         Args:
@@ -517,8 +517,8 @@ class PartitionTwoStageModel(End2EndModel):
             img_metas[0][0]['scale_factor'],
             cfg=rcnn_test_cfg)
 
-    def forward_test(self, imgs: Tensor, img_metas: Sequence[dict], *args,
-                     **kwargs):
+    def predict(self, imgs: Tensor, img_metas: Sequence[dict], *args,
+                **kwargs):
         """Implement forward test.
 
         Args:


### PR DESCRIPTION
## Motivation

Make inference possible with partition model as well as End2EndModel.

## Modification

Fixed predict function name of PartitionSingleStageModel and PartitionTwoStageModel from forward_test to predict.

## BC-breaking (Optional)

Nothing.

## Use cases (Optional)

Adding no feature.

## Checklist

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
  - This function does not depend on other projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
  - Document of prediction functions are same as other models.
