### PR TITLE
fix pose_tracker python api will raise ValueError when result has no human

### DIFF
--- a/csrc/mmdeploy/apis/python/pose_tracker.cpp
+++ b/csrc/mmdeploy/apis/python/pose_tracker.cpp
@@ -30,7 +30,7 @@ std::vector<py::tuple> Apply(mmdeploy::PoseTracker* self,
   std::vector<py::tuple> batch_ret;
   batch_ret.reserve(frames.size());
   for (const auto& rs : results) {
-    py::array_t<float> keypoints({static_cast<int>(rs.size()), rs[0].keypoint_count, 3});
+    py::array_t<float> keypoints({static_cast<int>(rs.size()), rs.size() > 0 ? rs[0].keypoint_count : 0, 3});
     py::array_t<float> bboxes({static_cast<int>(rs.size()), 4});
     py::array_t<uint32_t> track_ids(static_cast<int>(rs.size()));
     auto kpts_ptr = keypoints.mutable_data();


### PR DESCRIPTION
## Motivation

There is a bug in Python binding of PoseTracker. When inference result has no human body, there is possibility that a `ValueError: negative dimensions are not allowed numpy` exception raised. I made some digging and found that:
1. when no human found in the image, an empty `Result` object is created but `keypoint_count` is uninitialized;
2. when creating `py::array_t` in Python version `Apply` function, `keypoint_count` is used to initialize the array shape;
3. in this case, `keypoint_count` is random value, when it is negative, the `py::array_t` would fail to create.

## Modification

Add a check before reading `keypoint_count`.

## BC-breaking (Optional)

No.

## Use cases (Optional)

No.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
5. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
6. The documentation has been modified accordingly, like docstring or example tutorials.
