### PR TITLE
[Feature] Support rewritting the origin model in mmrazor

### DIFF
--- a/mmdeploy/apis/onnx/export.py
+++ b/mmdeploy/apis/onnx/export.py
@@ -116,7 +116,7 @@ def export(model: torch.nn.Module,
         from_mmrazor = isinstance(patched_model, MMArchitectureQuant)
         if from_mmrazor:
             quantizer = patched_model.quantizer
-            patched_model = patched_model.post_process_for_mmdeploy()
+            patched_model = patched_model.get_deploy_model()
 
         # patch input_metas
         if input_metas is not None:
@@ -128,7 +128,6 @@ def export(model: torch.nn.Module,
             def wrap_forward(forward):
 
                 def wrapper(*arg, **kwargs):
-                    kwargs['mode_1'] = kwargs.pop('mode')
                     return forward(*arg, **kwargs)
 
                 return wrapper

--- a/mmdeploy/apis/onnx/export.py
+++ b/mmdeploy/apis/onnx/export.py
@@ -109,7 +109,17 @@ def export(model: torch.nn.Module,
     if 'onnx_custom_passes' not in context_info:
         onnx_custom_passes = optimize_onnx if optimize else None
         context_info['onnx_custom_passes'] = onnx_custom_passes
+        
+        
     with RewriterContext(**context_info), torch.no_grad():
+        
+        from mmrazor.models import MMArchitectureQuant
+        from_mmrazor = isinstance(patched_model,MMArchitectureQuant)
+        if from_mmrazor:
+            quantizer = patched_model.quantizer
+            patched_model = patched_model.post_process_for_mmdeploy()
+            
+        
         # patch input_metas
         if input_metas is not None:
             assert isinstance(
@@ -128,17 +138,33 @@ def export(model: torch.nn.Module,
             patched_model.forward = partial(patched_model.forward,
                                             **input_metas)
 
-        torch.onnx.export(
-            patched_model,
-            args,
-            output_path,
-            export_params=True,
-            input_names=input_names,
-            output_names=output_names,
-            opset_version=opset_version,
-            dynamic_axes=dynamic_axes,
-            keep_initializers_as_inputs=keep_initializers_as_inputs,
-            verbose=verbose)
-
+        if from_mmrazor:     
+            quantizer.export_onnx(
+                patched_model,
+                args,
+                output_path,
+                export_params=True,
+                input_names=input_names,
+                output_names=output_names,
+                opset_version=opset_version,
+                dynamic_axes=dynamic_axes,
+                keep_initializers_as_inputs=keep_initializers_as_inputs,
+                verbose=verbose
+            )
+            
+        else:
+            torch.onnx.export(
+                patched_model,
+                args,
+                output_path,
+                export_params=True,
+                input_names=input_names,
+                output_names=output_names,
+                opset_version=opset_version,
+                dynamic_axes=dynamic_axes,
+                keep_initializers_as_inputs=keep_initializers_as_inputs,
+                verbose=verbose)
+        
+    
         if input_metas is not None:
             patched_model.forward = model_forward

--- a/mmdeploy/apis/utils/utils.py
+++ b/mmdeploy/apis/utils/utils.py
@@ -41,7 +41,7 @@ def build_task_processor(model_cfg: mmengine.Config,
         BaseTask: A task processor.
     """
     check_backend_device(deploy_cfg=deploy_cfg, device=device)
-    codebase_type = get_codebase(deploy_cfg)
+    codebase_type = get_codebase(deploy_cfg, model_cfg=model_cfg)
     custom_module_list = get_codebase_external_module(deploy_cfg)
     import_codebase(codebase_type, custom_module_list)
     codebase = get_codebase_class(codebase_type)

--- a/mmdeploy/codebase/mmrazor/deploy/__init__.py
+++ b/mmdeploy/codebase/mmrazor/deploy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .mmrazor import MMCodebase, MMRazor
+
+__all__ = ['MMRazor', 'MMCodebase']

--- a/mmdeploy/codebase/mmrazor/deploy/mmrazor.py
+++ b/mmdeploy/codebase/mmrazor/deploy/mmrazor.py
@@ -1,0 +1,94 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+import torch
+from mmengine import Config
+from mmengine.model import BaseDataPreprocessor
+from mmengine.registry import Registry
+
+from mmdeploy.apis.utils import build_task_processor
+from mmdeploy.codebase.base import CODEBASE, BaseTask, MMCodebase
+from mmdeploy.utils import Codebase, Task
+
+MMRAZOR_TASK = Registry('mmrazor_tasks')
+
+
+@CODEBASE.register_module(Codebase.MMRAZOR.value)
+class MMRazor(MMCodebase):
+    task_registry = MMRAZOR_TASK
+
+    @classmethod
+    def register_deploy_modules(cls):
+        pass
+
+    @classmethod
+    def register_all_modules(cls):
+        from mmrazor.utils import register_all_modules
+        register_all_modules(True)
+
+    @classmethod
+    def build_task_processor(cls, model_cfg: Config, deploy_cfg: Config,
+                             device: str):
+        return Razor(model_cfg=model_cfg, deploy_cfg=deploy_cfg, device=device)
+
+
+@MMRAZOR_TASK.register_module(Task.RAZOR.value)
+class Razor(BaseTask):
+
+    def __init__(self,
+                 model_cfg: Config,
+                 deploy_cfg: Config,
+                 device: str,
+                 experiment_name: str = 'BaseTask'):
+        super().__init__(model_cfg, deploy_cfg, device, experiment_name)
+        self.origin_model_cfg = self.revert_model_cfg(model_cfg)
+        self.base_task = build_task_processor(self.origin_model_cfg,
+                                              deploy_cfg, device)
+
+    def revert_model_cfg(self, model_cfg: Config):
+        origin_model_cfg = copy.deepcopy(model_cfg)
+        model = model_cfg['model']
+        if 'architecture' in model:
+            origin_model = model['architecture']
+        elif 'algorithm' in model:
+            origin_model = model['algorithm']['architecture']
+        else:
+            raise NotImplementedError()
+        origin_model_cfg['model'] = origin_model
+        if 'data_preprocessor' in origin_model:
+            origin_model_cfg['data_preprocessor'] = origin_model[
+                'data_preprocessor']
+        return origin_model_cfg
+
+    # abstract method
+
+    def build_backend_model(self,
+                            model_files=None,
+                            data_preprocessor_updater=None,
+                            **kwargs) -> torch.nn.Module:
+        return self.base_task.build_backend_model(model_files,
+                                                  data_preprocessor_updater,
+                                                  **kwargs)
+
+    def create_input(self,
+                     imgs: Union[str, np.ndarray],
+                     input_shape=None,
+                     data_preprocessor: Optional[BaseDataPreprocessor] = None,
+                     **kwargs) -> Tuple[Dict, torch.Tensor]:
+        return self.base_task.create_input(imgs, input_shape,
+                                           data_preprocessor, **kwargs)
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return self.base_task.get_model_name(*args, **kwargs)
+
+    def get_preprocess(self, *args, **kwargs) -> Dict:
+        return self.base_task.get_preprocess(*args, **kwargs)
+
+    def get_postprocess(self, *args, **kwargs) -> Dict:
+        return self.base_task.get_postprocess(*args, **kwargs)
+
+    @staticmethod
+    def get_partition_cfg(partition_type: str, **kwargs) -> Dict:
+        raise NotImplementedError()

--- a/mmdeploy/codebase/mmrazor/deploy/mmrazor.py
+++ b/mmdeploy/codebase/mmrazor/deploy/mmrazor.py
@@ -31,11 +31,12 @@ class MMRazor(MMCodebase):
     @classmethod
     def build_task_processor(cls, model_cfg: Config, deploy_cfg: Config,
                              device: str):
-        return Razor(model_cfg=model_cfg, deploy_cfg=deploy_cfg, device=device)
+        return Pruning(
+            model_cfg=model_cfg, deploy_cfg=deploy_cfg, device=device)
 
 
-@MMRAZOR_TASK.register_module(Task.RAZOR.value)
-class Razor(BaseTask):
+@MMRAZOR_TASK.register_module(Task.PRUNING.value)
+class Pruning(BaseTask):
 
     def __init__(self,
                  model_cfg: Config,
@@ -102,11 +103,11 @@ class Razor(BaseTask):
         if hasattr(model, '_razor_divisor'):
             import json
 
+            from mmrazor.models.utils.expandable_utils import \
+                make_channel_divisible
             from mmrazor.utils import print_log
-            from projects.cores.expandable_modules.unit import \
-                expand_static_model
             divisor = getattr(model, '_razor_divisor')
-            structure = expand_static_model(model, divisor)
+            structure = make_channel_divisible(model, divisor)
 
             print_log(f'make divisible: {json.dumps(structure,indent=4)}')
 

--- a/mmdeploy/codebase/mmrazor/deploy/mmrazor.py
+++ b/mmdeploy/codebase/mmrazor/deploy/mmrazor.py
@@ -92,3 +92,22 @@ class Razor(BaseTask):
     @staticmethod
     def get_partition_cfg(partition_type: str, **kwargs) -> Dict:
         raise NotImplementedError()
+
+    def build_pytorch_model(self,
+                            model_checkpoint: Optional[str] = None,
+                            cfg_options: Optional[Dict] = None,
+                            **kwargs) -> torch.nn.Module:
+        model = super().build_pytorch_model(model_checkpoint, cfg_options,
+                                            **kwargs)
+        if hasattr(model, '_razor_divisor'):
+            import json
+
+            from mmrazor.utils import print_log
+            from projects.cores.expandable_modules.unit import \
+                expand_static_model
+            divisor = getattr(model, '_razor_divisor')
+            structure = expand_static_model(model, divisor)
+
+            print_log(f'make divisible: {json.dumps(structure,indent=4)}')
+
+        return model

--- a/mmdeploy/utils/config_utils.py
+++ b/mmdeploy/utils/config_utils.py
@@ -83,7 +83,8 @@ def register_codebase(codebase: str) -> Codebase:
     return Codebase.get(codebase)
 
 
-def get_codebase(deploy_cfg: Union[str, mmengine.Config]) -> Codebase:
+def get_codebase(deploy_cfg: Union[str, mmengine.Config],
+                 model_cfg=None) -> Codebase:
     """Get the codebase from the config.
 
     Args:
@@ -92,6 +93,11 @@ def get_codebase(deploy_cfg: Union[str, mmengine.Config]) -> Codebase:
     Returns:
         Codebase : An enumeration denotes the codebase type.
     """
+    if model_cfg is not None:
+        model_cfg: dict = model_cfg['model']
+        if model_cfg.get('_scope_', None) == 'mmrazor'\
+                or model_cfg['type'].startswith('mmrazor.'):
+            return register_codebase('mmrazor')
     codebase_config = get_codebase_config(deploy_cfg)
     assert 'type' in codebase_config, 'The codebase config of deploy config'\
         'requires a "type" field'

--- a/mmdeploy/utils/config_utils.py
+++ b/mmdeploy/utils/config_utils.py
@@ -94,6 +94,7 @@ def get_codebase(deploy_cfg: Union[str, mmengine.Config],
         Codebase : An enumeration denotes the codebase type.
     """
     if model_cfg is not None:
+        # using mmrazor codebase if the model is a mmrazor model.
         model_cfg: dict = model_cfg['model']
         if model_cfg.get('_scope_', None) == 'mmrazor'\
                 or model_cfg['type'].startswith('mmrazor.'):

--- a/mmdeploy/utils/constants.py
+++ b/mmdeploy/utils/constants.py
@@ -28,7 +28,7 @@ class Task(AdvancedEnum):
     POSE_DETECTION = 'PoseDetection'
     ROTATED_DETECTION = 'RotatedDetection'
     VIDEO_RECOGNITION = 'VideoRecognition'
-    RAZOR = 'Razor'
+    PRUNING = 'Pruning'
 
 
 class Codebase(AdvancedEnum):

--- a/mmdeploy/utils/constants.py
+++ b/mmdeploy/utils/constants.py
@@ -28,6 +28,7 @@ class Task(AdvancedEnum):
     POSE_DETECTION = 'PoseDetection'
     ROTATED_DETECTION = 'RotatedDetection'
     VIDEO_RECOGNITION = 'VideoRecognition'
+    RAZOR = 'Razor'
 
 
 class Codebase(AdvancedEnum):
@@ -41,6 +42,7 @@ class Codebase(AdvancedEnum):
     MMPOSE = 'mmpose'
     MMROTATE = 'mmrotate'
     MMACTION = 'mmaction'
+    MMRAZOR = 'mmrazor'
 
 
 class IR(AdvancedEnum):

--- a/mmdeploy/utils/constants.py
+++ b/mmdeploy/utils/constants.py
@@ -28,7 +28,7 @@ class Task(AdvancedEnum):
     POSE_DETECTION = 'PoseDetection'
     ROTATED_DETECTION = 'RotatedDetection'
     VIDEO_RECOGNITION = 'VideoRecognition'
-    PRUNING = 'Pruning'
+    ModelCompress = 'ModelCompress'
 
 
 class Codebase(AdvancedEnum):


### PR DESCRIPTION
The interface in mmrazor to get the observed model has to be changed from `post_process_for_mmdeploy` to `get_deploy_model`.