### PR TITLE
[Fix] Fix aligned allocations on Android

### DIFF
--- a/csrc/mmdeploy/device/cpu/cpu_device.cpp
+++ b/csrc/mmdeploy/device/cpu/cpu_device.cpp
@@ -12,12 +12,13 @@ class CpuHostMemory : public NonCopyable {
   CpuHostMemory() : size_(), data_(), owned_data_{false} {}
   Result<void> Init(size_t size, size_t alignment) {
     alignment = std::max(alignment, sizeof(void*));
+    auto space = (size + alignment - 1) / alignment * alignment;
 #ifdef _MSC_VER
-    data_ = _aligned_malloc(size, alignment);
+    data_ = _aligned_malloc(space, alignment);
 #elif defined(ANDROID)
-    posix_memalign(&data_, alignment, size);
+    posix_memalign(&data_, alignment, space);
 #else
-    data_ = std::aligned_alloc(alignment, size);
+    data_ = std::aligned_alloc(alignment, space);
 #endif
     if (!data_) {
       return Status(eOutOfMemory);

--- a/csrc/mmdeploy/device/cpu/cpu_device.cpp
+++ b/csrc/mmdeploy/device/cpu/cpu_device.cpp
@@ -11,9 +11,11 @@ class CpuHostMemory : public NonCopyable {
  public:
   CpuHostMemory() : size_(), data_(), owned_data_{false} {}
   Result<void> Init(size_t size, size_t alignment) {
-    size_t space = (size + alignment - 1) / alignment * alignment;
+    alignment = std::max(alignment, sizeof(void*));
 #ifdef _MSC_VER
     data_ = _aligned_malloc(space, alignment);
+#elif defined(ANDROID)
+    posix_memalign(&data_, alignment, size);
 #else
     data_ = std::aligned_alloc(alignment, space);
 #endif

--- a/csrc/mmdeploy/device/cpu/cpu_device.cpp
+++ b/csrc/mmdeploy/device/cpu/cpu_device.cpp
@@ -13,11 +13,11 @@ class CpuHostMemory : public NonCopyable {
   Result<void> Init(size_t size, size_t alignment) {
     alignment = std::max(alignment, sizeof(void*));
 #ifdef _MSC_VER
-    data_ = _aligned_malloc(space, alignment);
+    data_ = _aligned_malloc(size, alignment);
 #elif defined(ANDROID)
     posix_memalign(&data_, alignment, size);
 #else
-    data_ = std::aligned_alloc(alignment, space);
+    data_ = std::aligned_alloc(alignment, size);
 #endif
     if (!data_) {
       return Status(eOutOfMemory);


### PR DESCRIPTION
Use `posix_memalign` on Android platform, and set minimum alignment to `sizeof(void*)`

- `std::aligned_alloc` is not available in all versions of NDK toolchains.
- Allocation APIs may fail if `alignment` is too small.
- `new` and `malloc` are aligned to `sizeof(void*)` anyway.

https://en.cppreference.com/w/cpp/memory/c/aligned_alloc