### PR TITLE
[Enhancement] Loosen protobuf version criteria for onnx upgrade

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -3,6 +3,6 @@ matplotlib
 multiprocess
 numpy
 onnx>=1.8.0
-protobuf<=3.20.1
+protobuf<=3.20.2
 six
 terminaltables


### PR DESCRIPTION
## Motivation
- onnx<1.13.0 has high security issue (https://github.com/advisories/GHSA-ffxj-547x-5j7c)
- Python packages depending on mmdeploy cannot upgrade onnx as
  - onnx==1.13.0 depends on protobuf>=3.20.2
  - mmdeploy depends on protobuf<=3.20.1


## Modification
- Suggesting [protobuf<=3.20.2] for quick solution


## Checklist
1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
