### PR TITLE
[WIP] Upload Coverage To Codecov From CircleCI

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -4,6 +4,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@4.1
+  codecov: codecov/codecov@3.2.3
 
 # the default pipeline parameters, which will be updated according to
 # the results of the path-filtering orb
@@ -122,6 +123,7 @@ commands:
             coverage xml
             coverage report -m
             cd ..
+      - codecov/upload
 jobs:
   lint:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -123,7 +123,7 @@ commands:
             coverage xml
             coverage report -m
             cd ..
-      - codecov/upload
+
 jobs:
   lint:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
@@ -263,6 +263,9 @@ jobs:
       - install_mmdeploy
       - install_model_converter_req
       - perform_model_converter_ut
+      - codecov/upload:
+          flags: unittests
+          upload_name: linux_tensorrt
       - run:
           name: Perform SDK unittests
           command: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+# See: https://docs.codecov.com/docs/codecovyml-reference
+
 comment:
   layout: "reach, diff, flags, files"
   behavior: default


### PR DESCRIPTION
## Motivation
upload coverage from circleci

## Modification

add orbs in circleCI: codecov
add config file: codecov.yml

## Use cases (Optional)

1. How to upload coverage info in circleCI?
    add step [codecov/upload] after collecting coverage info and get file
    see docs: https://circleci.com/developer/orbs/orb/codecov/codecov
2. How to see the coverage info that was uploaded in circleCI?
    visit https://app.codecov.io/github/open-mmlab/mmdeploy/commits and search your commit or pullrequest