### PR TITLE
Fix dynamical batch inference bug

### DIFF
--- a/mmdeploy/codebase/mmdet/models/dense_heads/detr_head.py
+++ b/mmdeploy/codebase/mmdet/models/dense_heads/detr_head.py
@@ -43,6 +43,8 @@ def detrhead__predict_by_feat__default(self,
         det_labels = indexes % self.num_classes
         bbox_index = indexes // self.num_classes
         bbox_index = (bbox_index + batch_index_offset).view(-1)
+        # if max_per_img is smaller than num_quries
+        bbox_preds = bbox_preds[:, bbox_index[-1], :]
         bbox_preds = bbox_preds.view(-1, 4)[bbox_index]
         bbox_preds = bbox_preds.view(batch_size, -1, 4)
     else:


### PR DESCRIPTION
When multi-batch detr model is converted from pytorch to onnx, if max_per_img is smaller than num_quries, there will be an incorrect index for bbox_preds. 

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
