### PR TITLE
Cherry-pick #1439 to fix 'topk' on different devices for onnxruntime-gpu inference

### DIFF
--- a/mmdeploy/pytorch/functions/topk.py
+++ b/mmdeploy/pytorch/functions/topk.py
@@ -17,7 +17,7 @@ def topk__dynamic(input: torch.Tensor,
                   sorted: bool = True):
     """Rewrite `topk` for default backend.
 
-    Cast k to tensor and makesure k is smaller than input.shape[dim].
+    Cast k to tensor and make sure k is smaller than input.shape[dim].
     """
     ctx = FUNCTION_REWRITER.get_context()
 
@@ -28,7 +28,8 @@ def topk__dynamic(input: torch.Tensor,
         k = torch.tensor(k, device=input.device, dtype=torch.long)
     # Always keep topk op for dynamic input
     if isinstance(size, torch.Tensor):
-        size = size.to(input.device)
+        # size would be treated as cpu tensor, trick to avoid that.
+        size = k.new_zeros(()) + size
     k = torch.where(k < size, k, size)
     return ctx.origin_func(input, k, dim=dim, largest=largest, sorted=sorted)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

#1586 

## Modification

Same as #1439 

## BC-breaking (Optional)

None.

## Use cases (Optional)

Same as #1439 

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
