### PR TITLE
[Enhancement] Bump protobuf to 3.20.3

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,6 +6,6 @@ multiprocess
 numpy
 onnx>=1.13.0
 prettytable
-protobuf<=3.20.2
+protobuf<=3.20.3
 six
 terminaltables


### PR DESCRIPTION
## Motivation

There are still many Python packages around which stick with the old 3.20 protobuf version. However, this is typically the very last release of major version 3, i.e. 3.20.3. Unfortunately, mmdeploy has a constraint of 3.20.2, which leads to unnecessary incompatibilities. 

## Modification

I propose to bump the patch version of protobuf to 3.20.3. This is very likely of no relevance to mmdeploy but a makes cohabitation with many other packages quite easier.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
