### PR TITLE
Mobilenet V3 to ONNX support

### DIFF
--- a/docs/en/03-benchmark/supported_models.md
+++ b/docs/en/03-benchmark/supported_models.md
@@ -28,6 +28,7 @@ The table below lists the models that are guaranteed to be exportable to other b
 | [ResNeXt](https://github.com/open-mmlab/mmpretrain/tree/main/configs/resnext)                            | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [SE-ResNet](https://github.com/open-mmlab/mmpretrain/tree/main/configs/seresnet)                         | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [MobileNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v2)                   | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
+| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)                   | MMPretrain       |      N      |      Y      |    N     |  N   |   N   |    N     |   N    |  N   |
 | [ShuffleNetV1](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v1)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [ShuffleNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v2)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [VisionTransformer](https://github.com/open-mmlab/mmpretrain/tree/main/configs/vision_transformer)       | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   ?   |    Y     |   Y    |  N   |

--- a/docs/en/03-benchmark/supported_models.md
+++ b/docs/en/03-benchmark/supported_models.md
@@ -28,7 +28,7 @@ The table below lists the models that are guaranteed to be exportable to other b
 | [ResNeXt](https://github.com/open-mmlab/mmpretrain/tree/main/configs/resnext)                            | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [SE-ResNet](https://github.com/open-mmlab/mmpretrain/tree/main/configs/seresnet)                         | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [MobileNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v2)                   | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
-| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)                   | MMPretrain       |      N      |      Y      |    N     |  N   |   N   |    N     |   N    |  N   |
+| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)                   | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   N   |    Y     |   N    |  N   |
 | [ShuffleNetV1](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v1)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [ShuffleNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v2)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [VisionTransformer](https://github.com/open-mmlab/mmpretrain/tree/main/configs/vision_transformer)       | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   ?   |    Y     |   Y    |  N   |

--- a/docs/en/04-supported-codebases/mmpretrain.md
+++ b/docs/en/04-supported-codebases/mmpretrain.md
@@ -178,6 +178,7 @@ Besides python API, mmdeploy SDK also provides other FFI (Foreign Function Inter
 | [ResNeXt](https://github.com/open-mmlab/mmpretrain/tree/main/configs/resnext)                      |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [SE-ResNet](https://github.com/open-mmlab/mmpretrain/tree/main/configs/seresnet)                   |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [MobileNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v2)             |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
+| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)             |      Y      |      Y       |    Y     |  Y   |   ?   |    Y     |
 | [ShuffleNetV1](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v1)           |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [ShuffleNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v2)           |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [VisionTransformer](https://github.com/open-mmlab/mmpretrain/tree/main/configs/vision_transformer) |      Y      |      Y       |    Y     |  Y   |   ?   |    Y     |

--- a/docs/zh_cn/03-benchmark/supported_models.md
+++ b/docs/zh_cn/03-benchmark/supported_models.md
@@ -28,6 +28,7 @@
 | [ResNeXt](https://github.com/open-mmlab/mmpretrain/tree/main/configs/resnext)                            | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [SE-ResNet](https://github.com/open-mmlab/mmpretrain/tree/main/configs/seresnet)                         | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [MobileNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v2)                   | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
+| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)                   | MMPretrain       |      N      |      Y      |    N     |  N   |   N   |    N     |   N    |  N   |
 | [ShuffleNetV1](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v1)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [ShuffleNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v2)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [VisionTransformer](https://github.com/open-mmlab/mmpretrain/tree/main/configs/vision_transformer)       | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   ?   |    Y     |   Y    |  N   |

--- a/docs/zh_cn/03-benchmark/supported_models.md
+++ b/docs/zh_cn/03-benchmark/supported_models.md
@@ -28,7 +28,7 @@
 | [ResNeXt](https://github.com/open-mmlab/mmpretrain/tree/main/configs/resnext)                            | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [SE-ResNet](https://github.com/open-mmlab/mmpretrain/tree/main/configs/seresnet)                         | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [MobileNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v2)                   | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
-| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)                   | MMPretrain       |      N      |      Y      |    N     |  N   |   N   |    N     |   N    |  N   |
+| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)                   | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   N   |    Y     |   N    |  N   |
 | [ShuffleNetV1](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v1)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [ShuffleNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v2)                 | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   Y   |    Y     |   Y    |  Y   |
 | [VisionTransformer](https://github.com/open-mmlab/mmpretrain/tree/main/configs/vision_transformer)       | MMPretrain       |      Y      |      Y      |    Y     |  Y   |   ?   |    Y     |   Y    |  N   |

--- a/docs/zh_cn/04-supported-codebases/mmpretrain.md
+++ b/docs/zh_cn/04-supported-codebases/mmpretrain.md
@@ -183,6 +183,7 @@ for label_id, score in result:
 | [ResNeXt](https://github.com/open-mmlab/mmpretrain/tree/main/configs/resnext)                      |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [SE-ResNet](https://github.com/open-mmlab/mmpretrain/tree/main/configs/seresnet)                   |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [MobileNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v2)             |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
+| [MobileNetV3](https://github.com/open-mmlab/mmpretrain/tree/main/configs/mobilenet_v3)             |      Y      |      Y       |    Y     |  Y   |   ?   |    Y     |
 | [ShuffleNetV1](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v1)           |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [ShuffleNetV2](https://github.com/open-mmlab/mmpretrain/tree/main/configs/shufflenet_v2)           |      Y      |      Y       |    Y     |  Y   |   Y   |    Y     |
 | [VisionTransformer](https://github.com/open-mmlab/mmpretrain/tree/main/configs/vision_transformer) |      Y      |      Y       |    Y     |  Y   |   ?   |    Y     |

--- a/mmdeploy/codebase/mmpretrain/deploy/classification.py
+++ b/mmdeploy/codebase/mmpretrain/deploy/classification.py
@@ -332,7 +332,8 @@ class Classification(BaseTask):
             dict: Composed of the postprocess information.
         """
         postprocess = self.model_cfg.model.head
-        if postprocess['type'] in ('EfficientFormerClsHead', 'StackedLinearClsHead'):
+        if postprocess['type'] in ('EfficientFormerClsHead',
+                                   'StackedLinearClsHead'):
             postprocess['type'] = 'LinearClsHead'
 
         if 'topk' not in postprocess:

--- a/mmdeploy/codebase/mmpretrain/deploy/classification.py
+++ b/mmdeploy/codebase/mmpretrain/deploy/classification.py
@@ -332,7 +332,7 @@ class Classification(BaseTask):
             dict: Composed of the postprocess information.
         """
         postprocess = self.model_cfg.model.head
-        if postprocess['type'] == 'EfficientFormerClsHead':
+        if postprocess['type'] in ('EfficientFormerClsHead', 'StackedLinearClsHead'):
             postprocess['type'] = 'LinearClsHead'
 
         if 'topk' not in postprocess:

--- a/tests/regression/mmpretrain.yml
+++ b/tests/regression/mmpretrain.yml
@@ -247,3 +247,14 @@ models:
       - *pipeline_ort_dynamic_fp32
       - *pipeline_trt_dynamic_fp32
       - *pipeline_openvino_dynamic_fp32
+
+  - name: MobileNetV3
+    metafile: configs/mobilenet_v3/metafile.yml
+    model_configs:
+      - configs/mobilenet_v3/mobilenet-v3-small_8xb128_in1k.py
+    pipelines:
+      - *pipeline_ts_fp32
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+      - *pipeline_ncnn_static_fp32
+      - *pipeline_openvino_dynamic_fp32


### PR DESCRIPTION
## Motivation

Support conversion of mmpretrain's Mobilenet V3 classification models to ONNX.

## Modification

Fixes error that was arising during conversion to ONNX: https://github.com/open-mmlab/mmdeploy/issues/2245
