### PR TITLE
[Enhancement] Add a visualize script for inference result comparation.

### DIFF
--- a/docs/en/02-how-to-run/useful_tools.md
+++ b/docs/en/02-how-to-run/useful_tools.md
@@ -202,3 +202,30 @@ And the output look like this:
 |  Max   |   1.689    | 591.983 |
 +--------+------------+---------+
 ```
+
+## visualize
+
+This tool can be used to visualize model inference results in different backend.
+
+### Usage
+
+```bash
+python tools/visualize.py \
+    --deploy-cfg {DEPLOY_CFG} \
+    --model-cfg {MODEL_CFG} \
+    --deploy-path {DEPLOY_PATH} \
+    --test-img {TEST_IMGS} \
+    --checkpoint {CHECKPOINTS} \
+    --save-dir {SAVE_DIR} \
+    --device {DEVICE}
+```
+
+### Description of all arguments
+
+- `deploy-cfg` : The path of the deploy config file in MMDeploy codebase.
+- `model-cfg` : The path of model config file in OpenMMLab codebase.
+- `deploy-path` : The path of the model to be tested, if the backend contains multiple files, you can use it multiple times.
+- `test-img` : The path of the images to be tested, you can use it multiple times.
+- `checkpoint` : The path of the checkpoint to be tested, if it is used, the result will be cancated to right part.
+- `save-dir` : The path to save the visualization results, if it not specified, it will be set to '.'.
+- `device` : The device type. If not specified, it will be set to `cpu`.

--- a/docs/zh_cn/02-how-to-run/useful_tools.md
+++ b/docs/zh_cn/02-how-to-run/useful_tools.md
@@ -202,3 +202,30 @@ python tools/profiler.py \
 |  Max   |   1.689    | 591.983 |
 +--------+------------+---------+
 ```
+
+## visualize
+
+这个工具可以用来可视化不同推理引擎的推理结果。
+
+### 用法
+
+```bash
+python tools/visualize.py \
+    --deploy-cfg {DEPLOY_CFG} \
+    --model-cfg {MODEL_CFG} \
+    --deploy-path {DEPLOY_PATH} \
+    --test-img {TEST_IMGS} \
+    --checkpoint {CHECKPOINTS} \
+    --save-dir {SAVE_DIR} \
+    --device {DEVICE}
+```
+
+### 参数说明
+
+- `deploy-cfg` : 输入的配置文件路径
+- `model-cfg` : 输入的模型配置文件路径
+- `deploy-path` : 测试的模型文件路径，如果部分模型含有多个文件，请多次使用该参数
+- `test-img` : 测试的图片路径，可以多次使用测试测试多张图片
+- `checkpoint` : PyTorch的权重文件，如果使用这个参数，推理的结果会被拼接到图像的右侧
+- `save-dir` : 保存可视化结果，如果没有指定则会被设为当前目录
+- `device` : 运行的设备类型，如果没有指定则会默认设置为`cpu`

