### PR TITLE
[Fix] Prevent RuntimeError in ONNX export with empty input in ONNXNMSRotatedOp

### DIFF
--- a/mmdeploy/mmcv/ops/nms_rotated.py
+++ b/mmdeploy/mmcv/ops/nms_rotated.py
@@ -49,7 +49,8 @@ class ONNXNMSRotatedOp(torch.autograd.Function):
                 indices.append(
                     torch.stack([batch_inds, cls_inds, box_inds], dim=-1))
 
-        indices = torch.cat(indices)
+        indices = torch.cat(indices) if len(indices) > 0 else torch.zeros(
+            (0, 3), dtype=torch.long, device=boxes.device)
         return indices
 
     @staticmethod


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR addresses a runtime error that occurs when exporting ONNX with dummy data (i.e., when no objects are present). Specifically, the issue arises from the `ONNXNMSRotatedOp` class in the `nms_rotated.py` file.

The problem was that when no objects were detected (resulting in `indices` being empty), a `RuntimeError` occurred when `torch.cat(indices)` was called. To resolve this issue, I added a condition to check the length of `indices` before concatenating. If `indices` is empty, it now returns a tensor of zeros with the appropriate shape, datatype, and device settings.

## Modification

```diff
-        indices = torch.cat(indices)
+        indices = torch.cat(indices) if len(indices) > 0 else torch.zeros(
+            (0, 3), dtype=torch.long, device=boxes.device)
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
