### PR TITLE
[Fix] Fix dbnet regression test

### DIFF
--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -316,7 +316,7 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
                     pytorch_metric.update(_metrics[ds])
                 if ds == dataset:
                     pytorch_metric.update(_metrics)
-        else:
+        if pytorch_metric == dict():
             pytorch_metric.update(_metrics)
         task_name = metafile_metric['Task']
         if task_name not in using_task:


### PR DESCRIPTION
Directly set pytorch metric when it's empty for regression_test.py.