### PR TITLE
[FIX] sdk normalization to_rgb option not working(dev1.x)

### DIFF
--- a/csrc/mmdeploy/preprocess/transform/normalize.cpp
+++ b/csrc/mmdeploy/preprocess/transform/normalize.cpp
@@ -103,8 +103,8 @@ class Normalize : public Transform {
       } else if (to_rgb_) {
         auto src_mat = to_mat(tensor, PixelFormat::kBGR);
         Mat dst_mat;
-        OUTCOME_TRY(cvt_color_.Apply(src_mat, dst_mat, PixelFormat::kBGR));
-        dst = to_tensor(src_mat);
+        OUTCOME_TRY(cvt_color_.Apply(src_mat, dst_mat, PixelFormat::kRGB));
+        dst = to_tensor(dst_mat);
         data[key] = std::move(dst);
       }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

fix problem on mmdeploy sdk normalization operation option to_rgb not working while to_float option set to false.

## Modification

`csrc/mmdeploy/preprocess/transform/normalize.cpp`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
