### PR TITLE
[Fix] remove score filtering in rtmdet_head rewriter since it leads to error shape in batch inference

### DIFF
--- a/mmdeploy/codebase/mmdet/models/dense_heads/rtmdet_head.py
+++ b/mmdeploy/codebase/mmdet/models/dense_heads/rtmdet_head.py
@@ -83,10 +83,7 @@ def rtmdet_head__predict_by_feat(self,
     br_x = (priors[..., 0] + flatten_bbox_preds[..., 2])
     br_y = (priors[..., 1] + flatten_bbox_preds[..., 3])
     bboxes = torch.stack([tl_x, tl_y, br_x, br_y], -1)
-    # directly multiply score factor and feed to nms
-    max_scores, _ = torch.max(flatten_cls_scores, 1)
-    mask = max_scores >= cfg.score_thr
-    scores = flatten_cls_scores.where(mask, flatten_cls_scores.new_zeros(1))
+    scores = flatten_cls_scores
     if not with_nms:
         return bboxes, scores
 


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Even though convert to tensorrt with dynamic shape successfully,
```
minshape:[1,3, 320, 320]
optshape: [8, 3, 320, 320]
maxshape: [16, 3, 320, 320]
```
The input shape somehow is always [1, 3, 320, 320] when using `trtexec` to test batch inference speed with option `--shapes`


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
