### PR TITLE
Add prefix mmdet to LoadImageFromNDArray

### DIFF
--- a/mmdeploy/codebase/mmdet/deploy/object_detection.py
+++ b/mmdeploy/codebase/mmdet/deploy/object_detection.py
@@ -60,7 +60,7 @@ def process_model_config(model_cfg: Config,
     if isinstance(imgs[0], np.ndarray):
         cfg = cfg.copy()
         # set loading pipeline type
-        cfg.test_pipeline[0].type = 'LoadImageFromNDArray'
+        cfg.test_pipeline[0].type = 'mmdet.LoadImageFromNDArray'
 
     pipeline = cfg.test_pipeline
 


### PR DESCRIPTION
## Motivation

I use mmdeploy in my project.

## Modification

There was an error when using a model from the mmyolo repository during image preprocessing, provided that an np.ndarray was supplied as input. If you input the path to the image, everything works fine.

Error reproduction code:
```python
from mmdeploy.apis.utils import build_task_processor
from mmdeploy.utils import get_input_shape, load_config
import torch
import cv2

deploy_cfg = './configs/deploy/detection_tensorrt_dynamic-192x192-960x960.py'
model_cfg = '../mmyolo/configs/yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py'
device = 'cuda:0'
backend_model = ['./work_dir/end2end.engine']
image_str = '../mmyolo/demo/demo.jpg'
image_np = cv2.imread(image_str)

# read deploy_cfg and model_cfg
deploy_cfg, model_cfg = load_config(deploy_cfg, model_cfg)

# build task and backend model
task_processor = build_task_processor(model_cfg, deploy_cfg, device)
model = task_processor.build_backend_model(backend_model)

# process input image
input_shape = get_input_shape(deploy_cfg)
model_inputs, _ = task_processor.create_input(image_str, input_shape)  # Success
model_inputs, _ = task_processor.create_input(image_np, input_shape)  # Fails
```
Error:
```
KeyError: 'LoadImageFromNDArray is not in the transform registry. Please check whether the value of `LoadImageFromNDArray` is correct or it was registered as expected.
```
Also I found similar issue - https://github.com/open-mmlab/mmdeploy/issues/2197
