### PR TITLE
[Fix] Export `mmdeploy` only in monolithic build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,12 @@ include(cmake/MMDeploy.cmake)
 add_subdirectory(csrc/mmdeploy)
 
 if (MMDEPLOY_BUILD_SDK)
-    install(TARGETS MMDeployStaticModules
-            MMDeployDynamicModules
-            MMDeployLibs
-            EXPORT MMDeployTargets)
+    if (NOT MMDEPLOY_BUILD_SDK_MONOLITHIC)
+        install(TARGETS MMDeployStaticModules
+                MMDeployDynamicModules
+                MMDeployLibs
+                EXPORT MMDeployTargets)
+    endif ()
 
     if (MMDEPLOY_BUILD_TEST)
         add_subdirectory(tests/test_csrc)

--- a/cmake/MMDeploy.cmake
+++ b/cmake/MMDeploy.cmake
@@ -15,6 +15,8 @@ endfunction ()
 macro(mmdeploy_add_net NAME)
     if (MMDEPLOY_DYNAMIC_BACKEND)
         mmdeploy_add_library(${NAME} SHARED ${ARGN})
+        # DYNAMIC_BACKEND implies BUILD_SDK_MONOLITHIC
+        mmdeploy_export_impl(${NAME})
         target_link_libraries(${PROJECT_NAME} PRIVATE mmdeploy)
         set(BACKEND_LIB_NAMES ${BACKEND_LIB_NAMES} ${PROJECT_NAME} PARENT_SCOPE)
     else ()

--- a/cmake/MMDeploy.cmake
+++ b/cmake/MMDeploy.cmake
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-function (mmdeploy_export NAME)
+function (mmdeploy_export_impl NAME)
     set(_LIB_DIR lib)
     if (MSVC)
         set(_LIB_DIR bin)
@@ -21,6 +21,13 @@ macro(mmdeploy_add_net NAME)
         mmdeploy_add_module(${NAME} ${ARGN})
     endif ()
 endmacro()
+
+function (mmdeploy_export NAME)
+    if (NOT MMDEPLOY_BUILD_SDK_MONOLITHIC)
+        mmdeploy_export_impl(${NAME})
+    endif ()
+endfunction ()
+
 
 function (mmdeploy_add_library NAME)
     # EXCLUDE: exclude from registering & exporting

--- a/csrc/mmdeploy/apis/c/CMakeLists.txt
+++ b/csrc/mmdeploy/apis/c/CMakeLists.txt
@@ -89,5 +89,5 @@ if (MMDEPLOY_BUILD_SDK_CSHARP_API OR MMDEPLOY_BUILD_SDK_MONOLITHIC)
                     INSTALL_RPATH "\$ORIGIN"
                     BUILD_RPATH "\$ORIGIN")
     endif ()
-    mmdeploy_export(mmdeploy)
+    mmdeploy_export_impl(mmdeploy)
 endif ()

--- a/csrc/mmdeploy/apis/cxx/CMakeLists.txt
+++ b/csrc/mmdeploy/apis/cxx/CMakeLists.txt
@@ -34,7 +34,7 @@ if (TARGET mmdeploy)
 else ()
     target_link_libraries(${PROJECT_NAME} INTERFACE mmdeploy::core)
 endif ()
-mmdeploy_export(${PROJECT_NAME})
+mmdeploy_export_impl(${PROJECT_NAME})
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/mmdeploy/common.hpp
         DESTINATION include/mmdeploy)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/demo/csrc/ DESTINATION example/cpp

--- a/demo/csrc/CMakeLists.txt
+++ b/demo/csrc/CMakeLists.txt
@@ -7,8 +7,8 @@ if (NOT (${CMAKE_PROJECT_NAME} STREQUAL "MMDeploy"))
 endif ()
 
 
-function(add_example dep folder name)
-    if (NOT dep OR TARGET mmdeploy_${dep})
+function(add_example task folder name)
+    if ((NOT task) OR (task IN_LIST MMDEPLOY_TASKS))
         # Search for c/cpp sources
         file(GLOB _SRCS ${folder}/${name}.c*)
         add_executable(${name} ${_SRCS})


### PR DESCRIPTION
base on #1797