### PR TITLE
pytorch2onnx API supports multimodal input

### DIFF
--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, Union
 
 import mmengine
 
-from .core import PIPELINE_MANAGER
+from mmdeploy.apis.core import PIPELINE_MANAGER
 
 
 @PIPELINE_MANAGER.register_pipeline()
@@ -14,6 +14,7 @@ def torch2onnx(img: Any,
                deploy_cfg: Union[str, mmengine.Config],
                model_cfg: Union[str, mmengine.Config],
                model_checkpoint: Optional[str] = None,
+               append_input: list = None,
                device: str = 'cuda:0'):
     """Convert PyTorch model to ONNX model.
 
@@ -42,13 +43,14 @@ def torch2onnx(img: Any,
         model_cfg (str | mmengine.Config): Model config file or Config object.
         model_checkpoint (str): A checkpoint path of PyTorch model,
             defaults to `None`.
+        append_input (list): Additional inputs other than images, suitable for multimodal models such as text features of Grounded DINO.
         device (str): A string specifying device type, defaults to 'cuda:0'.
     """
 
     from mmdeploy.apis.core.pipeline_manager import no_mp
     from mmdeploy.utils import (Backend, get_backend, get_dynamic_axes,
                                 get_input_shape, get_onnx_config, load_config)
-    from .onnx import export
+    from mmdeploy.apis.onnx import export
 
     # load deploy_cfg if necessary
     deploy_cfg, model_cfg = load_config(deploy_cfg, model_cfg)
@@ -68,6 +70,10 @@ def torch2onnx(img: Any,
 
     if isinstance(model_inputs, list) and len(model_inputs) == 1:
         model_inputs = model_inputs[0]
+    if isinstance(append_input, list):
+        temp = [model_inputs]
+        temp.extend(append_input)
+        model_inputs = temp
     data_samples = data['data_samples']
     input_metas = {'data_samples': data_samples, 'mode': 'predict'}
 

--- a/mmdeploy/apis/pytorch2onnx.py
+++ b/mmdeploy/apis/pytorch2onnx.py
@@ -6,6 +6,7 @@ import mmengine
 
 from mmdeploy.apis.core import PIPELINE_MANAGER
 
+print('ok')
 
 @PIPELINE_MANAGER.register_pipeline()
 def torch2onnx(img: Any,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

use cases:

img = 'test1.png'
work_dir = 'deploy_work_dir/onnx/gd/'
save_file = 'end2end_swint_static.onnx'
deploy_cfg = 'custom_deploy_config/onnx_static_gd.py'
model_cfg = 'configs/g_dino/g_dino_deploy_swinT.py'
model_checkpoint = 'model_weight/detector/gdino/groundingdino_swint.pth'
device = 'cpu'

embedded = torch.zeros(1, 256, 768, dtype=torch.float32).to(device)
masks = torch.ones(1, 256, 256, dtype=torch.bool).to(device)
hidden = torch.zeros(1, 256, 768, dtype=torch.float32).to(device)
position_ids = torch.zeros(1, 256, dtype=torch.int64).to(device)
text_token_mask = torch.ones(1, 256, dtype=bool).to(device)
postive_maps = torch.zeros(1, 3, 256, dtype=torch.float32).to(device)
append_input = [embedded,masks,hidden,position_ids,text_token_mask,postive_maps]
torch2onnx(img, work_dir, save_file, deploy_cfg, model_cfg,
  model_checkpoint, append_input, device)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
