### PR TITLE
[Fix] Fix random color for Palette

### DIFF
--- a/demo/csrc/cpp/utils/palette.h
+++ b/demo/csrc/cpp/utils/palette.h
@@ -82,6 +82,7 @@ inline Palette Palette::get(int n) {
   std::vector<cv::Point3f> centers(n);
   cv::Mat c_mat(centers, false);
   cv::Mat s_mat(samples, false);
+  c_mat = c_mat.reshape(1, {n, 3});  // CV_32FC3 -> CV_32FC1 for cv::kmeans output
   cv::kmeans(s_mat, n, indices, cv::TermCriteria(cv::TermCriteria::Type::COUNT, 10, 0), 1,
              cv::KMEANS_PP_CENTERS, c_mat);
   Palette p;


### PR DESCRIPTION
The output for cv::kmeans is CV_32FC1, if doesn't reshpae c_mat, it will allocate new memory and the centers will all be zero.