### PR TITLE
[Fix] Fix preprocess_model_config for CIFAR dataset

### DIFF
--- a/mmdeploy/codebase/mmcls/deploy/classification.py
+++ b/mmdeploy/codebase/mmcls/deploy/classification.py
@@ -62,9 +62,6 @@ def process_model_config(model_cfg: Config,
         if cfg.test_pipeline[0]['type'] == 'LoadImageFromFile':
             cfg.test_pipeline.pop(0)
     # check whether input_shape is valid
-    if 'CIFAR' in cfg.dataset_type:
-        # cifar dataset needs input image (32, 32)
-        cfg.test_pipeline.insert(-1, dict(type='Resize', scale=(32, 32)))
     if input_shape is not None:
         for pipeline_component in cfg.test_pipeline:
             if 'Crop' in pipeline_component['type']:
@@ -74,14 +71,6 @@ def process_model_config(model_cfg: Config,
                         logger = get_root_logger()
                         logger.warning(
                             f'`input shape` should be equal to `crop_size`: {crop_size},\
-                                but given: {input_shape}')
-            if 'Resize' in pipeline_component['type']:
-                if 'scale' in pipeline_component:
-                    size = pipeline_component['scale']
-                    if tuple(input_shape) != size:
-                        logger = get_root_logger()
-                        logger.warning(
-                            f'`input shape` should be equal to `shape`: {size},\
                                 but given: {input_shape}')
     return cfg
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The dev-1.x branch failed when deploying mmcls models using CIFAR dataset, because the test_pipeline of CIFAR dataset can not be handled in this branch.

## Modification

Fix preprocess_model_config for CIFAR dataset.

## BC-breaking (Optional)

None.

## Use cases (Optional)

```
python3 ./tools/deploy.py \
/root/workspace/external_data/code/mmdeploy/configs/mmcls/classification_tensorrt_dynamic-32x32-32x32.py \
/root/workspace/external_data/code/mmclassification/configs/resnet/resnet18_8xb16_cifar10.py \
"/root/workspace/external_data/code/mmdeploy_checkpoints/mmcls/resnetcifar/resnet18_b16x8_cifar10_20210528-bd6371c8.pth" \
"../mmclassification/demo/demo.JPEG"  \
--work-dir "../mmdeploy_regression_working_dir/mmcls/resnetcifar/tensorrt/dynamic/fp32/resnet18_b16x8_cifar10_20210528-bd6371c8"  \
--device cuda  \
--log-level INFO \
--dump-info \
--test-img ../mmclassification/tests/data/color.jpg
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
