### PR TITLE
[Fix] Fix package_tools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include requirements/*.txt
 include mmdeploy/backend/ncnn/*.so
 include mmdeploy/backend/ncnn/*.dll
 include mmdeploy/backend/ncnn/*.pyd
+include mmdeploy/backend/ncnn/mmdeploy_onnx2ncnn*
 include mmdeploy/lib/*.so
 include mmdeploy/lib/*.dll
 include mmdeploy/lib/*.pyd

--- a/tools/package_tools/mmdeploy_builder.py
+++ b/tools/package_tools/mmdeploy_builder.py
@@ -169,6 +169,7 @@ def build_mmdeploy(cfg, mmdeploy_dir, dist_dir=None):
         # build cmd
         build_cmd = 'cmake --build . -- -j$(nproc) && cmake --install .'
         _call_command(build_cmd, build_dir)
+        _remove_if_exist(osp.join(build_dir, 'lib'))
 
     # build wheel
     bdist_cmd = _create_bdist_cmd(cfg, c_ext=False, dist_dir=dist_dir)


### PR DESCRIPTION
- `mmdeploy_onnx2ncnn` executable shoud be copied to  wheel.
- bdist wheel seems copy `build/lib/*` to wheel which should be prevented.
https://github.com/pypa/wheel/issues/147
