### PR TITLE
fix stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,9 +5,6 @@ on:
     # check issue and pull request once at 01:30 a.m. every day
     - cron: '30 1 * * *'
 
-permissions:
-  contents: read
-
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,9 @@ on:
     # check issue and pull request once at 01:30 a.m. every day
     - cron: '30 1 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION


## Motivation
Stale workflow should have `write` permission to do job such close issues per [here](https://github.com/actions/stale#recommended-permissions).

## Modification

Reset to default permission, which changed in PR https://github.com/open-mmlab/mmdeploy/pull/1548

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
