### PR TITLE
[fix] mmcls CIFAR10/100 model evaluation

### DIFF
--- a/mmdeploy/codebase/mmcls/deploy/classification.py
+++ b/mmdeploy/codebase/mmcls/deploy/classification.py
@@ -37,7 +37,8 @@ def process_model_config(model_cfg: mmcv.Config,
 
     # check whether input_shape is valid
     if input_shape is not None:
-        if 'crop_size' in cfg.data.test.pipeline[2]:
+        if len(cfg.data.test.pipeline) >= 3 and \
+                'crop_size' in cfg.data.test.pipeline[2]:
             crop_size = cfg.data.test.pipeline[2]['crop_size']
             if tuple(input_shape) != (crop_size, crop_size):
                 logger = get_root_logger()


### PR DESCRIPTION
## Motivation

Avoid errors while evaluating CIFAR10 and CIFAR100 models.

In the [ImageNet config](https://github.com/open-mmlab/mmclassification/blob/dev-1.x/configs/_base_/datasets/imagenet_bs32.py), input shape can get by using `test_pipeline[2].crop_size`.

```py
test_pipeline = [
    dict(type='LoadImageFromFile'),
    dict(type='ResizeEdge', scale=256, edge='short'),
    dict(type='CenterCrop', crop_size=224),
    dict(type='PackClsInputs'),
]
```

However, the [CIFAR10 config](https://github.com/open-mmlab/mmclassification/blob/dev-1.x/configs/_base_/datasets/cifar100_bs16.py) has no information of input shape.

```
test_pipeline = [
    dict(type='PackClsInputs'),
]
```

Therefore, the input shape cannot be referenced and an error occurs.

```
  File "/mmdeploy/mmdeploy/apis/pytorch2onnx.py", line 64, in torch2onnx
    data, model_inputs = task_processor.create_input(
  File "/mmdeploy/mmdeploy/codebase/mmcls/deploy/classification.py", line 195, in create_input
    model_cfg = process_model_config(self.model_cfg, imgs, input_shape)
  File "/mmdeploy/mmdeploy/codebase/mmcls/deploy/classification.py", line 66, in process_model_config
    if 'crop_size' in cfg.test_pipeline[2]:
IndexError: list index out of range
```

## Modification

Added a check for `len(test_pipeline) >= 3` to skip checking the input shape when evaluating CIFAR10 and CIFAR100 models.

## BC-breaking (Optional)

Nothing

## Use cases (Optional)

Evaluate CIFAR10 and CIFAR100 models

## Checklist

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
