### PR TITLE
[Enhancement] Support cmake configure when system exists multiple cuda versions.

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -31,7 +31,7 @@ if (MSVC)
         string(REGEX REPLACE ".*v[0-9]+\\.([0-9]+).*" "\\1" _MINOR $ENV{CUDA_PATH})
         if (NOT (${CMAKE_VS_PLATFORM_TOOLSET_CUDA} STREQUAL "${_MAJOR}.${_MINOR}"))
             message(FATAL_ERROR "Auto detected cuda version ${CMAKE_VS_PLATFORM_TOOLSET_CUDA}"
-                " is mismatch with ENV{CUDA_PATH} $ENV{CUDA_PATH}. Plese modify CUDA_PATH"
+                " is mismatch with ENV{CUDA_PATH} $ENV{CUDA_PATH}. Please modify CUDA_PATH"
                 " to match ${CMAKE_VS_PLATFORM_TOOLSET_CUDA} or specify cuda toolset by"
                 " cmake -T cuda=/path/to/cuda ..")
         endif ()

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -11,6 +11,37 @@ if (MSVC OR (NOT DEFINED CMAKE_CUDA_RUNTIME_LIBRARY))
     set(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 endif ()
 
+if (MSVC)
+    # no plugin in BuildCustomizations and no specify cuda toolset
+    if (NOT CMAKE_VS_PLATFORM_TOOLSET_CUDA)
+        message(FATAL_ERROR "Please install CUDA MSBuildExtensions")
+    endif ()
+
+    if (CMAKE_VS_PLATFORM_TOOLSET_CUDA_CUSTOM_DIR)
+        # find_package(CUDA) required ENV{CUDA_PATH}
+        set(ENV{CUDA_PATH} ${CMAKE_VS_PLATFORM_TOOLSET_CUDA_CUSTOM_DIR})
+    else ()
+        # we use CUDA_PATH and ignore nvcc.exe
+        # cmake will import highest cuda props version, which may not equal to CUDA_PATH
+        if (NOT (DEFINED ENV{CUDA_PATH}))
+            message(FATAL_ERROR "Please set CUDA_PATH environment variable")
+        endif ()
+
+        string(REGEX REPLACE ".*v([0-9]+)\\..*" "\\1" _MAJOR $ENV{CUDA_PATH})
+        string(REGEX REPLACE ".*v[0-9]+\\.([0-9]+).*" "\\1" _MINOR $ENV{CUDA_PATH})
+        if (NOT (${CMAKE_VS_PLATFORM_TOOLSET_CUDA} STREQUAL "${_MAJOR}.${_MINOR}"))
+            message(FATAL_ERROR "Auto detected cuda version ${CMAKE_VS_PLATFORM_TOOLSET_CUDA}"
+                " is mismatch with ENV{CUDA_PATH} $ENV{CUDA_PATH}. Plese modify CUDA_PATH"
+                " to match ${CMAKE_VS_PLATFORM_TOOLSET_CUDA} or specify cuda toolset by"
+                " cmake -T cuda=/path/to/cuda ..")
+        endif ()
+
+        if (NOT (DEFINED ENV{CUDA_PATH_V${_MAJOR}_${_MINOR}}))
+            message(FATAL_ERROR "Please set CUDA_PATH_V${_MAJOR}_${_MINOR} environment variable")
+        endif ()
+    endif ()
+endif ()
+
 # nvcc compiler settings
 find_package(CUDA REQUIRED)
 

--- a/cmake/tensorrt.cmake
+++ b/cmake/tensorrt.cmake
@@ -29,6 +29,7 @@ else ()
     message(FATAL_ERROR "Cannot find TensorRT libs")
 endif ()
 
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(TENSORRT DEFAULT_MSG TENSORRT_INCLUDE_DIR
         TENSORRT_LIBRARY)
 if (NOT TENSORRT_FOUND)


### PR DESCRIPTION
## Motivation

On windows, to support cmake use cuda as a language, one need to install cuda msbuild extensions that cuda installer provides.

When configure mmdeploy with cuda, if not specify cuda toolkit, cmake will use the highest cuda extensions found in `$(VCTargetsPath)\BuildCustomizations`. And it also need environment variable `CUDA_PATH_V{X}_{Y}` to be set.

When using `find_package(CUDA)`, it will first search `CUDA_PATH` and then the dir of `nvcc.exe` if `nvcc.exe` can be found. The search path should be compatible with used extensions.

## Usage.
- If no cuda msbuild extensions installed to vs folder
  ```bash
  cmake  -A x64 -T v142,cuda="/path/to/cuda" ..
  ```
- If multiple cuda msbuild extensions installed to vs folder
  ```bash
  cmake  -A x64 -T v142,cuda="/path/to/cuda" ..
  OR
  cmake -A x64 -T v142,cuda=x.y
  ```