### PR TITLE
Transfer to cpu only when torch.Tensor arguments in onnx export

### DIFF
--- a/mmdeploy/apis/onnx/export.py
+++ b/mmdeploy/apis/onnx/export.py
@@ -132,7 +132,7 @@ def export(model: torch.nn.Module,
         if isinstance(args, torch.Tensor):
             args = args.cpu()
         elif isinstance(args, (tuple, list)):
-            args = tuple([_.cpu() for _ in args])
+            args = tuple([_.cpu() if isinstance(_, torch.Tensor) else _ for _ in args])
         else:
             raise RuntimeError(f'Not supported args: {args}')
         torch.onnx.export(


### PR DESCRIPTION
## Motivation

`.cpu()` in ONNX export inputs would be only supported in Tensor inputs so it should be only applied to Tensor types

## Modification

Adds type checking before `.cpu()` and pass it directly if not.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
