### PR TITLE
Fix trtlogger instead of mm logger

### DIFF
--- a/mmdeploy/backend/tensorrt/utils.py
+++ b/mmdeploy/backend/tensorrt/utils.py
@@ -138,7 +138,7 @@ def from_onnx(onnx_model: Union[str, onnx.ModelProto],
         >>>             device_id=0)
         >>>             })
     """
-
+    from functools import partial
     if device_id != 0:
         import os
         old_cuda_device = os.environ.get('CUDA_DEVICE', None)
@@ -152,6 +152,7 @@ def from_onnx(onnx_model: Union[str, onnx.ModelProto],
     load_tensorrt_plugin()
     # create builder and network
     logger = trt.Logger(log_level)
+    trtlogger = partial(logger.log, log_level)
     builder = trt.Builder(logger)
 
     # TODO: use TorchAllocator as builder.gpu_allocator
@@ -205,18 +206,18 @@ def from_onnx(onnx_model: Union[str, onnx.ModelProto],
         max_shape = param['max_shape']
         profile.set_shape(input_name, min_shape, opt_shape, max_shape)
     if config.add_optimization_profile(profile) < 0:
-        logger.warning(f'Invalid optimization profile {profile}.')
+        trtlogger(f'Invalid optimization profile {profile}.')
 
     if fp16_mode:
         if not getattr(builder, 'platform_has_fast_fp16', True):
-            logger.warning('Platform does not has fast native fp16.')
+            trtlogger('Platform does not has fast native fp16.')
         if version.parse(trt.__version__) < version.parse('8'):
             builder.fp16_mode = fp16_mode
         config.set_flag(trt.BuilderFlag.FP16)
 
     if int8_mode:
         if not getattr(builder, 'platform_has_fast_int8', True):
-            logger.warning('Platform does not has fast native int8.')
+            trtlogger('Platform does not has fast native int8.')
         from .calib_utils import HDF5Calibrator
         config.set_flag(trt.BuilderFlag.INT8)
         assert int8_param is not None

--- a/mmdeploy/backend/tensorrt/utils.py
+++ b/mmdeploy/backend/tensorrt/utils.py
@@ -148,10 +148,15 @@ def from_onnx(onnx_model: Union[str, onnx.ModelProto],
         else:
             os.environ.pop('CUDA_DEVICE')
 
+    # build a mmdeploy logger
+    logger = get_root_logger()
     load_tensorrt_plugin()
+
+    # build a tensorrt logger
+    trt_logger = trt.Logger(log_level)
+
     # create builder and network
-    logger = trt.Logger(log_level)
-    builder = trt.Builder(logger)
+    builder = trt.Builder(trt_logger)
 
     # TODO: use TorchAllocator as builder.gpu_allocator
 
@@ -160,10 +165,7 @@ def from_onnx(onnx_model: Union[str, onnx.ModelProto],
     network = builder.create_network(EXPLICIT_BATCH)
 
     # parse onnx
-    parser = trt.OnnxParser(network, logger)
-
-    # switch trt logger to mmdeploy logger
-    logger = get_root_logger()
+    parser = trt.OnnxParser(network, trt_logger)
 
     if isinstance(onnx_model, str):
         parse_valid = parser.parse_from_file(onnx_model)


### PR DESCRIPTION
TensorRT's logger behaves differently from mmdeploy's logger.
``` shell
>>> import tensorrt as trt
>>> log_level = trt.Logger.ERROR
>>> logger = trt.Logger(log_level)
>>> logger.warning('This is a warning')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'tensorrt.tensorrt.Logger' object has no attribute 'warning'
>>> logger.log(log_level, 'This is a warning')
[02/14/2023-11:26:54] [TRT] [E] This is a warning
```
We should use `logger.log` method for printing infomation.
Maybe this pr can also applies to the dev branch?
