### PR TITLE
[Fix]: Fix mmrotate and regression script

### DIFF
--- a/configs/mmrotate/rotated-detection_onnxruntime_static.py
+++ b/configs/mmrotate/rotated-detection_onnxruntime_static.py
@@ -1,3 +1,3 @@
 _base_ = ['./rotated-detection_static.py', '../_base_/backends/onnxruntime.py']
 
-onnx_config = dict(output_names=['dets', 'labels'], input_shape=None)
+onnx_config = dict(output_names=['dets', 'labels'], input_shape=[1024, 1024])

--- a/tests/regression/mmpose.yml
+++ b/tests/regression/mmpose.yml
@@ -51,7 +51,7 @@ openvino:
     deploy_config: configs/mmpose/pose-detection_openvino_static-256x192.py
   pipeline_openvino_static_fp32_256x256: &pipeline_openvino_static_fp32_256x256
     convert_image: *convert_image
-    backend_test: *default_backend_test
+    backend_test: False
     deploy_config: configs/mmpose/pose-detection_openvino_static-256x256.py
 
 ncnn:
@@ -74,7 +74,6 @@ torchscript:
   pipeline_ts_static_fp32: &pipeline_ts_fp32
     convert_image: *convert_image
     backend_test: *default_backend_test
-    sdk_config: *sdk_static
     deploy_config: configs/mmpose/pose-detection_torchscript.py
 
 models:

--- a/tools/regression_test.py
+++ b/tools/regression_test.py
@@ -332,7 +332,7 @@ def get_pytorch_result(model_name: str, meta_info: dict, checkpoint_path: Path,
     }
 
     # get pytorch fps value
-    fps_info = model_info.get('Metadata').get('inference time (ms/im)')
+    fps_info = model_info.get('Metadata', {}).get('inference time (ms/im)')
     if fps_info is None:
         fps = '-'
     elif isinstance(fps_info, list):


### PR DESCRIPTION

## Motivation
Fix

## Modification

- [x] Fix oriented_rcnn+onnxruntime visualization failure. No `input_shape` is set for static deploy config.
- [x] Fix `regression_test.py`
- [x] Disable regression test for openvino and SDK+torchscript for mmpose codebase.

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
