### PR TITLE
[Fix] method always using `cuda`

### DIFF
--- a/mmdeploy/codebase/mmdet/models/dense_heads/rtmdet_ins_head.py
+++ b/mmdeploy/codebase/mmdet/models/dense_heads/rtmdet_ins_head.py
@@ -163,7 +163,7 @@ def _mask_predict_by_feat_single(self, mask_feat, kernels, priors):
     batch_size = priors.shape[0]
     hw = mask_feat.size()[-2:]
     coord = self.prior_generator.single_level_grid_priors(
-        hw, level_idx=0).to(mask_feat.device)
+        hw, level_idx=0, device=mask_feat.device)
     coord = coord.unsqueeze(0).unsqueeze(0).repeat(batch_size, 1, 1, 1)
     priors = priors.unsqueeze(2)
     points = priors[..., :2]


### PR DESCRIPTION


## Motivation

`single_level_grid_priors` has a arg to specify device, which defaults to `'cuda'`. this PR fixes the function to allow using `cpu`.

## Modification

pass in the value of `mask_feat.device`  to the method instead of converting the tensor afterwards.

## BC-breaking (Optional)

no breaking changes

## Use cases (Optional)

no new features

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
