### PR TITLE
[Enhanced] method of memory loading model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(MMDEPLOY_BUILD_SDK_CSHARP_API "build SDK C# API support" OFF)
 option(MMDEPLOY_BUILD_SDK_JAVA_API "build SDK JAVA API" OFF)
 option(MMDEPLOY_BUILD_EXAMPLES "build examples" OFF)
 option(MMDEPLOY_SPDLOG_EXTERNAL "use external spdlog" OFF)
-option(MMDEPLOY_ZIP_MODEL "support SDK model in zip format" OFF)
+option(MMDEPLOY_ZIP_MODEL "support SDK model in zip format" ON)
 option(MMDEPLOY_COVERAGE "build SDK for coverage" OFF)
 option(MMDEPLOY_ELENA_FUSION "use elena to fuse preprocess" OFF)
 

--- a/csrc/mmdeploy/apis/c/mmdeploy/classifier.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/classifier.cpp
@@ -40,6 +40,18 @@ int mmdeploy_classifier_create_by_path(const char* model_path, const char* devic
   return ec;
 }
 
+int mmdeploy_classifier_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                       int device_id, mmdeploy_classifier_t* classifier) {
+  mmdeploy_model_t model{};
+
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_classifier_create(model, device_name, device_id, classifier);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_classifier_create_v2(mmdeploy_model_t model, mmdeploy_context_t context,
                                   mmdeploy_classifier_t* classifier) {
   return mmdeploy_pipeline_create_from_model(model, context, (mmdeploy_pipeline_t*)classifier);

--- a/csrc/mmdeploy/apis/c/mmdeploy/classifier.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/classifier.h
@@ -50,6 +50,20 @@ MMDEPLOY_API int mmdeploy_classifier_create_by_path(const char* model_path, cons
                                                     mmdeploy_classifier_t* classifier);
 
 /**
+ * @brief Create classifier's handle
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] classifier instance of a classifier, which must be destroyed
+ * by \ref mmdeploy_classifier_destroy
+ * @return status of creating classifier's handle
+ */
+MMDEPLOY_API int mmdeploy_classifier_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                                    int device_id,
+                                                    mmdeploy_classifier_t* classifier);
+
+/**
  * @brief Use classifier created by  \ref mmdeploy_classifier_create_by_path to get label
  * information of each image in a batch
  * @param[in] classifier classifier's handle created by  \ref mmdeploy_classifier_create_by_path

--- a/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/detector.cpp
@@ -53,6 +53,18 @@ int mmdeploy_detector_create_by_path(const char* model_path, const char* device_
   return ec;
 }
 
+int mmdeploy_detector_create_by_buffer(const void* buffer, int size, const char* device_name, int device_id,
+                                     mmdeploy_detector_t* detector) {
+  mmdeploy_model_t model{};
+
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_detector_create(model, device_name, device_id, detector);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_detector_create_input(const mmdeploy_mat_t* mats, int mat_count,
                                    mmdeploy_value_t* input) {
   return mmdeploy_common_create_input(mats, mat_count, input);

--- a/csrc/mmdeploy/apis/c/mmdeploy/detector.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/detector.h
@@ -55,6 +55,19 @@ MMDEPLOY_API int mmdeploy_detector_create_by_path(const char* model_path, const 
                                                   int device_id, mmdeploy_detector_t* detector);
 
 /**
+ * @brief Create detector's handle
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] detector instance of a detector
+ * @return status of creating detector's handle
+ */
+MMDEPLOY_API int mmdeploy_detector_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                                  int device_id, mmdeploy_detector_t* detector);
+
+
+/**
  * @brief Apply detector to batch images and get their inference results
  * @param[in] detector detector's handle created by \ref mmdeploy_detector_create_by_path
  * @param[in] mats a batch of images

--- a/csrc/mmdeploy/apis/c/mmdeploy/pose_detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/pose_detector.cpp
@@ -39,6 +39,17 @@ int mmdeploy_pose_detector_create_by_path(const char* model_path, const char* de
   return ec;
 }
 
+int mmdeploy_pose_detector_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                          int device_id, mmdeploy_pose_detector_t* detector) {
+  mmdeploy_model_t model{};
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_pose_detector_create(model, device_name, device_id, detector);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_pose_detector_apply(mmdeploy_pose_detector_t detector, const mmdeploy_mat_t* mats,
                                  int mat_count, mmdeploy_pose_detection_t** results) {
   return mmdeploy_pose_detector_apply_bbox(detector, mats, mat_count, nullptr, nullptr, results);

--- a/csrc/mmdeploy/apis/c/mmdeploy/pose_detector.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/pose_detector.h
@@ -51,6 +51,20 @@ MMDEPLOY_API int mmdeploy_pose_detector_create_by_path(const char* model_path,
                                                        mmdeploy_pose_detector_t* detector);
 
 /**
+ * @brief Create a pose detector instance
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] detector handle of the created pose detector, which must be destroyed
+ * by \ref mmdeploy_pose_detector_destroy
+ * @return status code of the operation
+ */
+MMDEPLOY_API int mmdeploy_pose_detector_create_by_buffer(const void* buffer, int size,
+                                                       const char* device_name, int device_id,
+                                                       mmdeploy_pose_detector_t* detector);
+
+/**
  * @brief Apply pose detector to a batch of images with full image roi
  * @param[in] detector pose detector's handle created by \ref
  * mmdeploy_pose_detector_create_by_path

--- a/csrc/mmdeploy/apis/c/mmdeploy/restorer.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/restorer.cpp
@@ -39,6 +39,17 @@ int mmdeploy_restorer_create_by_path(const char* model_path, const char* device_
   return ec;
 }
 
+int mmdeploy_restorer_create_by_buffer(const void* buffer , int size , const char* device_name, int device_id,
+                                     mmdeploy_restorer_t* restorer) {
+  mmdeploy_model_t model{};
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_restorer_create(model, device_name, device_id, restorer);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_restorer_apply(mmdeploy_restorer_t restorer, const mmdeploy_mat_t* images, int count,
                             mmdeploy_mat_t** results) {
   wrapped<mmdeploy_value_t> input;

--- a/csrc/mmdeploy/apis/c/mmdeploy/restorer.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/restorer.h
@@ -44,6 +44,20 @@ MMDEPLOY_API int mmdeploy_restorer_create_by_path(const char* model_path, const 
                                                   int device_id, mmdeploy_restorer_t* restorer);
 
 /**
+ * @brief Create a restorer instance
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] restorer handle of the created restorer, which must be destroyed
+ * by \ref mmdeploy_restorer_destroy
+ * @return status code of the operation
+ */
+MMDEPLOY_API int mmdeploy_restorer_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                                  int device_id, mmdeploy_restorer_t* restorer);
+
+
+/**
  * @brief Apply restorer to a batch of images
  * @param[in] restorer restorer's handle created by \ref mmdeploy_restorer_create_by_path
  * @param[in] images a batch of images

--- a/csrc/mmdeploy/apis/c/mmdeploy/rotated_detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/rotated_detector.cpp
@@ -39,6 +39,18 @@ int mmdeploy_rotated_detector_create_by_path(const char* model_path, const char*
   return ec;
 }
 
+int mmdeploy_rotated_detector_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                             int device_id, mmdeploy_rotated_detector_t* detector) {
+  mmdeploy_model_t model{};
+
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_rotated_detector_create(model, device_name, device_id, detector);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_rotated_detector_apply(mmdeploy_rotated_detector_t detector,
                                     const mmdeploy_mat_t* mats, int mat_count,
                                     mmdeploy_rotated_detection_t** results, int** result_count) {

--- a/csrc/mmdeploy/apis/c/mmdeploy/rotated_detector.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/rotated_detector.h
@@ -50,6 +50,19 @@ MMDEPLOY_API int mmdeploy_rotated_detector_create_by_path(const char* model_path
                                                           mmdeploy_rotated_detector_t* detector);
 
 /**
+ * @brief Create rotated detector's handle
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] detector instance of a rotated detector
+ * @return status of creating rotated detector's handle
+ */
+MMDEPLOY_API int mmdeploy_rotated_detector_create_by_buffer(const void* buffer, int size,
+                                                          const char* device_name, int device_id,
+                                                          mmdeploy_rotated_detector_t* detector);
+
+/**
  * @brief Apply rotated detector to batch images and get their inference results
  * @param[in] detector rotated detector's handle created by \ref
  * mmdeploy_rotated_detector_create_by_path

--- a/csrc/mmdeploy/apis/c/mmdeploy/segmentor.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/segmentor.cpp
@@ -41,6 +41,17 @@ int mmdeploy_segmentor_create_by_path(const char* model_path, const char* device
   return ec;
 }
 
+int mmdeploy_segmentor_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                      int device_id, mmdeploy_segmentor_t* segmentor) {
+  mmdeploy_model_t model{};
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_segmentor_create(model, device_name, device_id, segmentor);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_segmentor_apply(mmdeploy_segmentor_t segmentor, const mmdeploy_mat_t* mats,
                              int mat_count, mmdeploy_segmentation_t** results) {
   wrapped<mmdeploy_value_t> input;

--- a/csrc/mmdeploy/apis/c/mmdeploy/segmentor.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/segmentor.h
@@ -55,6 +55,20 @@ MMDEPLOY_API int mmdeploy_segmentor_create_by_path(const char* model_path, const
                                                    int device_id, mmdeploy_segmentor_t* segmentor);
 
 /**
+ * @brief Create segmentor's handle
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] segmentor instance of a segmentor, which must be destroyed
+ * by \ref mmdeploy_segmentor_destroy
+ * @return status of creating segmentor's handle
+ */
+MMDEPLOY_API int mmdeploy_segmentor_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                                   int device_id, mmdeploy_segmentor_t* segmentor);
+
+
+/**
  * @brief Apply segmentor to batch images and get their inference results
  * @param[in] segmentor segmentor's handle created by \ref mmdeploy_segmentor_create_by_path or \ref
  * mmdeploy_segmentor_create

--- a/csrc/mmdeploy/apis/c/mmdeploy/text_detector.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/text_detector.cpp
@@ -44,6 +44,17 @@ int mmdeploy_text_detector_create_by_path(const char* model_path, const char* de
   return ec;
 }
 
+int mmdeploy_text_detector_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                          int device_id, mmdeploy_text_detector_t* detector) {
+  mmdeploy_model_t model{};
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_text_detector_create(model, device_name, device_id, detector);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_text_detector_create_input(const mmdeploy_mat_t* mats, int mat_count,
                                         mmdeploy_value_t* input) {
   return mmdeploy_common_create_input(mats, mat_count, input);

--- a/csrc/mmdeploy/apis/c/mmdeploy/text_detector.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/text_detector.h
@@ -59,7 +59,7 @@ MMDEPLOY_API int mmdeploy_text_detector_create_by_path(const char* model_path,
  * by \ref mmdeploy_text_detector_destroy
  * @return status of creating text-detector's handle
  */