--- a/tools/visualize.py
+++ b/tools/visualize.py
@@ -1,0 +1,125 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import argparse
+import logging
+import os
+import os.path as osp
+import time
+from functools import partial
+
+from tqdm import tqdm
+import numpy as np
+import mmcv
+import mmengine
+
+from mmdeploy.apis import visualize_model
+from mmdeploy.utils import (Backend, get_backend, get_root_logger,
+                            load_config)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Model inference visualization.')
+    parser.add_argument('--deploy-cfg', help='deploy config path')
+    parser.add_argument('--model-cfg', help='model config path')
+    parser.add_argument('--deploy-path', 
+        type=str,
+        nargs='+',
+        help='deploy model path')
+    parser.add_argument(
+        '--checkpoint', 
+        default=None, 
+        help='model checkpoint path')
+    parser.add_argument(
+        '--test-img',
+        default=None,
+        type=str,
+        nargs='+',
+        help='image used to test model')
+    parser.add_argument(
+        '--save-dir',
+        default=None,
+        help='the dir to save inference results')
+    parser.add_argument(
+        '--device', help='device to run model', default='cpu')
+    parser.add_argument(
+        '--log-level',
+        help='set log level',
+        default='INFO',
+        choices=list(logging._nameToLevel.keys()))
+    parser.add_argument(
+        '--uri',
+        default='192.168.1.1:60000',
+        help='Remote ipv4:port or ipv6:port for inference on edge device.')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    logger = get_root_logger()
+    log_level = logging.getLevelName(args.log_level)
+    logger.setLevel(log_level)
+
+    deploy_cfg_path = args.deploy_cfg
+    model_cfg_path = args.model_cfg
+    checkpoint_path = args.checkpoint
+    deploy_model_path = args.deploy_path
+    if not isinstance(deploy_model_path, list):
+        deploy_model_path = [deploy_model_path]
+    
+    # load deploy_cfg
+    deploy_cfg = load_config(deploy_cfg_path)[0]
+    
+    # create save_dir or generate default save_dir
+    save_dir = args.save_dir
+    if save_dir:
+        # generate default dir
+        current_time = time.localtime()
+        save_dir = osp.join(
+            os.getcwd(), time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
+        )
+    mmengine.mkdir_or_exist(save_dir)
+
+    # get backend info
+    backend = get_backend(deploy_cfg)
+    extra = dict()
+    if backend == Backend.SNPE:
+        extra['uri'] = args.uri
+    
+    # iterate single_img
+    for single_img in tqdm(args.test_img):
+        filename = osp.basename(single_img)
+        output_file=osp.join(save_dir, filename)
+        visualize_model(
+            model_cfg_path,
+            deploy_cfg_path, 
+            deploy_model_path, 
+            single_img,
+            args.device,
+            backend,
+            output_file,
+            False,
+            **extra)
+                
+        if checkpoint_path:
+            pytorch_output_file = osp.join(save_dir, 'pytorch_out.jpg')
+            visualize_model(
+                model_cfg_path, 
+                deploy_cfg_path, 
+                [checkpoint_path],
+                single_img, 
+                args.device,
+                Backend.PYTORCH, 
+                pytorch_output_file, 
+                False)
+            
+            # concat pytorch result and backend result
+            backend_result = mmcv.imread(output_file)
+            pytorch_result = mmcv.imread(pytorch_output_file)
+            result = np.concatenate((backend_result, pytorch_result), axis=1)
+            mmcv.imwrite(result, output_file)
+            
+            # remove temp pytorch result
+            os.remove(osp.join(save_dir, pytorch_output_file))
+
+if __name__ == '__main__':
+    main()

--- a/tools/visualize.py
+++ b/tools/visualize.py
@@ -4,30 +4,25 @@ import logging
 import os
 import os.path as osp
 import time
-from functools import partial
 
-from tqdm import tqdm
-import numpy as np
 import mmcv
 import mmengine
+import numpy as np
+from tqdm import tqdm
 
 from mmdeploy.apis import visualize_model
-from mmdeploy.utils import (Backend, get_backend, get_root_logger,
-                            load_config)
+from mmdeploy.utils import Backend, get_backend, get_root_logger, load_config
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Model inference visualization.')
+    parser = argparse.ArgumentParser(
+        description='Model inference visualization.')
     parser.add_argument('--deploy-cfg', help='deploy config path')
     parser.add_argument('--model-cfg', help='model config path')
