### PR TITLE
[Fix]: limit urllib3 for readthedocs

### DIFF
--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -5,3 +5,4 @@ onnx>=1.8.0
 opencv-python==4.5.4.60
 sphinxcontrib-mermaid
 torch
+urllib3<2.0.0


### PR DESCRIPTION
fix readthedocs urllib:  https://github.com/open-mmlab/mmengine/pull/1132

## Motivation


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
