### PR TITLE
[Enhancement] Load openvino model from memory

### DIFF
--- a/csrc/mmdeploy/net/openvino/openvino_net.cpp
+++ b/csrc/mmdeploy/net/openvino/openvino_net.cpp
@@ -79,8 +79,8 @@ Result<void> OpenVINONet::Init(const Value& args) {
 
   OUTCOME_TRY(auto raw_xml, model.ReadFile(config.net));
   OUTCOME_TRY(auto raw_bin, model.ReadFile(config.weights));
-  auto ov_tensor = InferenceEngine::TensorDesc(
-    InferenceEngine::Precision::U8,{raw_bin.size()}, InferenceEngine::Layout::C);
+  auto ov_tensor = InferenceEngine::TensorDesc(InferenceEngine::Precision::U8, {raw_bin.size()},
+                                               InferenceEngine::Layout::C);
   auto ov_blob = InferenceEngine::make_shared_blob<uint8_t>(ov_tensor);
   ov_blob->allocate();
   memcpy(ov_blob->buffer(), raw_bin.data(), ov_blob->byteSize());

--- a/docker/CPU/Dockerfile
+++ b/docker/CPU/Dockerfile
@@ -1,4 +1,4 @@
-FROM openvino/ubuntu18_dev:2021.4.2
+FROM openvino/ubuntu20_dev:2022.3.0
 ARG PYTHON_VERSION=3.8
 ARG TORCH_VERSION=1.10.0
 ARG TORCHVISION_VERSION=0.11.0
@@ -57,7 +57,7 @@ RUN if [ ${USE_SRC_INSIDE} == true ] ; \
 RUN /opt/conda/bin/pip install torch==${TORCH_VERSION}+cpu torchvision==${TORCHVISION_VERSION}+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html \
     && /opt/conda/bin/pip install --no-cache-dir openmim
 
-RUN /opt/conda/bin/mim install --no-cache-dir "mmcv"${MMCV_VERSION} onnxruntime==${ONNXRUNTIME_VERSION} openvino-dev mmengine${MMENGINE_VERSION}
+RUN /opt/conda/bin/mim install --no-cache-dir "mmcv"${MMCV_VERSION} onnxruntime==${ONNXRUNTIME_VERSION} openvino-dev==2022.3.0 mmengine${MMENGINE_VERSION}
 
 ENV PATH /opt/conda/bin:$PATH
 WORKDIR /root/workspace
@@ -100,14 +100,14 @@ RUN git clone -b main https://github.com/open-mmlab/mmdeploy.git &&\
     /opt/conda/bin/mim install -e .
 
 ### build SDK
-ENV LD_LIBRARY_PATH="/root/workspace/mmdeploy/build/lib:/opt/intel/openvino/deployment_tools/ngraph/lib:/opt/intel/openvino/deployment_tools/inference_engine/lib/intel64:${LD_LIBRARY_PATH}"
+ENV LD_LIBRARY_PATH="/root/workspace/mmdeploy/build/lib:${LD_LIBRARY_PATH}"
 RUN cd mmdeploy && rm -rf build/CM* && mkdir -p build && cd build && cmake .. \
     -DMMDEPLOY_BUILD_SDK=ON \
     -DMMDEPLOY_BUILD_EXAMPLES=ON \
-    -DCMAKE_CXX_COMPILER=g++-7 \
+    -DCMAKE_CXX_COMPILER=g++-9 \
     -DONNXRUNTIME_DIR=${ONNXRUNTIME_DIR} \
     -Dncnn_DIR=/root/workspace/ncnn/build/install/lib/cmake/ncnn \
-    -DInferenceEngine_DIR=/opt/intel/openvino/deployment_tools/inference_engine/share \
+    -DInferenceEngine_DIR=/opt/intel/openvino/runtime/cmake \
     -DMMDEPLOY_TARGET_DEVICES=cpu \
     -DMMDEPLOY_BUILD_SDK_PYTHON_API=ON \
     -DMMDEPLOY_TARGET_BACKENDS="ort;ncnn;openvino" \


### PR DESCRIPTION
## Motivation

The openvino-dev version of based image is different with pip installed one, therefore the converted openvino model can't be loaded by sdk.

Previously, the openvino model will first rewrite to /tmp directory and load, which is not right when loading two openvino models at the same time. And this strategy has more overhead.


## Modification

- [x] fix cpu docker
- [x] load openvino model from memory 

