### PR TITLE
[Fix] fix torch allocator resouce releasing

### DIFF
--- a/mmdeploy/backend/tensorrt/torch_allocator.py
+++ b/mmdeploy/backend/tensorrt/torch_allocator.py
@@ -13,6 +13,7 @@ class TorchAllocator(trt.IGpuAllocator):
 
         self.device_id = device_id
         self.mems = set()
+        self.caching_delete = torch._C._cuda_cudaCachingAllocator_raw_delete
 
     def __del__(self):
         """destructor."""
@@ -56,7 +57,6 @@ class TorchAllocator(trt.IGpuAllocator):
         if memory not in self.mems:
             return False
 
-        if hasattr(torch.cuda, 'caching_allocator_delete'):
-            torch.cuda.caching_allocator_delete(memory)
+        self.caching_delete(memory)
         self.mems.discard(memory)
         return True

--- a/mmdeploy/backend/tensorrt/torch_allocator.py
+++ b/mmdeploy/backend/tensorrt/torch_allocator.py
@@ -53,11 +53,10 @@ class TorchAllocator(trt.IGpuAllocator):
         Returns:
             bool: deallocate success.
         """
-        logger = get_root_logger()
-        logger.debug(f'deallocate {memory} with TorchAllocator.')
         if memory not in self.mems:
             return False
 
-        torch.cuda.caching_allocator_delete(memory)
+        if hasattr(torch.cuda, "caching_allocator_delete"):
+            torch.cuda.caching_allocator_delete(memory)
         self.mems.discard(memory)
         return True

--- a/mmdeploy/backend/tensorrt/torch_allocator.py
+++ b/mmdeploy/backend/tensorrt/torch_allocator.py
@@ -56,7 +56,7 @@ class TorchAllocator(trt.IGpuAllocator):
         if memory not in self.mems:
             return False
 
-        if hasattr(torch.cuda, "caching_allocator_delete"):
+        if hasattr(torch.cuda, 'caching_allocator_delete'):
             torch.cuda.caching_allocator_delete(memory)
         self.mems.discard(memory)
         return True


### PR DESCRIPTION
Reproduce codes in master branch:
```python
from mmdeploy.backend.tensorrt.wrapper import TRTWrapper
trt_model = TRTWrapper(
    '/path_to/cls/resnet/end2end.engine',
    ['output'])
input = torch.rand(1, 3, 224, 224).cuda()
output_trt = trt_model.forward({'input': input})
print(output_trt)
```
Error might triggered:
```
/mmdeploy/utils/logging.py(28): get_logger
Exception caught in deallocate(): TypeError: 'NoneType' object is not callable
```
or
```
codes/mmdeploy/mmdeploy/backend/tensorrt/torch_allocator.py(61): deallocate

[ERROR] Exception caught in deallocate(): AttributeError: 'NoneType' object has no attribute 'caching_allocator_delete'
```