### PR TITLE
Fixed miniconda.sh errors in Dockerfile

### DIFF
--- a/docker/CPU/Dockerfile
+++ b/docker/CPU/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
     chmod +x ~/miniconda.sh && \
-    ~/miniconda.sh -b -p /opt/conda && \
+    bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
     /opt/conda/bin/conda install -y python=${PYTHON_VERSION} conda-build pyyaml numpy ipython cython typing typing_extensions mkl mkl-include ninja && \
     /opt/conda/bin/conda clean -ya

--- a/docker/GPU/Dockerfile
+++ b/docker/GPU/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update &&\
 
 RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
     chmod +x ~/miniconda.sh && \
-    ~/miniconda.sh -b -p /opt/conda && \
+    bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
     /opt/conda/bin/conda install -y python=${PYTHON_VERSION} conda-build pyyaml numpy ipython cython typing typing_extensions mkl mkl-include ninja && \
     /opt/conda/bin/conda clean -ya


### PR DESCRIPTION
When building the Docker image following the official instructions

```
docker build docker/CPU/ -t mmdeploy:master-cpu
```

it fails to run /root/minicnoda.sh with the following errors

```
Downloading and Extracting Packages


Downloading and Extracting Packages

Preparing transaction: ...working... done
Executing transaction: ...working... done
/root/miniconda.sh: 438: /root/miniconda.sh: [[: not found

Installing * environment...

/root/miniconda.sh: 444: /root/miniconda.sh: [[: not found

```

This PR fixes it by calling the script explicitly with bash.