### PR TITLE
[Feature] The float type is supported for the scale factor argument of interpolate_tensorrt.

### DIFF
--- a/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
@@ -42,10 +42,10 @@ nvinfer1::DimsExprs TRTBicubicInterpolate::getOutputDimensions(
   ret.nbDims = 4;
   ret.d[0] = inputs[0].d[0];
   ret.d[1] = inputs[0].d[1];
-  auto height = (double) inputs[0].d[2]->getConstantValue();
-  auto width = (double) inputs[0].d[3]->getConstantValue();
-  auto outHeight = (int) height * mScaleFactor[0];
-  auto outWidth = (int) width * mScaleFactor[1];
+  auto height = (double)inputs[0].d[2]->getConstantValue();
+  auto width = (double)inputs[0].d[3]->getConstantValue();
+  auto outHeight = (int)height * mScaleFactor[0];
+  auto outWidth = (int)width * mScaleFactor[1];
   ret.d[2] = exprBuilder.constant(outHeight);
   ret.d[3] = exprBuilder.constant(outWidth);
   return ret;

--- a/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
@@ -42,13 +42,12 @@ nvinfer1::DimsExprs TRTBicubicInterpolate::getOutputDimensions(
   ret.nbDims = 4;
   ret.d[0] = inputs[0].d[0];
   ret.d[1] = inputs[0].d[1];
-  auto height = exprBuilder.constant(mScaleFactor[0]);
-  auto width = exprBuilder.constant(mScaleFactor[1]);
-  auto d2 = exprBuilder.operation(DimensionOperation::kPROD, *inputs[0].d[2], *height);
-  auto d3 = exprBuilder.operation(DimensionOperation::kPROD, *inputs[0].d[3], *width);
-  ret.d[2] = d2;
-  ret.d[3] = d3;
-
+  auto height = (double) inputs[0].d[2]->getConstantValue();
+  auto width = (double) inputs[0].d[3]->getConstantValue();
+  auto outHeight = (int) height * mScaleFactor[0];
+  auto outWidth = (int) width * mScaleFactor[1];
+  ret.d[2] = exprBuilder.constant(outHeight);
+  ret.d[3] = exprBuilder.constant(outWidth);
   return ret;
 }
 


### PR DESCRIPTION
The existing scale factor of bicubic_interpolate supported only int type. But PyTorch interpolate also supports float type. So, it has been changed to support the float type as well.
Please let me know if there are any deficiencies.