### PR TITLE
fix uploading assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,23 +35,17 @@ jobs:
         run: |
           cd $OUTPUT_DIR/mmdeploy
           ls -sha *.whl
-          # twine upload mmdeploy-${MMDEPLOY_VERSION}-py3-none-manylinux2014_x86_64.whl --repository testpypi -u testmmdeploy -p ${{ secrets.test_pypi_password }}
           twine upload *.whl -u __token__ -p ${{ secrets.pypi_password }}
       - name: Upload mmdeploy_runtime
         continue-on-error: true
         run: |
           cd $OUTPUT_DIR/mmdeploy_runtime
           ls -sha *.whl
-          # twine upload mmdeploy_runtime-${MMDEPLOY_VERSION}-cp38-none-manylinux2014_x86_64.whl --repository testpypi -u testmmdeploy -p ${{ secrets.test_pypi_password }}
           twine upload *.whl -u __token__ -p ${{ secrets.pypi_password }}
-      - name: Create dummy softlinks to assets
+      - name: Check assets
         run: |
-          ln -sf $OUTPUT_DIR/sdk ./prebuild
-          ls -sha ./prebuild
+          ls -sha $OUTPUT_DIR/sdk
       - name: Upload mmdeploy sdk
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${MMDEPLOY_VERSION}
-          files: |
-              ./prebuild/*.zip
-              ./prebuild/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload v${MMDEPLOY_VERSION} ${OUTPUT_DIR}/sdk/*.zip ${OUTPUT_DIR}/sdk/*.tar.gz --clobber


### PR DESCRIPTION


## Motivation

uploading assets fails due to the wrong tag_name of action `softprops/action-gh-release@v1`. See issue https://github.com/softprops/action-gh-release/issues/360

## Modification

use gh script to upload assets

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
