### PR TITLE
[Fix] Substitute SyncBN with BN for mmpose

### DIFF
--- a/mmdeploy/codebase/mmpose/deploy/pose_detection.py
+++ b/mmdeploy/codebase/mmpose/deploy/pose_detection.py
@@ -158,9 +158,12 @@ class PoseDetection(BaseTask):
         Returns:
             nn.Module: An initialized pytorch model.
         """
+        from mmengine.model import revert_sync_batchnorm
         from mmpose.apis import init_model
         from mmpose.utils import register_all_modules
+
         register_all_modules()
+
         self.model_cfg.model.test_cfg['flip_test'] = False
 
         model = init_model(
@@ -168,6 +171,9 @@ class PoseDetection(BaseTask):
             model_checkpoint,
             device=self.device,
             cfg_options=cfg_options)
+        model = revert_sync_batchnorm(model)
+        model = model.to(self.device)
+        model.eval()
         return model
 
     def build_backend_model(

--- a/mmdeploy/codebase/mmpose/deploy/pose_detection.py
+++ b/mmdeploy/codebase/mmpose/deploy/pose_detection.py
@@ -145,36 +145,7 @@ class PoseDetection(BaseTask):
     def __init__(self, model_cfg: mmengine.Config, deploy_cfg: mmengine.Config,
                  device: str):
         super().__init__(model_cfg, deploy_cfg, device)
-
-    def build_pytorch_model(self,
-                            model_checkpoint: Optional[str] = None,
-                            cfg_options: Optional[Dict] = None,
-                            **kwargs) -> torch.nn.Module:
-        """build pytorch model from model config and checkpoint
-        Args:
-            model_checkpoint (str|None): Input model checkpoint file.
-            cfg_options (dict|None): Optional config arguments.
-
-        Returns:
-            nn.Module: An initialized pytorch model.
-        """
-        from mmengine.model import revert_sync_batchnorm
-        from mmpose.apis import init_model
-        from mmpose.utils import register_all_modules
-
-        register_all_modules()
-
         self.model_cfg.model.test_cfg['flip_test'] = False
-
-        model = init_model(
-            self.model_cfg,
-            model_checkpoint,
-            device=self.device,
-            cfg_options=cfg_options)
-        model = revert_sync_batchnorm(model)
-        model = model.to(self.device)
-        model.eval()
-        return model
 
     def build_backend_model(
             self,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

All other codebases can substitute SyncBN with BN in `build_pytorch_model` function from the `BaseTask` class, while mmpose overwrites the `build_pytorch_model` function without substitute SyncBN with BN. It will failed on RTMPose deployment. 

## Modification

Call the mmengine API `revert_sync_batchnorm` in mmpose `build_pytorch_model` function.

## BC-breaking (Optional)

None.

## Use cases (Optional)

RTMPose deployment.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
