### PR TITLE
export get_simcc_maximum for simcc

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           export TAG=$TAG_PREFIX
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo $TAG
-          docker ./docker/Release/ -t ${TAG} --no-cache
+          docker build ./docker/Release/ -t ${TAG} --no-cache
           docker push $TAG
       - name: Push docker image with released tag
         if: startsWith(github.ref, 'refs/tags/') == true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,19 +29,19 @@ jobs:
           echo $MMDEPLOY_VERSION
           echo "MMDEPLOY_VERSION=$MMDEPLOY_VERSION"  >> $GITHUB_ENV
           echo "OUTPUT_DIR=$PREBUILD_DIR/$MMDEPLOY_VERSION" >> $GITHUB_ENV
-          pip install twine
+          python3 -m pip install twine --user
       - name: Upload mmdeploy
         continue-on-error: true
         run: |
           cd $OUTPUT_DIR/mmdeploy
           ls -sha *.whl
-          twine upload *.whl -u __token__ -p ${{ secrets.pypi_password }}
+          python3 -m twine upload *.whl -u __token__ -p ${{ secrets.pypi_password }}
       - name: Upload mmdeploy_runtime
         continue-on-error: true
         run: |
           cd $OUTPUT_DIR/mmdeploy_runtime
           ls -sha *.whl
-          twine upload *.whl -u __token__ -p ${{ secrets.pypi_password }}
+          python3 -m twine upload *.whl -u __token__ -p ${{ secrets.pypi_password }}
       - name: Check assets
         run: |
           ls -sha $OUTPUT_DIR/sdk

--- a/configs/mmpose/pose-detection_simcc_onnxruntime_dynamic.py
+++ b/configs/mmpose/pose-detection_simcc_onnxruntime_dynamic.py
@@ -14,3 +14,7 @@ onnx_config = dict(
             0: 'batch'
         }
     })
+
+codebase_config = dict(
+    export_postprocess=False  # do not export get_simcc_maximum
+)

--- a/mmdeploy/codebase/mmpose/codecs/__init__.py
+++ b/mmdeploy/codebase/mmpose/codecs/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from .post_processing import get_simcc_maximum
+
+__all__ = ['get_simcc_maximum']

--- a/mmdeploy/codebase/mmpose/codecs/post_processing.py
+++ b/mmdeploy/codebase/mmpose/codecs/post_processing.py
@@ -1,0 +1,33 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
+
+def get_simcc_maximum(simcc_x: torch.Tensor,
+                      simcc_y: torch.Tensor) -> torch.Tensor:
+    """Get maximum response location and value from simcc representations.
+
+    rewrite to support `torch.Tensor` input type.
+
+    Args:
+        simcc_x (torch.Tensor): x-axis SimCC in shape (N, K, Wx)
+        simcc_y (torch.Tensor): y-axis SimCC in shape (N, K, Wy)
+
+    Returns:
+        tuple:
+        - locs (torch.Tensor): locations of maximum heatmap responses in shape
+            (N, K, 2)
+        - vals (torch.Tensor): values of maximum heatmap responses in shape
+            (N, K)
+    """
+    N, K, _ = simcc_x.shape
+    simcc_x = simcc_x.flatten(0, 1)
+    simcc_y = simcc_y.flatten(0, 1)
+    x_locs = simcc_x.argmax(dim=1, keepdim=True)
+    y_locs = simcc_y.argmax(dim=1, keepdim=True)
+    locs = torch.cat((x_locs, y_locs), dim=1).to(torch.float32)
+    max_val_x, _ = simcc_x.max(dim=1, keepdim=True)
+    max_val_y, _ = simcc_y.max(dim=1, keepdim=True)
+    vals, _ = torch.cat([max_val_x, max_val_y], dim=1).min(dim=1)
+    locs = locs.reshape(N, K, 2)
+    vals = vals.reshape(N, K)
+    return locs, vals

--- a/mmdeploy/codebase/mmpose/deploy/pose_detection.py
+++ b/mmdeploy/codebase/mmpose/deploy/pose_detection.py
@@ -13,7 +13,8 @@ from mmengine.model import BaseDataPreprocessor
 from mmengine.registry import Registry
 
 from mmdeploy.codebase.base import CODEBASE, BaseTask, MMCodebase
-from mmdeploy.utils import Codebase, Task, get_input_shape, get_root_logger
+from mmdeploy.utils import (Codebase, Task, get_codebase_config,
+                            get_input_shape, get_root_logger)
 
 
 def process_model_config(
@@ -362,6 +363,9 @@ class PoseDetection(BaseTask):
                 params['post_process'] = 'megvii'
                 params['modulate_kernel'] = self.model_cfg.kernel_sizes[-1]
             elif codec.type == 'SimCCLabel':
+                export_postprocess = get_codebase_config(self.deploy_cfg).get(
+                    'export_postprocess', False)
+                params['export_postprocess'] = export_postprocess
                 component = 'SimCCLabelDecode'
             elif codec.type == 'RegressionLabel':
                 component = 'DeepposeRegressionHeadDecode'

--- a/mmdeploy/codebase/mmpose/models/heads/__init__.py
+++ b/mmdeploy/codebase/mmpose/models/heads/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from . import mspn_head, yolox_pose_head  # noqa: F401,F403
+from . import mspn_head, simcc_head, yolox_pose_head  # noqa: F401,F403
 
-__all__ = ['mspn_head', 'yolox_pose_head']
+__all__ = ['mspn_head', 'yolox_pose_head', 'simcc_head']

--- a/mmdeploy/codebase/mmpose/models/heads/simcc_head.py
+++ b/mmdeploy/codebase/mmpose/models/heads/simcc_head.py
@@ -1,0 +1,28 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from mmdeploy.codebase.mmpose.codecs import get_simcc_maximum
+from mmdeploy.core import FUNCTION_REWRITER
+from mmdeploy.utils import get_codebase_config
+
+
+@FUNCTION_REWRITER.register_rewriter('mmpose.models.heads.RTMCCHead.forward')
+@FUNCTION_REWRITER.register_rewriter('mmpose.models.heads.SimCCHead.forward')
+def simcc_head__forward(self, feats):
+    """Rewrite `forward` of SimCCHead for default backend.
+
+    Args:
+        feats (tuple[Tensor]): Input features.
+    Returns:
+        key-points (torch.Tensor): Output keypoints in
+            shape of (N, K, 3)
+    """
+    ctx = FUNCTION_REWRITER.get_context()
+    simcc_x, simcc_y = ctx.origin_func(self, feats)
+    codebase_cfg = get_codebase_config(ctx.cfg)
+    export_postprocess = codebase_cfg.get('export_postprocess', False)
+    if not export_postprocess:
+        return simcc_x, simcc_y
+    assert self.decoder.use_dark is False, \
+        'Do not support SimCCLabel with use_dark=True'
+    pts, scores = get_simcc_maximum(simcc_x, simcc_y)
+    pts /= self.decoder.simcc_split_ratio
+    return pts, scores


### PR DESCRIPTION
## Motivation

export get_simcc_maximum for simcc and rtmpose models.

## Modification

 Support torch2onnx with post-processing `get_simcc_maximum` for `onnxruntime` and `tensorrt` backend.
- Note that `ncnn` backend is not supported in this PR.


## BC-breaking (Optional)

None

## Use cases (Optional)

###  Add the following records to deploy config to enable exporting `get_simcc_maximum`
```
codebase_config = dict(
    export_postprocess=True  # export get_simcc_maximum
)
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
4. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
5. The documentation has been modified accordingly, like docstring or example tutorials.
