### PR TITLE
fix build with gcc14

### DIFF
--- a/csrc/mmdeploy/core/graph.cpp
+++ b/csrc/mmdeploy/core/graph.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 
+#include <algorithm>
+
 #include "mmdeploy/core/graph.h"
 
 #include "mmdeploy/archive/value_archive.h"

--- a/csrc/mmdeploy/preprocess/transform/normalize.cpp
+++ b/csrc/mmdeploy/preprocess/transform/normalize.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 
+#include <algorithm>
+
 #include "mmdeploy/core/registry.h"
 #include "mmdeploy/core/tensor.h"
 #include "mmdeploy/core/utils/formatter.h"

--- a/csrc/mmdeploy/preprocess/transform/pad.cpp
+++ b/csrc/mmdeploy/preprocess/transform/pad.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 
 #include <array>
+#include <algorithm>
 
 #include "mmdeploy/core/utils/formatter.h"
 #include "mmdeploy/operation/managed.h"


### PR DESCRIPTION
## Motivation

when building with gcc 14 I get build error that `std:count is not found`


## Modification

add  required includes in files that didn't compile

## BC-breaking (Optional)

no

## Use cases (Optional)

no

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
