### PR TITLE
Fix error when default_scope is None

### DIFF
--- a/mmdeploy/codebase/base/task.py
+++ b/mmdeploy/codebase/base/task.py
@@ -52,7 +52,7 @@ class BaseTask(metaclass=ABCMeta):
         if not DefaultScope.check_instance_created(self.experiment_name):
             self.scope = DefaultScope.get_instance(
                 self.experiment_name,
-                scope_name=self.model_cfg.get('default_scope'))
+                scope_name=str(self.model_cfg.get('default_scope')))
         else:
             self.scope = DefaultScope.get_instance(self.experiment_name)
 


### PR DESCRIPTION
## Motivation

Some models don't have any default scope, which means

```
        if not DefaultScope.check_instance_created(self.experiment_name):
            self.scope = DefaultScope.get_instance(
                self.experiment_name,
                scope_name=self.model_cfg.get('default_scope'))
                )
```

returns `None` which causes an error because `scope_name` should be string.

## Modification

Convert to string while retrieving value for `scope_name`