### PR TITLE
MMOCR codebase should import typing_utils instead of typing in v1.x

### DIFF
--- a/mmdeploy/codebase/mmocr/models/text_detection/heads.py
+++ b/mmdeploy/codebase/mmocr/models/text_detection/heads.py
@@ -2,7 +2,7 @@
 from typing import Dict
 
 import torch
-from mmocr.utils.typing import DetSampleList
+from mmocr.utils.typing_utils import DetSampleList
 
 from mmdeploy.core import FUNCTION_REWRITER
 

--- a/mmdeploy/codebase/mmocr/models/text_recognition/sar_decoder.py
+++ b/mmdeploy/codebase/mmocr/models/text_recognition/sar_decoder.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence
 
 import torch
 import torch.nn.functional as F
-from mmocr.utils.typing import TextRecogDataSample
+from mmocr.utils.typing_utils import TextRecogDataSample
 from torch import nn
 
 from mmdeploy.core import FUNCTION_REWRITER, MODULE_REWRITER


### PR DESCRIPTION
This PR fixes a bug in the MMOCR codebase where the pre 1.x file for typing hints was imported instead of the post 1.x file for typing hints. 