-    parser.add_argument('--deploy-path', 
-        type=str,
-        nargs='+',
-        help='deploy model path')
     parser.add_argument(
-        '--checkpoint', 
-        default=None, 
-        help='model checkpoint path')
+        '--deploy-path', type=str, nargs='+', help='deploy model path')
+    parser.add_argument(
+        '--checkpoint', default=None, help='model checkpoint path')
     parser.add_argument(
         '--test-img',
         default=None,
@@ -35,11 +30,8 @@ def parse_args():
         nargs='+',
         help='image used to test model')
     parser.add_argument(
-        '--save-dir',
-        default=None,
-        help='the dir to save inference results')
-    parser.add_argument(
-        '--device', help='device to run model', default='cpu')
+        '--save-dir', default=None, help='the dir to save inference results')
+    parser.add_argument('--device', help='device to run model', default='cpu')
     parser.add_argument(
         '--log-level',
         help='set log level',
@@ -65,18 +57,17 @@ def main():
     deploy_model_path = args.deploy_path
     if not isinstance(deploy_model_path, list):
         deploy_model_path = [deploy_model_path]
-    
+
     # load deploy_cfg
     deploy_cfg = load_config(deploy_cfg_path)[0]
-    
+
     # create save_dir or generate default save_dir
     save_dir = args.save_dir
     if save_dir:
         # generate default dir
         current_time = time.localtime()
-        save_dir = osp.join(
-            os.getcwd(), time.strftime("%Y_%m_%d_%H_%M_%S", current_time)
-        )
+        save_dir = osp.join(os.getcwd(),
+                            time.strftime('%Y_%m_%d_%H_%M_%S', current_time))
     mmengine.mkdir_or_exist(save_dir)
 
     # get backend info
@@ -84,42 +75,30 @@ def main():
     extra = dict()
     if backend == Backend.SNPE:
         extra['uri'] = args.uri
-    
+
     # iterate single_img
     for single_img in tqdm(args.test_img):
         filename = osp.basename(single_img)
-        output_file=osp.join(save_dir, filename)
-        visualize_model(
-            model_cfg_path,
-            deploy_cfg_path, 
-            deploy_model_path, 
-            single_img,
-            args.device,
-            backend,
-            output_file,
-            False,
-            **extra)
-                
+        output_file = osp.join(save_dir, filename)
+        visualize_model(model_cfg_path, deploy_cfg_path, deploy_model_path,
+                        single_img, args.device, backend, output_file, False,
+                        **extra)
+
         if checkpoint_path:
             pytorch_output_file = osp.join(save_dir, 'pytorch_out.jpg')
-            visualize_model(
-                model_cfg_path, 
-                deploy_cfg_path, 
-                [checkpoint_path],
-                single_img, 
-                args.device,
-                Backend.PYTORCH, 
-                pytorch_output_file, 
-                False)
-            
+            visualize_model(model_cfg_path, deploy_cfg_path, [checkpoint_path],
+                            single_img, args.device, Backend.PYTORCH,
+                            pytorch_output_file, False)
+
             # concat pytorch result and backend result
             backend_result = mmcv.imread(output_file)
             pytorch_result = mmcv.imread(pytorch_output_file)
             result = np.concatenate((backend_result, pytorch_result), axis=1)
             mmcv.imwrite(result, output_file)
-            
+
             # remove temp pytorch result
             os.remove(osp.join(save_dir, pytorch_output_file))
+
 
 if __name__ == '__main__':
     main()

--- a/tools/visualize.py
+++ b/tools/visualize.py
@@ -30,7 +30,9 @@ def parse_args():
         nargs='+',
         help='image used to test model')
     parser.add_argument(
-        '--save-dir', default=None, help='the dir to save inference results')
+        '--save-dir',
+        default=os.getcwd(),
+        help='the dir to save inference results')
     parser.add_argument('--device', help='device to run model', default='cpu')
     parser.add_argument(
         '--log-level',
@@ -62,12 +64,9 @@ def main():
     deploy_cfg = load_config(deploy_cfg_path)[0]
 
     # create save_dir or generate default save_dir
-    save_dir = args.save_dir
-    if save_dir:
-        # generate default dir
-        current_time = time.localtime()
-        save_dir = osp.join(os.getcwd(),
-                            time.strftime('%Y_%m_%d_%H_%M_%S', current_time))
+    current_time = time.localtime()
+    save_dir = osp.join(os.getcwd(),
+                        time.strftime('%Y_%m_%d_%H_%M_%S', current_time))
     mmengine.mkdir_or_exist(save_dir)
 
     # get backend info


### PR DESCRIPTION
## Motivation

1. add a visualization script to visualize the backend inference results, refer to the visualization section in tools/deploy.py
2. script parameters include deployment config, model config, backend model path, image list, pytorch model (ckpt, optional), visualization result save path, etc.
3. require that when the pytorch model is passed in, the back-end results and the pytorch results graph are concatenated for comparison

## Modification

tools/visualize.py

## Use cases (Optional)

Run command:
```bash
python mmdeploy/tools/visualize.py \
    --deploy-cfg mmdeploy/configs/mmdet/detection/detection_onnxruntime_dynamic.py \
    --model-cfg mmdetection/configs/faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py \
    --deploy-path mmdeploy_model/faster-rcnn/end2end.onnx \
    --checkpoint checkpoints/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth \
    --test-img mmdetection/demo/demo.jpg mmdetection/demo/demo2.jpg \
    --save-dir mmdeploy_model/faster-rcnn \
    --device cuda
```

Inference result:
<img width="806" alt="image" src="https://user-images.githubusercontent.com/47499836/233104771-1430c247-c292-4094-baca-ee65f906b86a.png">