-MMDEPLOY_API int mmdeploy_text_detector_create_by_path(const void* buffer, int size,
+MMDEPLOY_API int mmdeploy_text_detector_create_by_buffer(const void* buffer, int size,
                                                        const char* device_name, int device_id,
                                                        mmdeploy_text_detector_t* detector);
 

--- a/csrc/mmdeploy/apis/c/mmdeploy/text_detector.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/text_detector.h
@@ -50,6 +50,20 @@ MMDEPLOY_API int mmdeploy_text_detector_create_by_path(const char* model_path,
                                                        mmdeploy_text_detector_t* detector);
 
 /**
+ * @brief Create text-detector's handle
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device
+ * @param[out] detector instance of a text-detector, which must be destroyed
+ * by \ref mmdeploy_text_detector_destroy
+ * @return status of creating text-detector's handle
+ */
+MMDEPLOY_API int mmdeploy_text_detector_create_by_path(const void* buffer, int size,
+                                                       const char* device_name, int device_id,
+                                                       mmdeploy_text_detector_t* detector);
+
+/**
  * @brief Apply text-detector to batch images and get their inference results
  * @param[in] detector text-detector's handle created by \ref mmdeploy_text_detector_create_by_path
  * @param[in] mats a batch of images

--- a/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.cpp
@@ -78,6 +78,17 @@ int mmdeploy_text_recognizer_create_by_path(const char* model_path, const char* 
   return ec;
 }
 
+int mmdeploy_text_recognizer_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                            int device_id, mmdeploy_text_recognizer_t* recognizer) {
+  mmdeploy_model_t model{};
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_text_recognizer_create(model, device_name, device_id, recognizer);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_text_recognizer_apply(mmdeploy_text_recognizer_t recognizer,
                                    const mmdeploy_mat_t* images, int count,
                                    mmdeploy_text_recognition_t** results) {

--- a/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.h
@@ -52,6 +52,20 @@ MMDEPLOY_API int mmdeploy_text_recognizer_create_by_path(const char* model_path,
                                                          mmdeploy_text_recognizer_t* recognizer);
 
 /**
+ * @brief Create a text recognizer instance
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] recognizer handle of the created text recognizer, which must be destroyed
+ * by \ref mmdeploy_text_recognizer_destroy
+ * @return status code of the operation
+ */
+MMDEPLOY_API int mmdeploy_text_recognizer_create_by_path(const void* buffer, int size,
+                                                         const char* device_name, int device_id,
+                                                         mmdeploy_text_recognizer_t* recognizer);
+
+/**
  * @brief Apply text recognizer to a batch of text images
  * @param[in] recognizer text recognizer's handle created by \ref
  * mmdeploy_text_recognizer_create_by_path

--- a/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/text_recognizer.h
@@ -61,7 +61,7 @@ MMDEPLOY_API int mmdeploy_text_recognizer_create_by_path(const char* model_path,
  * by \ref mmdeploy_text_recognizer_destroy
  * @return status code of the operation
  */
-MMDEPLOY_API int mmdeploy_text_recognizer_create_by_path(const void* buffer, int size,
+MMDEPLOY_API int mmdeploy_text_recognizer_create_by_buffer(const void* buffer, int size,
                                                          const char* device_name, int device_id,
                                                          mmdeploy_text_recognizer_t* recognizer);
 

--- a/csrc/mmdeploy/apis/c/mmdeploy/video_recognizer.cpp
+++ b/csrc/mmdeploy/apis/c/mmdeploy/video_recognizer.cpp
@@ -44,6 +44,20 @@ int mmdeploy_video_recognizer_create_by_path(const char* model_path, const char*
   mmdeploy_model_destroy(model);
   return ec;
 }
+
+int mmdeploy_video_recognizer_create_by_buffer(const void* buffer, int size, const char* device_name,
+                                             int device_id,
+                                             mmdeploy_video_recognizer_t* recognizer) {
+  mmdeploy_model_t model{};
+
+  if (auto ec = mmdeploy_model_create(buffer, size, &model)) {
+    return ec;
+  }
+  auto ec = mmdeploy_video_recognizer_create(model, device_name, device_id, recognizer);
+  mmdeploy_model_destroy(model);
+  return ec;
+}
+
 int mmdeploy_video_recognizer_apply(mmdeploy_video_recognizer_t recognizer,
                                     const mmdeploy_mat_t* images,
                                     const mmdeploy_video_sample_info_t* video_info, int video_count,

--- a/csrc/mmdeploy/apis/c/mmdeploy/video_recognizer.h
+++ b/csrc/mmdeploy/apis/c/mmdeploy/video_recognizer.h
@@ -56,6 +56,20 @@ MMDEPLOY_API int mmdeploy_video_recognizer_create_by_path(const char* model_path
                                                           mmdeploy_video_recognizer_t* recognizer);
 
 /**
+ * @brief Create a video recognizer instance
+ * @param[in] buffer a linear buffer contains the model information
+ * @param[in] size size of \p buffer in bytes
+ * @param[in] device_name name of device, such as "cpu", "cuda", etc.
+ * @param[in] device_id id of device.
+ * @param[out] recognizer handle of the created video recognizer, which must be destroyed
+ * by \ref mmdeploy_video_recognizer_destroy
+ * @return status code of the operation
+ */
+MMDEPLOY_API int mmdeploy_video_recognizer_create_by_buffer(const void* buffer, int size,
+                                                          const char* device_name, int device_id,
+                                                          mmdeploy_video_recognizer_t* recognizer);
+
+/**
  * @brief Apply video recognizer to a batch of videos
  * @param[in] recognizer video recognizer's handle created by \ref
  * mmdeploy_video_recognizer_create_by_path


### PR DESCRIPTION
## Motivation

There is no way to load the model from memory, so it cannot be loaded from memory when the model is encrypted

## Modification

Add methods to load models from memory

