### PR TITLE
[Feature] The float type is supported for the scale factor argument of interpolate_tensorrt.

### DIFF
--- a/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
@@ -89,12 +89,14 @@ int TRTBicubicInterpolate::enqueue(const nvinfer1::PluginTensorDesc *inputDesc,
   const void *x = inputs[0];
   void *output = outputs[0];
 
+  float height_scale = mScaleFactor[0];
+  float width_scale = mScaleFactor[1];
   // TODO: add fp16 support
   auto data_type = inputDesc[0].type;
   switch (data_type) {
     case nvinfer1::DataType::kFLOAT:
       bicubic_interpolate<float>((float *)x, (float *)output, batch, channels, height, width,
-                                 height_out, width_out, mAlignCorners, stream);
+                                 height_out, width_out, height_scale, width_scale, mAlignCorners, stream);
       break;
     default:
       return 1;

--- a/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
@@ -42,10 +42,10 @@ nvinfer1::DimsExprs TRTBicubicInterpolate::getOutputDimensions(
   ret.nbDims = 4;
   ret.d[0] = inputs[0].d[0];
   ret.d[1] = inputs[0].d[1];
-  auto height = (double) inputs[0].d[2]->getConstantValue();
-  auto width = (double) inputs[0].d[3]->getConstantValue();
-  auto outHeight = (int) height * mScaleFactor[0];
-  auto outWidth = (int) width * mScaleFactor[1];
+  auto height = (double)inputs[0].d[2]->getConstantValue();
+  auto width = (double)inputs[0].d[3]->getConstantValue();
+  auto outHeight = (int)height * mScaleFactor[0];
+  auto outWidth = (int)width * mScaleFactor[1];
   ret.d[2] = exprBuilder.constant(outHeight);
   ret.d[3] = exprBuilder.constant(outWidth);
   return ret;

--- a/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.cpp
@@ -42,13 +42,12 @@ nvinfer1::DimsExprs TRTBicubicInterpolate::getOutputDimensions(
   ret.nbDims = 4;
   ret.d[0] = inputs[0].d[0];
   ret.d[1] = inputs[0].d[1];
-  auto height = exprBuilder.constant(mScaleFactor[0]);
-  auto width = exprBuilder.constant(mScaleFactor[1]);
-  auto d2 = exprBuilder.operation(DimensionOperation::kPROD, *inputs[0].d[2], *height);
-  auto d3 = exprBuilder.operation(DimensionOperation::kPROD, *inputs[0].d[3], *width);
-  ret.d[2] = d2;
-  ret.d[3] = d3;
-
+  auto height = (double) inputs[0].d[2]->getConstantValue();
+  auto width = (double) inputs[0].d[3]->getConstantValue();
+  auto outHeight = (int) height * mScaleFactor[0];
+  auto outWidth = (int) width * mScaleFactor[1];
+  ret.d[2] = exprBuilder.constant(outHeight);
+  ret.d[3] = exprBuilder.constant(outWidth);
   return ret;
 }
 

--- a/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.hpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate.hpp
@@ -10,7 +10,7 @@
 namespace mmdeploy {
 class TRTBicubicInterpolate : public TRTPluginBase {
  public:
-  TRTBicubicInterpolate(const std::string &name, std::vector<float> scale_factor,
+  TRTBicubicInterpolate(const std::string &name, std::vector<int> output_size, std::vector<float> scale_factor,
                         bool align_corners);
 
   TRTBicubicInterpolate(const std::string name, const void *data, size_t length);
@@ -46,6 +46,7 @@ class TRTBicubicInterpolate : public TRTPluginBase {
   void serialize(void *buffer) const TRT_NOEXCEPT override;
 
  private:
+  std::vector<int> mOutputSize;
   std::vector<float> mScaleFactor;
   bool mAlignCorners;
 };
@@ -57,10 +58,10 @@ class TRTBicubicInterpolateCreator : public TRTPluginCreatorBase {
   const char *getPluginName() const TRT_NOEXCEPT override;
 
   const char *getPluginVersion() const TRT_NOEXCEPT override;
-  nvinfer1::IPluginV2 *createPlugin(const char *name, const nvinfer1::PluginFieldCollection *fc)
+  nvinfer1::IPluginV2DynamicExt *createPlugin(const char *name, const nvinfer1::PluginFieldCollection *fc)
       TRT_NOEXCEPT override;
 
-  nvinfer1::IPluginV2 *deserializePlugin(const char *name, const void *serialData,
+  nvinfer1::IPluginV2DynamicExt *deserializePlugin(const char *name, const void *serialData,
                                          size_t serialLength) TRT_NOEXCEPT override;
 };
 }  // namespace mmdeploy

--- a/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate_kernel.hpp
+++ b/csrc/mmdeploy/backend_ops/tensorrt/bicubic_interpolate/trt_bicubic_interpolate_kernel.hpp
@@ -7,5 +7,6 @@
 template <typename scalar_t>
 void bicubic_interpolate(const scalar_t *input, scalar_t *output, int batch, int channels,
                          int in_height, int in_width, int out_height, int out_width,
+                         scalar_t height_scale, scalar_t width_scale,
                          bool align_corners, cudaStream_t stream);
 #endif  // TRT_BICUBIC_INTERPOLATE_KERNEL_HPP

--- a/tests/test_ops/test_ops.py
+++ b/tests/test_ops/test_ops.py
@@ -115,7 +115,7 @@ def test_grid_sample(backend,
 @pytest.mark.parametrize('mode', ['bicubic', 'nearest'])
 @pytest.mark.parametrize('align_corners', [True, False])
 @pytest.mark.parametrize('output_size', [[10, 20], None])
-@pytest.mark.parametrize('scale_factor', [2])
+@pytest.mark.parametrize('scale_factor', [2, 2.25])
 @pytest.mark.parametrize('n, c, h, w', [(2, 3, 5, 10)])
 def test_bicubic_interpolate(backend,
                              dynamic_export,

--- a/tests/test_pytorch/test_pytorch_functions.py
+++ b/tests/test_pytorch/test_pytorch_functions.py
@@ -148,7 +148,7 @@ def test_bicubic_interpolate__tensorrt():
     input = torch.randn([1, 2, 2, 2])
 
     def model_func(input):
-        return F.interpolate(input, scale_factor=[1.5, 1.5], mode='bicubic')
+        return F.interpolate(input, scale_factor=[1.5, 1.5], mode='bicubic', align_corners=False)
 
     model_output = model_func(input)
     wrapped_func = WrapFunction(model_func)
@@ -162,8 +162,7 @@ def test_bicubic_interpolate__tensorrt():
 
     if is_backend_output:
         output = output[0].detach().cpu()
-
-        assert np.allclose(model_output, output, rtol=1, atol=1)
+        assert np.allclose(model_output, output, rtol=1e-03, atol=1e-05)
     else:
         assert output is not None
 

--- a/tests/test_pytorch/test_pytorch_functions.py
+++ b/tests/test_pytorch/test_pytorch_functions.py
@@ -143,30 +143,6 @@ def test_interpolate__rknn():
     assert np.allclose(model_output, rewrite_output[0], rtol=1e-03, atol=1e-05)
 
 
-@backend_checker(Backend.TENSORRT)
-def test_bicubic_interpolate__tensorrt():
-    input = torch.randn([1, 2, 2, 2])
-
-    def model_func(input):
-        return F.interpolate(input, scale_factor=[1.5, 1.5], mode='bicubic', align_corners=False)
-
-    model_output = model_func(input)
-    wrapped_func = WrapFunction(model_func)
-
-    # mmdeploy.pytorch.functions.interpolate.interpolate__tensorrt
-    deploy_cfg_tensorrt = get_trt_config(['values'], [1, 2, 2, 2])
-    output, is_backend_output = get_rewrite_outputs(
-        wrapped_func,
-        model_inputs={'input': input},
-        deploy_cfg=deploy_cfg_tensorrt)
-
-    if is_backend_output:
-        output = output[0].detach().cpu()
-        assert np.allclose(model_output, output, rtol=1e-03, atol=1e-05)
-    else:
-        assert output is not None
-
-
 @backend_checker(Backend.NCNN)
 def test_linear_ncnn():
     input = torch.rand([1, 2, 2])
@@ -259,6 +235,7 @@ def test_size__ascend():
 
 
 class TestTopk:
+
     input = torch.rand(1, 5, 5, 5)
 
     @backend_checker(Backend.NCNN)
@@ -314,6 +291,7 @@ class TestTopk:
 @pytest.mark.parametrize('shape', [[2, 2], [4, 2], [2, 4], [2, 4, 2]])
 @pytest.mark.parametrize('diagonal', [0, 1, -1])
 def test_triu_trt(shape, diagonal):
+
     input = torch.rand(shape)
     model_output = torch.triu(input=input, diagonal=diagonal)
 
@@ -360,6 +338,7 @@ def test_normalize_ncnn(input, dim):
 
 @backend_checker(Backend.ASCEND)
 def test_getitem__ascend():
+
     input = torch.rand(1, 2, 3)
 
     def tensor_getitem(x):


### PR DESCRIPTION
The existing scale factor of bicubic_interpolate supported only int type. But PyTorch interpolate also supports float type. So, it has been changed to support the float type as well.
Please let me know if there are any deficiencies.