### PR TITLE
[Fix] swap width and height in Resize and Pad according to upstream codebases

### DIFF
--- a/csrc/mmdeploy/preprocess/transform/pad.cpp
+++ b/csrc/mmdeploy/preprocess/transform/pad.cpp
@@ -83,8 +83,8 @@ class Pad : public Transform {
           data["pad_fixed_size"].push_back(pad_w);
         } else {
           padding = {0, 0, size_[0] - width, size_[1] - height};
-          data["pad_fixed_size"].push_back(size_[0]);
           data["pad_fixed_size"].push_back(size_[1]);
+          data["pad_fixed_size"].push_back(size_[0]);
         }
       } else if (size_divisor_ != 1) {
         auto pad_h = (height + size_divisor_ - 1) / size_divisor_ * size_divisor_;

--- a/csrc/mmdeploy/preprocess/transform/pad.cpp
+++ b/csrc/mmdeploy/preprocess/transform/pad.cpp
@@ -82,7 +82,7 @@ class Pad : public Transform {
           data["pad_fixed_size"].push_back(pad_h);
           data["pad_fixed_size"].push_back(pad_w);
         } else {
-          padding = {0, 0, size_[1] - width, size_[0] - height};
+          padding = {0, 0, size_[0] - width, size_[1] - height};
           data["pad_fixed_size"].push_back(size_[0]);
           data["pad_fixed_size"].push_back(size_[1]);
         }

--- a/csrc/mmdeploy/preprocess/transform/resize.cpp
+++ b/csrc/mmdeploy/preprocess/transform/resize.cpp
@@ -74,12 +74,12 @@ class Resize : public Transform {
         MMDEPLOY_DEBUG(
             "neither 'scale' or 'scale_factor' is provided in input value. "
             "'img_scale' will be used");
-        if (-1 == img_scale_[1]) {
+        if (-1 == img_scale_[0]) {
           if (w < h) {
-            dst_w = img_scale_[0];
+            dst_w = img_scale_[1];
             dst_h = dst_w * h / w;
           } else {
-            dst_h = img_scale_[0];
+            dst_h = img_scale_[1];
             dst_w = dst_h * w / h;
           }
         } else {

--- a/csrc/mmdeploy/preprocess/transform/resize.cpp
+++ b/csrc/mmdeploy/preprocess/transform/resize.cpp
@@ -27,6 +27,8 @@ class Resize : public Transform {
           MMDEPLOY_ERROR("'size' expects an array of size 2, but got {}", args["size"].size());
           throw_exception(eInvalidArgument);
         }
+        // the order in openmmalb config is [width, height], while in SDK it is [height, width]
+        // keep the last dim -1
         auto width = args["size"][0].get<int>();
         auto height = args["size"][1].get<int>();
         if (-1 == height) {

--- a/csrc/mmdeploy/preprocess/transform/resize.cpp
+++ b/csrc/mmdeploy/preprocess/transform/resize.cpp
@@ -27,8 +27,8 @@ class Resize : public Transform {
           MMDEPLOY_ERROR("'size' expects an array of size 2, but got {}", args["size"].size());
           throw_exception(eInvalidArgument);
         }
-        auto height = args["size"][0].get<int>();
-        auto width = args["size"][1].get<int>();
+        auto width = args["size"][0].get<int>();
+        auto height = args["size"][1].get<int>();
         img_scale_ = {height, width};
       } else {
         MMDEPLOY_ERROR("'size' is expected to be an integer or and array of size 2");

--- a/csrc/mmdeploy/preprocess/transform/resize.cpp
+++ b/csrc/mmdeploy/preprocess/transform/resize.cpp
@@ -29,7 +29,11 @@ class Resize : public Transform {
         }
         auto width = args["size"][0].get<int>();
         auto height = args["size"][1].get<int>();
-        img_scale_ = {height, width};
+        if (-1 == height) {
+          img_scale_ = {width, -1};
+        } else {
+          img_scale_ = {height, width};
+        }
       } else {
         MMDEPLOY_ERROR("'size' is expected to be an integer or and array of size 2");
         throw_exception(eInvalidArgument);
@@ -74,12 +78,12 @@ class Resize : public Transform {
         MMDEPLOY_DEBUG(
             "neither 'scale' or 'scale_factor' is provided in input value. "
             "'img_scale' will be used");
-        if (-1 == img_scale_[0]) {
+        if (-1 == img_scale_[1]) {
           if (w < h) {
-            dst_w = img_scale_[1];
+            dst_w = img_scale_[0];
             dst_h = dst_w * h / w;
           } else {
-            dst_h = img_scale_[1];
+            dst_h = img_scale_[0];
             dst_w = dst_h * w / h;
           }
         } else {

--- a/tests/test_csrc/preprocess/test_pad.cpp
+++ b/tests/test_csrc/preprocess/test_pad.cpp
@@ -111,7 +111,7 @@ TEST_CASE("transform 'Pad'", "[pad]") {
     constexpr int width = 800;
     for (auto& mat : mats) {
       for (auto& mode : modes) {
-        Value cfg{{"type", "Pad"}, {"size", {height, width}}, {"padding_mode", mode}};
+        Value cfg{{"type", "Pad"}, {"size", {width, height}}, {"padding_mode", mode}};
         auto [pad_left, pad_top, pad_right, pad_bottom] = GetPadSize(mat, height, width);
         TestPad(cfg, mat, pad_top, pad_left, pad_bottom, pad_right, border_map[mode], 0);
       }

--- a/tests/test_csrc/preprocess/test_resize.cpp
+++ b/tests/test_csrc/preprocess/test_resize.cpp
@@ -230,7 +230,7 @@ TEST_CASE("resize transform: size", "[resize]") {
     for (auto& mat : mats) {
       for (auto& interp : interpolations) {
         Value cfg{{"type", "Resize"},
-                  {"size", {dst_height, dst_width}},
+                  {"size", {dst_width, dst_height}},
                   {"keep_ratio", keep_ratio},
                   {"interpolation", interp}};
         TestResize(cfg, kHost, mat, dst_height, dst_width);


### PR DESCRIPTION
https://mmcv.readthedocs.io/en/2.x/understand_mmcv/data_transform.html

![image](https://user-images.githubusercontent.com/41138331/237061112-93beee43-ef1e-4c2b-960e-1a5cac33ca38.png)
