### PR TITLE
Fix "has no attribute startswith"

### DIFF
--- a/mmdeploy/utils/config_utils.py
+++ b/mmdeploy/utils/config_utils.py
@@ -97,7 +97,7 @@ def get_codebase(deploy_cfg: Union[str, mmengine.Config],
         # using mmrazor codebase if the model is a mmrazor model.
         model_cfg: dict = model_cfg['model']
         if model_cfg.get('_scope_', None) == 'mmrazor'\
-                or model_cfg['type'].startswith('mmrazor.'):
+                or str(model_cfg['type']).startswith('mmrazor.'):
             return register_codebase('mmrazor')
     codebase_config = get_codebase_config(deploy_cfg)
     assert 'type' in codebase_config, 'The codebase config of deploy config'\


### PR DESCRIPTION
The value needs to be converted to string first.

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When trying to 
```python
from mmdeploy.utils import get_input_shape, load_config

deploy_cfg = 'configs/mmpretrain/classification_onnxruntime_dynamic.py'
model_cfg = 'mmpretrain/configs/resnet/resnet18_8xb32_in1k.py'

# read deploy_cfg and model_cfg
deploy_cfg, model_cfg = load_config(deploy_cfg, model_cfg)
```

the `load_config` throws an error because

```python
        if model_cfg.get('_scope_', None) == 'mmrazor'\
                or model_cfg['type'].startswith('mmrazor.'):
```

 the '`type` value is not string for the function `startswith()` to work.

## Modification

Convert `type` value to string before checking the prefix.